### PR TITLE
Block when sending project events

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -387,10 +387,6 @@ func (p *Project) Notify(eventType EventType, serviceName string, data map[strin
 	}
 
 	for _, l := range p.listeners {
-		// Don't ever block
-		select {
-		case l <- event:
-		default:
-		}
+		l <- event
 	}
 }


### PR DESCRIPTION
Not blocking here was causing some messages to be dropped. As a result, some project events weren't being logged.

Fixes #35

Signed-off-by: Josh Curl <hello@joshcurl.com>