### PR TITLE
Update test-unit and test-integration script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,9 @@ LIBCOMPOSE_ENVS := \
 	-e OS_PLATFORM_ARG \
 	-e OS_ARCH_ARG \
 	-e DOCKER_TEST_HOST \
-	-e TESTFLAGS
+	-e TESTDIRS \
+	-e TESTFLAGS \
+	-e TESTVERBOSE
 
 # (default to no bind mount if DOCKER_HOST is set)
 BIND_DIR := $(if $(DOCKER_HOST),,bundles)
@@ -27,7 +29,7 @@ test: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-unit test-integration
 
 test-unit: build
-	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-unit
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh test-unit
 
 test-integration: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-integration

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -97,8 +97,10 @@ func (s *RunSuite) FromText(c *C, projectName, command string, argsAndInput ...s
 
 	cmd := exec.Command(s.command, args...)
 	cmd.Stdin = bytes.NewBufferString(strings.Replace(input, "\t", "  ", -1))
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
+	if os.Getenv("TESTVERBOSE") != "" {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stdout
+	}
 
 	err := cmd.Run()
 	if err != nil {

--- a/script/make.sh
+++ b/script/make.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+export LIBCOMPOSE_PKG='github.com/docker/libcompose'
+
 # List of bundles to create when no argument is passed
 DEFAULT_BUNDLES=(
 	validate-gofmt

--- a/script/test-integration
+++ b/script/test-integration
@@ -5,8 +5,10 @@ export DEST=.
 
 bundle .integration-daemon-start
 
-TESTFLAGS="$TESTFLAGS -check.v"
-#godep go test -v ./_integration-test
-godep go test -v ./integration
+TESTFLAGS="$TESTFLAGS -test.timeout=30m -check.v"
+
+cd integration
+TESTVERBOSE=$TESTVERBOSE go test $TESTFLAGS
+cd ..
 
 bundle .integration-daemon-stop

--- a/script/test-unit
+++ b/script/test-unit
@@ -29,8 +29,8 @@ fi
 TESTS_FAILED=()
 
 for dir in $TESTDIRS; do
-    echo '+ go test' $TESTFLAGS "${dir}"
-    godep go test ${TESTFLAGS} ${dir}
+    echo '+ go test' $TESTFLAGS "${LIBCOMPOSE_PKG}/${dir#./}"
+    godep go test ${TESTFLAGS} "${LIBCOMPOSE_PKG}/${dir#./}"
     if [ $? != 0 ]; then
         TESTS_FAILED+=("$dir")
         echo


### PR DESCRIPTION
… to support `TESTFLAGS` and `TESTDIRS` 🐢.

This makes it possible to do such things as (same as in `docker/docker`) :

```bash
$ TESTFLAGS='-check.f RunSuite.TestBuild' make test-integration
# Runs only RunSuite.TestBuild
# […]

$ TESTDIRS='project' make test-unit
# […]
---> Making bundle: test-unit (in .)
+ go test -cover -coverprofile=cover.out github.com/docker/libcompose/project
ok      github.com/docker/libcompose/project    0.035s  coverage: 44.5% of statements

Test success

$ TESTDIRS='project' TESTFLAGS='-test.run ^TestParseLine$' make test-unit
# […]
---> Making bundle: test-unit (in .)
+ go test -cover -coverprofile=cover.out -test.run ^TestParseLine$ github.com/docker/libcompose/project
ok      github.com/docker/libcompose/project    0.017s  coverage: 5.1% of statements

Test success
```

This also removes the `binary` target dependency of `test-unit` as we don't need to build the binary to run unit-tests — and thus `make test-unit` is quicker :wink:.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>