### PR TITLE
Don't use memswap_limit for test

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -13,7 +13,6 @@ func (s *RunSuite) TestFields(c *C) {
           image: tianon/true
           cpuset: 1,2
           mem_limit: 4194304
-          memswap_limit: 8388608
         `)
 
 	name := fmt.Sprintf("%s_%s_1", p, "hello")
@@ -23,7 +22,6 @@ func (s *RunSuite) TestFields(c *C) {
 	c.Assert(cn.Config.Image, Equals, "tianon/true")
 	c.Assert(cn.HostConfig.CPUSetCPUs, Equals, "1,2")
 	c.Assert(cn.HostConfig.Memory, Equals, int64(4194304))
-	c.Assert(cn.HostConfig.MemorySwap, Equals, int64(8388608))
 }
 
 func (s *RunSuite) TestHelloWorld(c *C) {


### PR DESCRIPTION
As it could be disabled on the machine that builds and thus give an test
failure for a wrong reason.

See https://jenkins.dockerproject.org/job/Libcompose%20Master/71/console

Signed-off-by: Vincent Demeester <vincent@sbr.pm>