### PR TITLE
Linting package logger

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -374,9 +374,9 @@ func (c *Container) Log() error {
 		}
 		return scanner.Err()
 	} else {
-		_, err := stdcopy.StdCopy(&logger.LoggerWrapper{
+		_, err := stdcopy.StdCopy(&logger.Wrapper{
 			Logger: l,
-		}, &logger.LoggerWrapper{
+		}, &logger.Wrapper{
 			Err:    true,
 			Logger: l,
 		}, output)

--- a/logger/null.go
+++ b/logger/null.go
@@ -1,14 +1,18 @@
 package logger
 
+// NullLogger is a logger.Logger and logger.Factory implementation that does nothing.
 type NullLogger struct {
 }
 
+// Out is a no-op function.
 func (n *NullLogger) Out(_ []byte) {
 }
 
+// Err is a no-op function.
 func (n *NullLogger) Err(_ []byte) {
 }
 
+// Create implements logger.Factory and returns a NullLogger.
 func (n *NullLogger) Create(_ string) Logger {
 	return &NullLogger{}
 }

--- a/logger/types.go
+++ b/logger/types.go
@@ -1,20 +1,25 @@
 package logger
 
+// Factory defines methods a factory should implement, to create a Logger
+// based on the specified name.
 type Factory interface {
 	Create(name string) Logger
 }
 
+// Logger defines methods to implement for being a logger.
 type Logger interface {
 	Out(bytes []byte)
 	Err(bytes []byte)
 }
 
-type LoggerWrapper struct {
+// Wrapper is a wrapper around Logger that implements the Writer interface,
+// mainly use by docker/pkg/stdcopy functions.
+type Wrapper struct {
 	Err    bool
 	Logger Logger
 }
 
-func (l *LoggerWrapper) Write(bytes []byte) (int, error) {
+func (l *Wrapper) Write(bytes []byte) (int, error) {
 	if l.Err {
 		l.Logger.Err(bytes)
 	} else {

--- a/script/validate-lint
+++ b/script/validate-lint
@@ -12,6 +12,7 @@ packages=(
     cli/logger
     cli/main
     lookup
+    logger
     version
     utils
 )


### PR DESCRIPTION
Made a `golint` pass on package `logger` 🐙.

The main change is `logger.LoggerWrapper` is now `logger.Wrapper`.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>