### PR TITLE
Setup validate-golint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN go get github.com/mitchellh/gox
 RUN go get github.com/aktau/github-release
 RUN go get github.com/tools/godep
 RUN go get golang.org/x/tools/cmd/cover
+RUN go get github.com/golang/lint/golint
 
 # Which docker version to test on
 ENV DOCKER_VERSION 1.7.1

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,10 @@ validate-dco: build
 validate-gofmt: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-gofmt
 
-validate: validate-dco validate-gofmt
+validate-lint: build
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-lint
+
+validate: validate-dco validate-gofmt validate-lint
 
 shell: build
 	$(DOCKER_RUN_LIBCOMPOSE) bash

--- a/lookup/simple_env.go
+++ b/lookup/simple_env.go
@@ -19,7 +19,6 @@ func (o *OsEnvLookup) Lookup(key, serviceName string, config *project.ServiceCon
 	ret := os.Getenv(key)
 	if ret == "" {
 		return []string{}
-	} else {
-		return []string{fmt.Sprintf("%s=%s", key, ret)}
 	}
+	return []string{fmt.Sprintf("%s=%s", key, ret)}
 }

--- a/script/make.sh
+++ b/script/make.sh
@@ -5,8 +5,9 @@ set -e
 DEFAULT_BUNDLES=(
 	validate-gofmt
 	#validate-git-marks
-        validate-dco
-        
+	validate-dco
+	validate-lint
+
 	binary
 
 	test-unit

--- a/script/validate-lint
+++ b/script/validate-lint
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# We will eventually get to the point where packages should be the complete list
+# of subpackages, vendoring excluded, as given by:
+#
+# packages=( $(go list ./... 2> /dev/null | grep -vE "^github.com/docker/libcompose/Godeps" || true ) )
+
+packages=(
+    cli/main
+    lookup
+    version
+)
+
+errors=()
+for p in "${packages[@]}"; do
+	# Run golint on package/*.go file explicitly to validate all go files
+	# and not just the ones for the current platform.
+	failedLint=$(golint "$p"/*.go)
+	if [ "$failedLint" ]; then
+		errors+=( "$failedLint" )
+	fi
+done
+
+if [ ${#errors[@]} -eq 0 ]; then
+	echo 'Congratulations!  All Go source files have been linted.'
+else
+	{
+		echo "Errors from golint:"
+		for err in "${errors[@]}"; do
+			echo "$err"
+		done
+		echo
+		echo 'Please fix the above errors. You can test via "golint" and commit the result.'
+		echo
+	} >&2
+	false
+fi


### PR DESCRIPTION
- Add a `validate-lint` target (and `script/validate-lint` that does the
  job)
- Add the first package that is covered by it : `version`.

For the demo :

```bash
λ make validate-lint  
# […]
Successfully built 875de57690ce
docker run --rm -it --privileged -e OS_PLATFORM_ARG -e OS_ARCH_ARG -e DOCKER_TEST_HOST -e TESTFLAGS -v "/home/vincent/src/docker/libcompose/bundles:/go/src/github.com/docker/libcompose/bundles" "libcompose-dev:14-setup-validate-golint" ./script/make.sh validate-lint
---> Making bundle: validate-lint (in .)
Congratulations!  All Go source files have been linted.
```

Related to #14 🐸