### PR TITLE
restart: no gets interpreted as restart: false

### DIFF
--- a/project/merge.go
+++ b/project/merge.go
@@ -51,8 +51,21 @@ func mergeProject(p *Project, bytes []byte) (map[string]*ServiceConfig, error) {
 		datas[name] = data
 	}
 
-	err := utils.Convert(datas, &configs)
-	return configs, err
+	if err := utils.Convert(datas, &configs); err != nil {
+		return nil, err
+	}
+
+	adjustValues(configs)
+	return configs, nil
+}
+
+func adjustValues(configs map[string]*ServiceConfig) {
+	// yaml parser turns "no" into "false" but that is not valid for a restart policy
+	for _, v := range configs {
+		if v.Restart == "false" {
+			v.Restart = "no"
+		}
+	}
 }
 
 func readEnvFile(configLookup ConfigLookup, inFile string, serviceData rawService) (rawService, error) {

--- a/project/merge_test.go
+++ b/project/merge_test.go
@@ -146,3 +146,47 @@ child:
 		t.Fatal("Invalid image", child.Image)
 	}
 }
+
+func TestRestartNo(t *testing.T) {
+	p := NewProject(&Context{
+		ConfigLookup: &NullLookup{},
+	})
+
+	config, err := mergeProject(p, []byte(`
+test:
+  restart: no
+  image: foo
+`))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test := config["test"]
+
+	if test.Restart != "no" {
+		t.Fatal("Invalid restart policy", test.Restart)
+	}
+}
+
+func TestRestartAlways(t *testing.T) {
+	p := NewProject(&Context{
+		ConfigLookup: &NullLookup{},
+	})
+
+	config, err := mergeProject(p, []byte(`
+test:
+  restart: always
+  image: foo
+`))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	test := config["test"]
+
+	if test.Restart != "always" {
+		t.Fatal("Invalid restart policy", test.Restart)
+	}
+}


### PR DESCRIPTION
The yaml parser seems to turn `restart: no` into `restart: false` and
false is not a valid restart policy.  This patch manually fixes up the
value to be `no` if it is read as `false`.

This is based off of #66 because in that PR I added `merge_test.go` and didn't want to duplicate it and then have to deal with merge conflicts/rebasing.