### PR TITLE
Setup validate-vet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN go get github.com/aktau/github-release
 RUN go get github.com/tools/godep
 RUN go get golang.org/x/tools/cmd/cover
 RUN go get github.com/golang/lint/golint
+RUN go get golang.org/x/tools/cmd/vet
 
 # Which docker version to test on
 ENV DOCKER_VERSION 1.7.1

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,10 @@ validate-gofmt: build
 validate-lint: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-lint
 
-validate: validate-dco validate-gofmt validate-lint
+validate-vet: build
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-vet
+
+validate: validate-dco validate-gofmt validate-lint validate-vet
 
 shell: build
 	$(DOCKER_RUN_LIBCOMPOSE) bash

--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -178,7 +178,7 @@ func ProjectScale(p *project.Project, c *cli.Context) {
 		}
 
 		if _, ok := p.Configs[name]; !ok {
-			logrus.Fatalf("% is not defined in the template", name)
+			logrus.Fatalf("%s is not defined in the template", name)
 		}
 
 		service, err := p.CreateService(name)

--- a/docker/container.go
+++ b/docker/container.go
@@ -55,10 +55,10 @@ func (c *Container) Info() (project.Info, error) {
 
 	result := project.Info{}
 
-	result = append(result, project.InfoPart{"Name", name(container.Names)})
-	result = append(result, project.InfoPart{"Command", container.Command})
-	result = append(result, project.InfoPart{"State", container.Status})
-	result = append(result, project.InfoPart{"Ports", portString(container.Ports)})
+	result = append(result, project.InfoPart{Key: "Name", Value: name(container.Names)})
+	result = append(result, project.InfoPart{Key: "Command", Value: container.Command})
+	result = append(result, project.InfoPart{Key: "State", Value: container.Status})
+	result = append(result, project.InfoPart{Key: "Ports", Value: portString(container.Ports)})
 
 	return result, nil
 }
@@ -292,7 +292,7 @@ func (c *Container) addLinks(links map[string]string, service project.Service, r
 
 func (c *Container) addIpc(config *dockerclient.HostConfig, service project.Service, containers []project.Container) (*dockerclient.HostConfig, error) {
 	if len(containers) == 0 {
-		return nil, fmt.Errorf("Failed to find container for IPC %", c.service.Config().Ipc)
+		return nil, fmt.Errorf("Failed to find container for IPC %v", c.service.Config().Ipc)
 	}
 
 	id, err := containers[0].Id()
@@ -306,7 +306,7 @@ func (c *Container) addIpc(config *dockerclient.HostConfig, service project.Serv
 
 func (c *Container) addNetNs(config *dockerclient.HostConfig, service project.Service, containers []project.Container) (*dockerclient.HostConfig, error) {
 	if len(containers) == 0 {
-		return nil, fmt.Errorf("Failed to find container for networks ns %", c.service.Config().Net)
+		return nil, fmt.Errorf("Failed to find container for networks ns %v", c.service.Config().Net)
 	}
 
 	id, err := containers[0].Id()
@@ -382,8 +382,6 @@ func (c *Container) Log() error {
 		}, output)
 		return err
 	}
-
-	return nil
 }
 
 func (c *Container) pull(image string) error {

--- a/script/make.sh
+++ b/script/make.sh
@@ -7,6 +7,7 @@ DEFAULT_BUNDLES=(
 	#validate-git-marks
 	validate-dco
 	validate-lint
+	validate-vet
 
 	binary
 

--- a/script/validate-vet
+++ b/script/validate-vet
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+source "$(dirname "$BASH_SOURCE")/.validate"
+
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- '*.go' | grep -v '^Godeps/' || true) )
+unset IFS
+
+errors=()
+for f in "${files[@]}"; do
+	# we use "git show" here to validate that what's committed passes go vet
+	failedVet=$(go vet "$f")
+	if [ "$failedVet" ]; then
+		errors+=( "$failedVet" )
+	fi
+done
+
+
+if [ ${#errors[@]} -eq 0 ]; then
+	echo 'Congratulations!  All Go source files have been vetted.'
+else
+	{
+		echo "Errors from go vet:"
+		for err in "${errors[@]}"; do
+			echo " - $err"
+		done
+		echo
+		echo 'Please fix the above errors. You can test via "go vet" and commit the result.'
+		echo
+	} >&2
+	false
+fi


### PR DESCRIPTION
- Add a `validate-vet` target (and `script/validate-vet` that does the
  job)
- Added package `version` and `cli/app` that are vetted for now.

```bash
λ make validate-vet
# […]
---> Making bundle: validate-vet (in .)
warning: no common commits
cli/app/app.go:181: unrecognized printf verb 'i'
exit status 1
Makefile:41: recipe for target 'validate-vet' failed
make: *** [validate-vet] Error 1
```

and then 

```bash
λ make validate-vet
# […]
---> Making bundle: validate-vet (in .)
warning: no common commits
Congratulations!  All Go source files have been vetted.
```

Related to #14. 🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>