### PR TITLE
Strings are valid for numeric fields

### DIFF
--- a/project/interpolation.go
+++ b/project/interpolation.go
@@ -3,6 +3,7 @@ package project
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -106,10 +107,21 @@ func parseConfig(option, service string, data *interface{}, mapping func(string)
 	switch typedData := (*data).(type) {
 	case string:
 		var success bool
-		*data, success = parseLine(typedData, mapping)
+
+		interpolatedLine, success := parseLine(typedData, mapping)
 
 		if !success {
 			return fmt.Errorf("Invalid interpolation format for \"%s\" option in service \"%s\": \"%s\"", option, service, typedData)
+		}
+
+		// If possible, convert the value to an integer
+		// If the type should be a string and not an int, go-yaml will convert it back into a string
+		lineAsInteger, err := strconv.Atoi(interpolatedLine)
+
+		if err == nil {
+			*data = lineAsInteger
+		} else {
+			*data = interpolatedLine
 		}
 	case []interface{}:
 		for k, v := range typedData {


### PR DESCRIPTION
Fixes #85. This works by attempting to convert all fields to integers. If it's successful for a given field, it sets the type as an integer, and if not it sets it as a string.

Then, if the type of that field should be an integer in `ServiceConfig`, all is well. If not, then go-yaml will convert that field back into a string when it unmarshals to a  `ServiceConfig`.

Thanks to @ibuildthecloud for thinking of this method.

Signed-off-by: Josh Curl <hello@joshcurl.com>