### PR TITLE
Check service name whether exists

### DIFF
--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -16,6 +16,14 @@ func (s *RunSuite) TestUp(c *C) {
 	c.Assert(cn.State.Running, Equals, true)
 }
 
+func (s *RunSuite) TestUpNotExistService(c *C) {
+	p := s.ProjectFromText(c, "up", SimpleTemplate)
+
+	name := fmt.Sprintf("%s_%s_1", p, "not_exist")
+	cn := s.GetContainerByName(c, name)
+	c.Assert(cn, IsNil)
+}
+
 func (s *RunSuite) TestLink(c *C) {
 	p := s.ProjectFromText(c, "up", `
         server:

--- a/project/project.go
+++ b/project/project.go
@@ -336,6 +336,13 @@ func (p *Project) traverse(start bool, selected map[string]bool, wrappers map[st
 	p.loadWrappers(wrappers, wrapperList)
 	p.reload = []string{}
 
+	// check service name
+	for s := range selected {
+		if wrappers[s] == nil {
+			return errors.New("No such service: " + s)
+		}
+	}
+
 	launched := map[string]bool{}
 
 	for _, wrapper := range wrappers {


### PR DESCRIPTION
When up/start.... a service which is not exist in yml, libcompose will hang there.
This PR fix this. 
Output:
```
[root@localhost sleep]# libcompose up no_exist
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
FATA[0000] No such service: no_exist
```

Signed-off-by: Bo Hai <bohai@huawei.com>