### PR TITLE
Fix error handling and event firing for container events

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -168,8 +168,10 @@ func (c *Container) Up(imageName string) error {
 		if err != nil {
 			return err
 		}
-		err := c.client.StartContainer(container.Id, info.HostConfig)
-		return err
+
+		if err := c.client.StartContainer(container.Id, info.HostConfig); err != nil {
+			return err
+		}
 
 		c.service.context.Project.Notify(project.CONTAINER_STARTED, c.service.Name(), map[string]string{
 			"name": c.Name(),


### PR DESCRIPTION
There was a short circuit `return err` in the code that probably was the result of a bad rebase.  Just fixing the bug, it prevented the CONTAINER_STARTED event from being fired.