### PR TITLE
 A blank value for environment should be treated as unset

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -91,9 +91,12 @@ func (p *Project) CreateService(name string) (Service, error) {
 		parsedEnv := make([]string, 0, len(config.Environment.Slice()))
 
 		for _, env := range config.Environment.Slice() {
-			if strings.IndexRune(env, '=') != -1 {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) > 1 && parts[1] != "" {
 				parsedEnv = append(parsedEnv, env)
 				continue
+			} else {
+				env = parts[0]
 			}
 
 			for _, value := range p.context.EnvironmentLookup.Lookup(env, name, &config) {

--- a/project/project.go
+++ b/project/project.go
@@ -136,16 +136,14 @@ func (p *Project) Load(bytes []byte) error {
 	return nil
 }
 
-func (p *Project) loadWrappers(wrappers map[string]*serviceWrapper) error {
-	for _, name := range p.reload {
+func (p *Project) loadWrappers(wrappers map[string]*serviceWrapper, list []string) error {
+	for _, name := range list {
 		wrapper, err := newServiceWrapper(name, p)
 		if err != nil {
 			return err
 		}
 		wrappers[name] = wrapper
 	}
-
-	p.reload = []string{}
 
 	return nil
 }
@@ -263,7 +261,7 @@ func (p *Project) forEach(services []string, action wrapperAction, cycleAction s
 		selected[s] = true
 	}
 
-	return p.traverse(selected, wrappers, action, cycleAction)
+	return p.traverse(true, selected, wrappers, action, cycleAction)
 }
 
 func (p *Project) startService(wrappers map[string]*serviceWrapper, history []string, selected, launched map[string]bool, wrapper *serviceWrapper, action wrapperAction, cycleAction serviceAction) error {
@@ -317,16 +315,25 @@ func (p *Project) startService(wrappers map[string]*serviceWrapper, history []st
 	return nil
 }
 
-func (p *Project) traverse(selected map[string]bool, wrappers map[string]*serviceWrapper, action wrapperAction, cycleAction serviceAction) error {
+func (p *Project) traverse(start bool, selected map[string]bool, wrappers map[string]*serviceWrapper, action wrapperAction, cycleAction serviceAction) error {
 	restart := false
+	wrapperList := []string{}
 
-	for _, wrapper := range wrappers {
-		if err := wrapper.Reset(); err != nil {
-			return err
+	if start {
+		for name := range p.Configs {
+			wrapperList = append(wrapperList, name)
 		}
+	} else {
+		for _, wrapper := range wrappers {
+			if err := wrapper.Reset(); err != nil {
+				return err
+			}
+		}
+		wrapperList = p.reload
 	}
 
-	p.loadWrappers(wrappers)
+	p.loadWrappers(wrappers, wrapperList)
+	p.reload = []string{}
 
 	launched := map[string]bool{}
 
@@ -356,7 +363,7 @@ func (p *Project) traverse(selected map[string]bool, wrappers map[string]*servic
 				log.Errorf("Failed calling callback: %v", err)
 			}
 		}
-		return p.traverse(selected, wrappers, action, cycleAction)
+		return p.traverse(false, selected, wrappers, action, cycleAction)
 	}
 	return firstError
 }

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 )
 
@@ -80,5 +81,41 @@ func TestEventEquality(t *testing.T) {
 
 	if EventServiceStart == EventServiceUp {
 		t.Fatal("Events match")
+	}
+}
+
+type TestEnvironmentLookup struct {
+}
+
+func (t *TestEnvironmentLookup) Lookup(key, serviceName string, config *ServiceConfig) []string {
+	return []string{fmt.Sprintf("%s=X", key)}
+}
+
+func TestEnvironmentResolve(t *testing.T) {
+	factory := &TestServiceFactory{
+		Counts: map[string]int{},
+	}
+
+	p := NewProject(&Context{
+		ServiceFactory:    factory,
+		EnvironmentLookup: &TestEnvironmentLookup{},
+	})
+	p.Configs = map[string]*ServiceConfig{
+		"foo": {
+			Environment: NewMaporEqualSlice([]string{
+				"A",
+				"A=",
+				"A=B",
+			}),
+		},
+	}
+
+	service, err := p.CreateService("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(service.Config().Environment.Slice(), []string{"A=X", "A=X", "A=B"}) {
+		t.Fatal("Invalid environment", service.Config().Environment.Slice())
 	}
 }

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -5,6 +5,69 @@ import (
 	"testing"
 )
 
+type TestServiceFactory struct {
+	Counts map[string]int
+}
+
+type TestService struct {
+	factory *TestServiceFactory
+	name    string
+	config  *ServiceConfig
+	EmptyService
+	Count int
+}
+
+func (t *TestService) Config() *ServiceConfig {
+	return t.config
+}
+
+func (t *TestService) Name() string {
+	return t.name
+}
+
+func (t *TestService) Create() error {
+	key := t.name + ".create"
+	t.factory.Counts[key] = t.factory.Counts[key] + 1
+	return nil
+}
+
+func (t *TestService) DependentServices() []ServiceRelationship {
+	return nil
+}
+
+func (t *TestServiceFactory) Create(project *Project, name string, serviceConfig *ServiceConfig) (Service, error) {
+	return &TestService{
+		factory: t,
+		config:  serviceConfig,
+		name:    name,
+	}, nil
+}
+
+func TestTwoCall(t *testing.T) {
+	factory := &TestServiceFactory{
+		Counts: map[string]int{},
+	}
+
+	p := NewProject(&Context{
+		ServiceFactory: factory,
+	})
+	p.Configs = map[string]*ServiceConfig{
+		"foo": {},
+	}
+
+	if err := p.Create("foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.Create("foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	if factory.Counts["foo.create"] != 2 {
+		t.Fatal("Failed to create twice")
+	}
+}
+
 func TestEventEquality(t *testing.T) {
 	if fmt.Sprintf("%s", EventServiceStart) != "Started" ||
 		fmt.Sprintf("%v", EventServiceStart) != "Started" {


### PR DESCRIPTION
This fixes an issue in which the below would not lookup `A` in the
current environment.

```yaml
test:
  image: foo
  environment:
    A:
```

This PR is based on #65 because it had all the test stubs I needed.