### PR TITLE
Fix issue in which extending could end up with both build and image

### DIFF
--- a/project/merge.go
+++ b/project/merge.go
@@ -217,6 +217,12 @@ func parse(configLookup ConfigLookup, inFile string, serviceData rawService, dat
 	}
 
 	for k, v := range serviceData {
+		// Image and build are mutually exclusive in merge
+		if k == "image" {
+			delete(baseService, "build")
+		} else if k == "build" {
+			delete(baseService, "image")
+		}
 		existing, ok := baseService[k]
 		if ok {
 			baseService[k] = merge(existing, v)

--- a/project/merge_test.go
+++ b/project/merge_test.go
@@ -1,0 +1,148 @@
+package project
+
+import "testing"
+
+type NullLookup struct {
+}
+
+func (n *NullLookup) Lookup(file, relativeTo string) ([]byte, string, error) {
+	return nil, "", nil
+}
+
+func TestExtendsInheritImage(t *testing.T) {
+	p := NewProject(&Context{
+		ConfigLookup: &NullLookup{},
+	})
+
+	config, err := Merge(p, []byte(`
+parent:
+  image: foo
+child:
+  extends:
+    service: parent
+`))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent := config["parent"]
+	child := config["child"]
+
+	if parent.Image != "foo" {
+		t.Fatal("Invalid image", parent.Image)
+	}
+
+	if child.Build != "" {
+		t.Fatal("Invalid build", child.Build)
+	}
+
+	if child.Image != "foo" {
+		t.Fatal("Invalid image", child.Image)
+	}
+}
+
+func TestExtendsInheritBuild(t *testing.T) {
+	p := NewProject(&Context{
+		ConfigLookup: &NullLookup{},
+	})
+
+	config, err := Merge(p, []byte(`
+parent:
+  build: .
+child:
+  extends:
+    service: parent
+`))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent := config["parent"]
+	child := config["child"]
+
+	if parent.Build != "." {
+		t.Fatal("Invalid build", parent.Build)
+	}
+
+	if child.Build != "." {
+		t.Fatal("Invalid build", child.Build)
+	}
+
+	if child.Image != "" {
+		t.Fatal("Invalid image", child.Image)
+	}
+}
+
+func TestExtendBuildOverImage(t *testing.T) {
+	p := NewProject(&Context{
+		ConfigLookup: &NullLookup{},
+	})
+
+	config, err := Merge(p, []byte(`
+parent:
+  image: foo
+child:
+  build: .
+  extends:
+    service: parent
+`))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent := config["parent"]
+	child := config["child"]
+
+	if parent.Image != "foo" {
+		t.Fatal("Invalid image", parent.Image)
+	}
+
+	if child.Build != "." {
+		t.Fatal("Invalid build", child.Build)
+	}
+
+	if child.Image != "" {
+		t.Fatal("Invalid image", child.Image)
+	}
+}
+
+func TestExtendImageOverBuild(t *testing.T) {
+	p := NewProject(&Context{
+		ConfigLookup: &NullLookup{},
+	})
+
+	config, err := Merge(p, []byte(`
+parent:
+  build: .
+child:
+  image: foo
+  extends:
+    service: parent
+`))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent := config["parent"]
+	child := config["child"]
+
+	if parent.Image != "" {
+		t.Fatal("Invalid image", parent.Image)
+	}
+
+	if parent.Build != "." {
+		t.Fatal("Invalid build", parent.Build)
+	}
+
+	if child.Build != "" {
+		t.Fatal("Invalid build", child.Build)
+	}
+
+	if child.Image != "foo" {
+		t.Fatal("Invalid image", child.Image)
+	}
+}


### PR DESCRIPTION
According to Docker Compose docs

> In the case of build and image, using one in the local service causes
> Compose to discard the other, if it was defined in the original
> service.

The above was not being respected