### PR TITLE
Modify help info format same as docker

### DIFF
--- a/cli/command/help.go
+++ b/cli/command/help.go
@@ -1,0 +1,37 @@
+package command
+
+import (
+	"github.com/codegangsta/cli"
+	"os"
+	"path"
+)
+
+func init() {
+	cli.AppHelpTemplate = `Usage: {{.Name}} {{if .Flags}}[OPTIONS] {{end}}COMMAND [arg...]
+
+{{.Usage}}
+
+Version: {{.Version}}{{if or .Author .Email}}
+
+Author:{{if .Author}}
+  {{.Author}}{{if .Email}} - <{{.Email}}>{{end}}{{else}}
+  {{.Email}}{{end}}{{end}}
+{{if .Flags}}
+Options:
+  {{range .Flags}}{{.}}
+  {{end}}{{end}}
+Commands:
+  {{range .Commands}}{{.Name}}{{with .ShortName}}, {{.}}{{end}}{{ "\t" }}{{.Usage}}
+  {{end}}
+Run '{{.Name}} COMMAND --help' for more information on a command.
+`
+	cli.CommandHelpTemplate = `Usage: ` + path.Base(os.Args[0]) + ` {{.Name}}{{if .Flags}} [OPTIONS]
+
+{{.Usage}}
+
+Options:
+   {{range .Flags}}{{.}}
+   {{end}}{{end}}
+`
+
+}


### PR DESCRIPTION
### Before:
```
[root@localhost integration]# libcompose --help
NAME:
   libcompose-cli - Command line interface for libcompose.

USAGE:
   libcompose-cli [global options] command [command options] [arguments...]

VERSION:
   0.0.0-dev (HEAD)

AUTHOR:
  Docker Compose Contributors - <https://github.com/docker/libcompose>

COMMANDS:
   build	Build or rebuild services.
   create	Create all services but do not start
   up		Bring all services up
   start	Start services
   logs		Get service logs
   restart	Restart services
   stop, down	Stop services
   scale	Scale services
   rm		Delete services
   pull		Pulls images for services
   kill		Force stop service containers
   port		Print the public port for a port binding
   ps		List containers
   help, h	Shows a list of commands or help for one command
   
GLOBAL OPTIONS:
   --verbose, --debug			
   --file, -f "docker-compose.yml"	Specify an alternate compose file (default: docker-compose.yml) [$COMPOSE_FILE]
   --project-name, -p 			Specify an alternate project name (default: directory name)
   --tls				Use TLS; implied by --tlsverify
   --tlsverify				Use TLS and verify the remote [$DOCKER_TLS_VERIFY]
   --tlscacert 				Trust certs signed only by this CA
   --tlscert 				Path to TLS certificate file
   --tlskey 				Path to TLS key file
   --configdir 				Path to docker config dir, default ${HOME}/.docker
   --help, -h				show help
   --version, -v			print the version
[root@localhost libcompose]# libcompose help rm
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
NAME:
   rm - Delete services

USAGE:
   command rm [command options] [arguments...]

OPTIONS:
   --force, -f	Allow deletion of all services
```
## After:
```
[root@localhost command]# libcompose --help
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
Usage: libcompose-cli [OPTIONS] COMMAND [arg...]

Command line interface for libcompose.

Version: 0.0.0-dev (HEAD)

Author:
  Docker Compose Contributors - <https://github.com/docker/libcompose>

Options:
  --verbose, --debug			
  --file, -f "docker-compose.yml"	Specify an alternate compose file (default: docker-compose.yml) [$COMPOSE_FILE]
  --project-name, -p 			Specify an alternate project name (default: directory name)
  --tls					Use TLS; implied by --tlsverify
  --tlsverify				Use TLS and verify the remote [$DOCKER_TLS_VERIFY]
  --tlscacert 				Trust certs signed only by this CA
  --tlscert 				Path to TLS certificate file
  --tlskey 				Path to TLS key file
  --configdir 				Path to docker config dir, default ${HOME}/.docker
  --help, -h				show help
  --version, -v				print the version
  
Commands:
  build		Build or rebuild services.
  create	Create all services but do not start
  up		Bring all services up
  start		Start services
  logs		Get service logs
  restart	Restart services
  stop, down	Stop services
  scale		Scale services
  rm		Delete services
  pull		Pulls images for services
  kill		Force stop service containers
  port		Print the public port for a port binding
  ps		List containers
  help, h	Shows a list of commands or help for one command
  
Run 'libcompose-cli COMMAND --help' for more information on a command.

[root@localhost command]# libcompose help rm
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
Usage: main rm [OPTIONS]

Delete services

Options:
   --force, -f	Allow deletion of all services
```
Signed-off-by: Bo Hai <bohai@huawei.com>