### PR TITLE
Allow multiple calls to project methods without reinitializing project

### DIFF
--- a/project/project_test.go
+++ b/project/project_test.go
@@ -5,6 +5,69 @@ import (
 	"testing"
 )
 
+type TestServiceFactory struct {
+	Counts map[string]int
+}
+
+type TestService struct {
+	factory *TestServiceFactory
+	name    string
+	config  *ServiceConfig
+	EmptyService
+	Count int
+}
+
+func (t *TestService) Config() *ServiceConfig {
+	return t.config
+}
+
+func (t *TestService) Name() string {
+	return t.name
+}
+
+func (t *TestService) Create() error {
+	key := t.name + ".create"
+	t.factory.Counts[key] = t.factory.Counts[key] + 1
+	return nil
+}
+
+func (t *TestService) DependentServices() []ServiceRelationship {
+	return nil
+}
+
+func (t *TestServiceFactory) Create(project *Project, name string, serviceConfig *ServiceConfig) (Service, error) {
+	return &TestService{
+		factory: t,
+		config:  serviceConfig,
+		name:    name,
+	}, nil
+}
+
+func TestTwoCall(t *testing.T) {
+	factory := &TestServiceFactory{
+		Counts: map[string]int{},
+	}
+
+	p := NewProject(&Context{
+		ServiceFactory: factory,
+	})
+	p.Configs = map[string]*ServiceConfig{
+		"foo": {},
+	}
+
+	if err := p.Create("foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Create("foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	if factory.Counts["foo.create"] != 2 {
+		t.Fatal("Failed to create twice")
+	}
+}
+
 func TestEventEquality(t *testing.T) {
 	if fmt.Sprintf("%s", EventServiceStart) != "Started" ||
 		fmt.Sprintf("%v", EventServiceStart) != "Started" {


### PR DESCRIPTION
Prior to this change if one was to do project.Create() and then
project.Start(), with the same project object, the second invocation
would do nothing.  This is because the initial list of services to
traverse was based off of p.reload.  This patch changes it such that
reload is not taken into account on start but only when we need to
restart the execution.

Signed-off-by: Darren Shepherd <darren@rancher.com>