### PR TITLE
docker: support relative paths for volumes

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -212,7 +212,7 @@ func (c *Container) OutOfSync() (bool, error) {
 }
 
 func (c *Container) createContainer(imageName string) (*dockerclient.Container, error) {
-	config, err := ConvertToAPI(c.service.serviceConfig)
+	config, err := ConvertToAPI(c.service)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/convert.go
+++ b/docker/convert.go
@@ -31,8 +31,8 @@ func isVolume(s string) bool {
 }
 
 // ConvertToAPI converts a service configuration to a docker API container configuration.
-func ConvertToAPI(c *project.ServiceConfig) (*dockerclient.ContainerConfig, error) {
-	config, hostConfig, err := Convert(c)
+func ConvertToAPI(s *Service) (*dockerclient.ContainerConfig, error) {
+	config, hostConfig, err := Convert(s.serviceConfig, s.context)
 	if err != nil {
 		return nil, err
 	}
@@ -52,12 +52,15 @@ func ConvertToAPI(c *project.ServiceConfig) (*dockerclient.ContainerConfig, erro
 }
 
 // Convert converts a service configuration to an docker inner representation (using runconfig structures)
-func Convert(c *project.ServiceConfig) (*runconfig.Config, *runconfig.HostConfig, error) {
-	vs := Filter(c.Volumes, isVolume)
+func Convert(c *project.ServiceConfig, ctx *Context) (*runconfig.Config, *runconfig.HostConfig, error) {
+	volumes := make(map[string]struct{}, len(c.Volumes))
+	for k, v := range c.Volumes {
+		vol := ctx.ResourceLookup.ResolvePath(v, ctx.ComposeFile)
 
-	volumes := make(map[string]struct{}, len(vs))
-	for _, v := range vs {
-		volumes[v] = struct{}{}
+		c.Volumes[k] = vol
+		if isVolume(vol) {
+			volumes[vol] = struct{}{}
+		}
 	}
 
 	ports, binding, err := nat.ParsePortSpecs(c.Ports)

--- a/docker/project.go
+++ b/docker/project.go
@@ -9,8 +9,8 @@ import (
 
 // NewProject creates a Project with the specified context.
 func NewProject(context *Context) (*project.Project, error) {
-	if context.ConfigLookup == nil {
-		context.ConfigLookup = &lookup.FileConfigLookup{}
+	if context.ResourceLookup == nil {
+		context.ResourceLookup = &lookup.FileConfigLookup{}
 	}
 
 	if context.EnvironmentLookup == nil {

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -253,6 +254,24 @@ func (s *RunSuite) TestLink(c *C) {
 		fmt.Sprintf("/%s:/%s/%s", serverName, clientName, "server"),
 		fmt.Sprintf("/%s:/%s/%s", serverName, clientName, serverName),
 	}))
+}
+
+func (s *RunSuite) TestRelativeVolume(c *C) {
+	p := s.ProjectFromText(c, "up", `
+	server:
+	  image: busybox
+	  volumes:
+	    - .:/path
+	`)
+
+	absPath, err := filepath.Abs(".")
+	c.Assert(err, IsNil)
+	serverName := fmt.Sprintf("%s_%s_1", p, "server")
+	cn := s.GetContainerByName(c, serverName)
+
+	c.Assert(cn, NotNil)
+	c.Assert(len(cn.Volumes), DeepEquals, 1)
+	c.Assert(cn.Volumes["/path"], DeepEquals, absPath)
 }
 
 func (s *RunSuite) TestScale(c *C) {

--- a/lookup/file.go
+++ b/lookup/file.go
@@ -2,13 +2,44 @@ package lookup
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
 )
 
-// FileConfigLookup is a "bare" structure that implements the project.ConfigLookup interface
+// relativePath returns the proper relative path for the given file path. If
+// the relativeTo string equals "-", then it means that it's from the stdin,
+// and the returned path will be the current working directory. Otherwise, if
+// file is really an absolute path, then it will be returned without any
+// changes. Otherwise, the returned path will be a combination of relativeTo
+// and file.
+func relativePath(file, relativeTo string) string {
+	// stdin: return the current working directory if possible.
+	if relativeTo == "-" {
+		if cwd, err := os.Getwd(); err == nil {
+			return cwd
+		}
+	}
+
+	// If the given file is already an absolute path, just return it.
+	// Otherwise, the returned path will be relative to the given relativeTo
+	// path.
+	if filepath.IsAbs(file) {
+		return file
+	}
+
+	abs, err := filepath.Abs(filepath.Join(path.Dir(relativeTo), file))
+	if err != nil {
+		logrus.Errorf("Failed to get absolute directory: %s", err)
+		return file
+	}
+	return abs
+}
+
+// FileConfigLookup is a "bare" structure that implements the project.ResourceLookup interface
 type FileConfigLookup struct {
 }
 
@@ -17,14 +48,27 @@ type FileConfigLookup struct {
 // If file starts with a slash ('/'), it tries to load it, otherwise it will build a
 // filename using the folder part of relativeTo joined with file.
 func (f *FileConfigLookup) Lookup(file, relativeTo string) ([]byte, string, error) {
-	if strings.HasPrefix(file, "/") {
-		logrus.Debugf("Reading file %s", file)
-		bytes, err := ioutil.ReadFile(file)
-		return bytes, file, err
+	file = relativePath(file, relativeTo)
+	logrus.Debugf("Reading file %s", file)
+	bytes, err := ioutil.ReadFile(file)
+	return bytes, file, err
+}
+
+// ResolvePath returns the path to be used for the given path volume. This
+// function already takes care of relative paths.
+func (f *FileConfigLookup) ResolvePath(path, inFile string) string {
+	vs := strings.SplitN(path, ":", 2)
+	if len(vs) != 2 || filepath.IsAbs(vs[0]) {
+		return path
 	}
 
-	fileName := path.Join(path.Dir(relativeTo), file)
-	logrus.Debugf("Reading file %s relative to %s", fileName, relativeTo)
-	bytes, err := ioutil.ReadFile(fileName)
-	return bytes, fileName, err
+	if !strings.HasPrefix(vs[0], "./") && !strings.HasPrefix(vs[0], "~/") &&
+		!strings.HasPrefix(vs[0], "/") {
+
+		logrus.Warnf("The mapping \"%s\" is ambiguous. In a future version of Docker, it will "+
+			"designate a \"named\" volume (see https://github.com/docker/docker/pull/14242). "+
+			"To prevent unexpected behaviour, change it to \"./%s\".", vs[0], vs[0])
+	}
+	vs[0] = relativePath(vs[0], inFile)
+	return strings.Join(vs, ":")
 }

--- a/lookup/file_test.go
+++ b/lookup/file_test.go
@@ -1,6 +1,7 @@
 package lookup
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -12,8 +13,12 @@ type input struct {
 }
 
 func TestLookupError(t *testing.T) {
+	abs, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("Failed to get absolute directory: %s", err)
+	}
 	invalids := map[input]string{
-		input{"", ""}:                             "read .: is a directory",
+		input{"", ""}:                             fmt.Sprintf("read %s: is a directory", abs),
 		input{"", "/tmp/"}:                        "read /tmp: is a directory",
 		input{"file", "/does/not/exists/"}:        "open /does/not/exists/file: no such file or directory",
 		input{"file", "/does/not/something"}:      "open /does/not/file: no such file or directory",

--- a/project/context.go
+++ b/project/context.go
@@ -27,7 +27,7 @@ type Context struct {
 	isOpen              bool
 	ServiceFactory      ServiceFactory
 	EnvironmentLookup   EnvironmentLookup
-	ConfigLookup        ConfigLookup
+	ResourceLookup      ResourceLookup
 	LoggerFactory       logger.Factory
 	IgnoreMissingConfig bool
 	Project             *Project

--- a/project/merge.go
+++ b/project/merge.go
@@ -42,7 +42,7 @@ func mergeProject(p *Project, bytes []byte) (map[string]*ServiceConfig, error) {
 	}
 
 	for name, data := range datas {
-		data, err := parse(p.context.ConfigLookup, p.context.EnvironmentLookup, p.File, data, datas)
+		data, err := parse(p.context.ResourceLookup, p.context.EnvironmentLookup, p.File, data, datas)
 		if err != nil {
 			logrus.Errorf("Failed to parse service %s: %v", name, err)
 			return nil, err
@@ -68,7 +68,7 @@ func adjustValues(configs map[string]*ServiceConfig) {
 	}
 }
 
-func readEnvFile(configLookup ConfigLookup, inFile string, serviceData rawService) (rawService, error) {
+func readEnvFile(resourceLookup ResourceLookup, inFile string, serviceData rawService) (rawService, error) {
 	var config ServiceConfig
 
 	if err := utils.Convert(serviceData, &config); err != nil {
@@ -79,7 +79,7 @@ func readEnvFile(configLookup ConfigLookup, inFile string, serviceData rawServic
 		return serviceData, nil
 	}
 
-	if configLookup == nil {
+	if resourceLookup == nil {
 		return nil, fmt.Errorf("Can not use env_file in file %s no mechanism provided to load files", inFile)
 	}
 
@@ -87,7 +87,7 @@ func readEnvFile(configLookup ConfigLookup, inFile string, serviceData rawServic
 
 	for i := len(config.EnvFile.Slice()) - 1; i >= 0; i-- {
 		envFile := config.EnvFile.Slice()[i]
-		content, _, err := configLookup.Lookup(envFile, inFile)
+		content, _, err := resourceLookup.Lookup(envFile, inFile)
 		if err != nil {
 			return nil, err
 		}
@@ -152,8 +152,8 @@ func resolveBuild(inFile string, serviceData rawService) (rawService, error) {
 	return serviceData, nil
 }
 
-func parse(configLookup ConfigLookup, environmentLookup EnvironmentLookup, inFile string, serviceData rawService, datas rawServiceMap) (rawService, error) {
-	serviceData, err := readEnvFile(configLookup, inFile, serviceData)
+func parse(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup, inFile string, serviceData rawService, datas rawServiceMap) (rawService, error) {
+	serviceData, err := readEnvFile(resourceLookup, inFile, serviceData)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func parse(configLookup ConfigLookup, environmentLookup EnvironmentLookup, inFil
 		return serviceData, nil
 	}
 
-	if configLookup == nil {
+	if resourceLookup == nil {
 		return nil, fmt.Errorf("Can not use extends in file %s no mechanism provided to files", inFile)
 	}
 
@@ -188,12 +188,12 @@ func parse(configLookup ConfigLookup, environmentLookup EnvironmentLookup, inFil
 
 	if file == "" {
 		if serviceData, ok := datas[service]; ok {
-			baseService, err = parse(configLookup, environmentLookup, inFile, serviceData, datas)
+			baseService, err = parse(resourceLookup, environmentLookup, inFile, serviceData, datas)
 		} else {
 			return nil, fmt.Errorf("Failed to find service %s to extend", service)
 		}
 	} else {
-		bytes, resolved, err := configLookup.Lookup(file, inFile)
+		bytes, resolved, err := resourceLookup.Lookup(file, inFile)
 		if err != nil {
 			logrus.Errorf("Failed to lookup file %s: %v", file, err)
 			return nil, err
@@ -214,7 +214,7 @@ func parse(configLookup ConfigLookup, environmentLookup EnvironmentLookup, inFil
 			return nil, fmt.Errorf("Failed to find service %s in file %s", service, file)
 		}
 
-		baseService, err = parse(configLookup, environmentLookup, resolved, baseService, baseRawServices)
+		baseService, err = parse(resourceLookup, environmentLookup, resolved, baseService, baseRawServices)
 	}
 
 	if err != nil {

--- a/project/merge_test.go
+++ b/project/merge_test.go
@@ -9,9 +9,13 @@ func (n *NullLookup) Lookup(file, relativeTo string) ([]byte, string, error) {
 	return nil, "", nil
 }
 
+func (n *NullLookup) ResolvePath(path, inFile string) string {
+	return ""
+}
+
 func TestExtendsInheritImage(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -44,7 +48,7 @@ child:
 
 func TestExtendsInheritBuild(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -77,7 +81,7 @@ child:
 
 func TestExtendBuildOverImage(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -111,7 +115,7 @@ child:
 
 func TestExtendImageOverBuild(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -149,7 +153,7 @@ child:
 
 func TestRestartNo(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -171,7 +175,7 @@ test:
 
 func TestRestartAlways(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`

--- a/project/types.go
+++ b/project/types.go
@@ -210,9 +210,10 @@ type EnvironmentLookup interface {
 	Lookup(key, serviceName string, config *ServiceConfig) []string
 }
 
-// ConfigLookup defines methods to provides file loading.
-type ConfigLookup interface {
+// ResourceLookup defines methods to provides file loading.
+type ResourceLookup interface {
 	Lookup(file, relativeTo string) ([]byte, string, error)
+	ResolvePath(path, inFile string) string
 }
 
 // Project holds libcompose project information.


### PR DESCRIPTION
Consider the following yaml file:

```yaml
test:
  image: opensuse:13.2
  volumes:
    - foo:/foo
  command: sh -c 'echo Hello World'
```

docker-compose can handle the above configuration file. However this
implementation fails because it cannot handle the relative path "foo". This
commit fixes this by converting relative paths to absolute paths when
converting the given config file.

Moreover, this commit also merges two for loops that were dealing with volumes.

Signed-off-by: Miquel Sabaté <msabate@suse.com>