### PR TITLE
Add unit-tests (and thus coverage) to lookup pkg

### DIFF
--- a/lookup/file.go
+++ b/lookup/file.go
@@ -8,9 +8,14 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+// FileConfigLookup is a "bare" structure that implements the project.ConfigLookup interface
 type FileConfigLookup struct {
 }
 
+// Lookup returns the content and the actual filename of the file that is "built" using the
+// specified file and relativeTo string. file and relativeTo are supposed to be file path.
+// If file starts with a slash ('/'), it tries to load it, otherwise it will build a
+// filename using the folder part of relativeTo joined with file.
 func (f *FileConfigLookup) Lookup(file, relativeTo string) ([]byte, string, error) {
 	if strings.HasPrefix(file, "/") {
 		logrus.Debugf("Reading file %s", file)

--- a/lookup/file_test.go
+++ b/lookup/file_test.go
@@ -1,0 +1,65 @@
+package lookup
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+)
+
+type input struct {
+	file       string
+	relativeTo string
+}
+
+func TestLookupError(t *testing.T) {
+	invalids := map[input]string{
+		input{"", ""}:                             "read .: is a directory",
+		input{"", "/tmp/"}:                        "read /tmp: is a directory",
+		input{"file", "/does/not/exists/"}:        "open /does/not/exists/file: no such file or directory",
+		input{"file", "/does/not/something"}:      "open /does/not/file: no such file or directory",
+		input{"file", "/does/not/exists/another"}: "open /does/not/exists/file: no such file or directory",
+		input{"/does/not/exists/file", "/tmp/"}:   "open /does/not/exists/file: no such file or directory",
+		input{"does/not/exists/file", "/tmp/"}:    "open /tmp/does/not/exists/file: no such file or directory",
+	}
+
+	fileConfigLookup := FileConfigLookup{}
+
+	for invalid, expectedError := range invalids {
+		_, _, err := fileConfigLookup.Lookup(invalid.file, invalid.relativeTo)
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("Expected error with '%s', got '%v'", expectedError, err)
+		}
+	}
+}
+
+func TestLookupOK(t *testing.T) {
+	tmpFolder, err := ioutil.TempDir("", "lookup-tests")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpFile1 := filepath.Join(tmpFolder, "file1")
+	tmpFile2 := filepath.Join(tmpFolder, "file2")
+	if err = ioutil.WriteFile(tmpFile1, []byte("content1"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err = ioutil.WriteFile(tmpFile2, []byte("content2"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	fileConfigLookup := FileConfigLookup{}
+
+	valids := map[input]string{
+		input{"file1", tmpFolder + "/"}:     "content1",
+		input{"file2", tmpFolder + "/"}:     "content2",
+		input{tmpFile1, tmpFolder}:          "content1",
+		input{tmpFile1, "/does/not/exists"}: "content1",
+		input{"file2", tmpFile1}:            "content2",
+	}
+
+	for valid, expectedContent := range valids {
+		out, _, err := fileConfigLookup.Lookup(valid.file, valid.relativeTo)
+		if err != nil || string(out) != expectedContent {
+			t.Fatalf("Expected %s to contains '%s', got %s, %v.", valid.file, expectedContent, out, err)
+		}
+	}
+}

--- a/lookup/simple_env.go
+++ b/lookup/simple_env.go
@@ -7,9 +7,14 @@ import (
 	"github.com/docker/libcompose/project"
 )
 
+// OsEnvLookup is a "bare" structure that implements the project.EnvironmentLookup interface
 type OsEnvLookup struct {
 }
 
+// Lookup creates a string slice of string containing a "docker-friendly" environment string
+// in the form of 'key=value'. It gets environment values using os.Getenv.
+// If the os environment variable does not exists, the slice is empty. serviceName and config
+// are not used at all in this implementation.
 func (o *OsEnvLookup) Lookup(key, serviceName string, config *project.ServiceConfig) []string {
 	ret := os.Getenv(key)
 	if ret == "" {

--- a/lookup/simple_env_test.go
+++ b/lookup/simple_env_test.go
@@ -1,0 +1,31 @@
+package lookup
+
+import (
+	"testing"
+
+	"github.com/docker/libcompose/project"
+)
+
+func TestOsEnvLookup(t *testing.T) {
+	// Putting bare minimun value for serviceName and config as there are
+	// not important on this test.
+	serviceName := "anything"
+	config := &project.ServiceConfig{}
+
+	osEnvLookup := &OsEnvLookup{}
+
+	envs := osEnvLookup.Lookup("PATH", serviceName, config)
+	if len(envs) != 1 {
+		t.Fatalf("Expected envs to contains one element, but was %v", envs)
+	}
+
+	envs = osEnvLookup.Lookup("path", serviceName, config)
+	if len(envs) != 0 {
+		t.Fatalf("Expected envs to be empty, but was %v", envs)
+	}
+
+	envs = osEnvLookup.Lookup("DOES_NOT_EXIST", serviceName, config)
+	if len(envs) != 0 {
+		t.Fatalf("Expected envs to be empty, but was %v", envs)
+	}
+}


### PR DESCRIPTION
Add unit coverage to the package `lookup`, to start small 🐧.

```bash
+ go test -cover -coverprofile=cover.out ./lookup
ok      github.com/docker/libcompose/lookup     0.005s  coverage: 100.0% of statements
```

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>