### PR TITLE
Environment variables can contain equal signs

### DIFF
--- a/project/interpolation.go
+++ b/project/interpolation.go
@@ -147,7 +147,12 @@ func interpolate(environmentLookup EnvironmentLookup, config *rawServiceMap) err
 					return ""
 				}
 
-				return strings.Split(values[0], "=")[1]
+				// Use first result if many are given
+				value := values[0]
+
+				// Environment variables come in key=value format
+				// Return everything past first '='
+				return strings.SplitN(value, "=", 2)[1]
 			})
 
 			if err != nil {

--- a/project/interpolation_test.go
+++ b/project/interpolation_test.go
@@ -159,6 +159,47 @@ func TestInterpolate(t *testing.T) {
 			"LABEL_VALUE": "myvalue",
 		})
 
+	// Same as above, but testing with equal signs in variables
+	testInterpolatedConfig(t,
+		`web:
+  # unbracketed name
+  image: =busybox
+
+  # array element
+  ports:
+    - "=:8000"
+
+  # dictionary item value
+  labels:
+    mylabel: "myvalue=="
+
+  # unset value
+  hostname: "host-"
+
+  # escaped interpolation
+  command: "${ESCAPED}"`,
+		`web:
+  # unbracketed name
+  image: $IMAGE
+
+  # array element
+  ports:
+    - "${HOST_PORT}:8000"
+
+  # dictionary item value
+  labels:
+    mylabel: "${LABEL_VALUE}"
+
+  # unset value
+  hostname: "host-${UNSET_VALUE}"
+
+  # escaped interpolation
+  command: "$${ESCAPED}"`, map[string]string{
+			"IMAGE":       "=busybox",
+			"HOST_PORT":   "=",
+			"LABEL_VALUE": "myvalue==",
+		})
+
 	testInvalidInterpolatedConfig(t,
 		`web:
   image: "${"`)


### PR DESCRIPTION
Environment variables containing an equals sign weren't being parsed correctly. This is a fix for that issue, as well as an additional unit test to cover that case.

Signed-off-by: Josh Curl <hello@joshcurl.com>