### PR TITLE
Enable back validate-git-marks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ validate-lint: build
 validate-vet: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-vet
 
-validate: validate-dco validate-gofmt validate-lint validate-vet
+validate-git-marks: build
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-git-marks
+
+validate: build
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-dco validate-git-marks validate-gofmt validate-lint validate-vet
 
 shell: build
 	$(DOCKER_RUN_LIBCOMPOSE) bash

--- a/script/make.sh
+++ b/script/make.sh
@@ -6,9 +6,9 @@ DEFAULT_BUNDLES=(
 	validate-gofmt
 	#validate-git-marks
 	validate-dco
+	validate-git-marks
 	validate-lint
 	validate-vet
-
 	binary
 
 	test-unit

--- a/script/validate-git-marks
+++ b/script/validate-git-marks
@@ -1,28 +1,44 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 source "$(dirname "$BASH_SOURCE")/.validate"
 
-folders=$(find * -type d | egrep -v '^Godeps|bundles|.git')
+# folders=$(find * -type d | egrep -v '^Godeps|bundles|.git')
 
-IN_MARK=$(grep -r "^<<<<<<<" $folders)
-if [ $? -eq 0 ]; then
-	echo "-- Git conflict marks have been found, please correct them :"
-	echo "$IN_MARK"
-	return false
+IFS=$'\n'
+files=( $(validate_diff --diff-filter=ACMR --name-only -- '*' | grep -v '^Godeps/' || true) )
+unset IFS
+
+badFiles=()
+for f in "${files[@]}"; do
+    if [ $(grep -r "^<<<<<<<" $f) ]; then
+        badFiles+=( "$f" )
+        continue
+    fi
+
+    if [ $(grep -r "^>>>>>>>" $f) ]; then
+        badFiles+=( "$f" )
+        continue
+    fi
+
+    if [ $(grep -r "^=======$" $f) ]; then
+        badFiles+=( "$f" )
+        continue
+    fi
+    set -e
+done
+
+
+if [ ${#badFiles[@]} -eq 0 ]; then
+	echo 'Congratulations!  There is no conflict.'
+else
+	{
+		echo "There is trace of conflict(s) in the following files :"
+		for f in "${badFiles[@]}"; do
+			echo " - $f"
+		done
+		echo
+		echo 'Please fix the conflict(s) commit the result.'
+		echo
+	} >&2
+	false
 fi
-
-OUT_MARK=$(grep -r "^>>>>>>>" $folders)
-if [ $? -eq 0 ]; then
-	echo "-- Git conflict marks have been found, please correct them :"
-	echo "$OUT_MARK"
-	return false
-fi
-
-SEPARATE_MARK=$(grep -r "^=======$" $folders)
-if [ $? -eq 0 ]; then
-	echo "-- Git conflict marks have been found, please correct them :"
-	echo "$SEPARATE_MARK"
-	return false
-fi
-
-echo "Congratulations : no git conflict marks have been found!"


### PR DESCRIPTION
Rewrite of `validate-git-marks` to work well with the current buildchain.

- Add a `validate-git-marks` target.
- Re-order the *validates* bundles to run `dco` and `git-marks` before `gofmt`.

A failure will look like :

```bash
λ make validate-git-marks
# […]
---> Making bundle: validate-git-marks (in .)
There is trace of conflicts in the following files :
 - cli/app/app.go

Please fix the conflicts commit the result.

Makefile:41: recipe for target 'validate-git-marks' failed
make: *** [validate-git-marks] Error 1

```

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>