### PR TITLE
Warn if scaling a service that specifies a host port

### DIFF
--- a/docker/service_test.go
+++ b/docker/service_test.go
@@ -1,0 +1,27 @@
+package docker
+
+import (
+	"github.com/docker/libcompose/project"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSpecifiesHostPort(t *testing.T) {
+	servicesWithHostPort := []Service{
+		{serviceConfig: &project.ServiceConfig{Ports: []string{"8000:8000"}}},
+		{serviceConfig: &project.ServiceConfig{Ports: []string{"127.0.0.1:8000:8000"}}},
+	}
+
+	for _, service := range servicesWithHostPort {
+		assert.True(t, service.specificiesHostPort())
+	}
+
+	servicesWithoutHostPort := []Service{
+		{serviceConfig: &project.ServiceConfig{Ports: []string{"8000"}}},
+		{serviceConfig: &project.ServiceConfig{Ports: []string{"127.0.0.1::8000"}}},
+	}
+
+	for _, service := range servicesWithoutHostPort {
+		assert.False(t, service.specificiesHostPort())
+	}
+}

--- a/integration/scale_test.go
+++ b/integration/scale_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"strings"
 
 	. "gopkg.in/check.v1"
 )
@@ -42,4 +43,28 @@ func (s *RunSuite) TestScale(c *C) {
 	c.Assert(cn, IsNil)
 	cn = s.GetContainerByName(c, name)
 	c.Assert(cn, IsNil)
+}
+
+func (s *RunSuite) TestScaleWithHostPortWarning(c *C) {
+	template := `
+	test:
+	  image: busybox
+		ports:
+			- 8001:8001
+	`
+	p := s.ProjectFromText(c, "up", template)
+
+	name := fmt.Sprintf("%s_%s_1", p, "test")
+	cn := s.GetContainerByName(c, name)
+	c.Assert(cn, NotNil)
+
+	c.Assert(cn.State.Running, Equals, true)
+
+	containers := s.GetContainersByProject(c, p)
+	c.Assert(1, Equals, len(containers))
+
+	_, output := s.FromTextCaptureOutput(c, p, "scale", "test=2", template)
+
+	// Assert warning is given when trying to scale a service that specifies a host port
+	c.Assert(strings.Contains(output, "If multiple containers for this service are created on a single host, the port will clash."), Equals, true)
 }


### PR DESCRIPTION
Mimics the warning that Compose gives when trying to scale a service that specifies a port on the host.

Signed-off-by: Josh Curl <hello@joshcurl.com>