### PR TITLE
Implement container_name support

### DIFF
--- a/docker/name.go
+++ b/docker/name.go
@@ -20,11 +20,19 @@ type inOrderNamer struct {
 	done  chan bool
 }
 
+type singleNamer struct {
+	name string
+}
+
 func OneName(client dockerclient.Client, project, service string) (string, error) {
 	namer := NewNamer(client, project, service)
 	defer namer.Close()
 
 	return namer.Next(), nil
+}
+
+func NewSingleNamer(name string) Namer {
+	return &singleNamer{name}
 }
 
 func NewNamer(client dockerclient.Client, project, service string) Namer {
@@ -69,5 +77,13 @@ func (i *inOrderNamer) Close() error {
 	default:
 	}
 
+	return nil
+}
+
+func (s *singleNamer) Next() string {
+	return s.name
+}
+
+func (s *singleNamer) Close() error {
 	return nil
 }

--- a/integration/basic_test.go
+++ b/integration/basic_test.go
@@ -264,6 +264,34 @@ func (s *RunSuite) TestBuild(c *C) {
 	c.Assert(two.Config.Cmd, DeepEquals, []string{"echo", "two"})
 }
 
+func (s *RunSuite) TestContainerName(c *C) {
+	containerName := "containerName"
+	template := fmt.Sprintf(`hello:
+    image: busybox
+    command: top
+    container_name: %s`, containerName)
+	s.CreateProjectFromText(c, template)
+
+	cn := s.GetContainerByName(c, containerName)
+	c.Assert(cn, NotNil)
+
+	c.Assert(cn.Name, Equals, "/"+containerName)
+}
+
+func (s *RunSuite) TestContainerNameWithScale(c *C) {
+	containerName := "containerName"
+	template := fmt.Sprintf(`hello:
+    image: busybox
+    command: top
+    container_name: %s`, containerName)
+	p := s.CreateProjectFromText(c, template)
+
+	s.FromText(c, p, "scale", "hello=2", template)
+	containers := s.GetContainersByProject(c, p)
+	c.Assert(len(containers), Equals, 1)
+
+}
+
 func asMap(items []string) map[string]bool {
 	result := map[string]bool{}
 	for _, item := range items {

--- a/integration/common.go
+++ b/integration/common.go
@@ -31,6 +31,17 @@ type RunSuite struct {
 	projects []string
 }
 
+func (r *RunSuite) TearDownTest(c *C) {
+	// Delete all containers
+	client := GetClient(c)
+	containers, err := client.ListContainers(true, false, "")
+	c.Assert(err, IsNil)
+	for _, container := range containers {
+		err := client.RemoveContainer(container.Id, true, true)
+		c.Assert(err, IsNil)
+	}
+}
+
 var _ = Suite(&RunSuite{
 	command: "../bundles/libcompose-cli_linux-amd64",
 })

--- a/project/types.go
+++ b/project/types.go
@@ -161,6 +161,7 @@ type ServiceConfig struct {
 	CpuSet        string            `yaml:"cpuset,omitempty"`
 	CpuShares     int64             `yaml:"cpu_shares,omitempty"`
 	Command       Command           `yaml:"command"` // omitempty breaks serialization!
+	ContainerName string            `yaml:"container_name,omitempty"`
 	Devices       []string          `yaml:"devices,omitempty"`
 	Dns           Stringorslice     `yaml:"dns"`        // omitempty breaks serialization!
 	DnsSearch     Stringorslice     `yaml:"dns_search"` // omitempty breaks serialization!


### PR DESCRIPTION
Fixes #28 — This implements `container_name` support as in docker-compose 1.4.

> Went with option 1 - a service with a custom name simply can't be scaled beyond 1 container. We let the Docker daemon enforce that.

This does the same as `docker-compose` : if `container_name` is present and we do a `scale` on it should fail but this will come from the `docker` side. This means one container will start, and as libcompose does not (yet ?) stop running containers in case of failure, it would stays up.

There is room for improvement in the integration tests, but that probably will be for another PR.

Signed-off-by: Vincent Demeester <vincent@sbr.pm>