### PR TITLE
Carry #82 : support command ps -q

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -44,13 +44,14 @@ func WithProject(factory ProjectFactory, action ProjectAction) func(context *cli
 // ProjectPs lists the containers.
 func ProjectPs(p *project.Project, c *cli.Context) {
 	allInfo := project.InfoSet{}
+	qFlag := c.Bool("q")
 	for name := range p.Configs {
 		service, err := p.CreateService(name)
 		if err != nil {
 			logrus.Fatal(err)
 		}
 
-		info, err := service.Info()
+		info, err := service.Info(qFlag)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -58,7 +59,7 @@ func ProjectPs(p *project.Project, c *cli.Context) {
 		allInfo = append(allInfo, info...)
 	}
 
-	os.Stdout.WriteString(allInfo.String())
+	os.Stdout.WriteString(allInfo.String(!qFlag))
 }
 
 // ProjectPort prints the public port for a port binding.

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -30,6 +30,12 @@ func PsCommand(factory app.ProjectFactory) cli.Command {
 		Name:   "ps",
 		Usage:  "List containers",
 		Action: app.WithProject(factory, app.ProjectPs),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "q",
+				Usage: "Only display IDs",
+			},
+		},
 	}
 }
 

--- a/docker/container.go
+++ b/docker/container.go
@@ -52,7 +52,7 @@ func (c *Container) findInfo() (*dockerclient.Container, error) {
 }
 
 // Info returns info about the container, like name, command, state or ports.
-func (c *Container) Info() (project.Info, error) {
+func (c *Container) Info(qFlag bool) (project.Info, error) {
 	container, err := c.findExisting()
 	if err != nil {
 		return nil, err
@@ -60,10 +60,14 @@ func (c *Container) Info() (project.Info, error) {
 
 	result := project.Info{}
 
-	result = append(result, project.InfoPart{Key: "Name", Value: name(container.Names)})
-	result = append(result, project.InfoPart{Key: "Command", Value: container.Command})
-	result = append(result, project.InfoPart{Key: "State", Value: container.Status})
-	result = append(result, project.InfoPart{Key: "Ports", Value: portString(container.Ports)})
+	if qFlag {
+		result = append(result, project.InfoPart{Key: "Id", Value: container.Id})
+	} else {
+		result = append(result, project.InfoPart{Key: "Name", Value: name(container.Names)})
+		result = append(result, project.InfoPart{Key: "Command", Value: container.Command})
+		result = append(result, project.InfoPart{Key: "State", Value: container.Status})
+		result = append(result, project.InfoPart{Key: "Ports", Value: portString(container.Ports)})
+	}
 
 	return result, nil
 }

--- a/docker/container.go
+++ b/docker/container.go
@@ -61,7 +61,7 @@ func (c *Container) Info(qFlag bool) (project.Info, error) {
 	result := project.Info{}
 
 	if qFlag {
-		result = append(result, project.InfoPart{Key: "Id", Value: container.Id})
+		result = append(result, project.InfoPart{Key: "Id", Value: container.ID})
 	} else {
 		result = append(result, project.InfoPart{Key: "Name", Value: name(container.Names)})
 		result = append(result, project.InfoPart{Key: "Command", Value: container.Command})

--- a/docker/service.go
+++ b/docker/service.go
@@ -146,7 +146,7 @@ func (s *Service) Up() error {
 
 // Info implements Service.Info. It returns an project.InfoSet with the containers
 // related to this service (can be multiple if using the scale command).
-func (s *Service) Info() (project.InfoSet, error) {
+func (s *Service) Info(qFlag bool) (project.InfoSet, error) {
 	result := project.InfoSet{}
 	containers, err := s.collectContainers()
 	if err != nil {
@@ -154,7 +154,7 @@ func (s *Service) Info() (project.InfoSet, error) {
 	}
 
 	for _, c := range containers {
-		info, err := c.Info()
+		info, err := c.Info(qFlag)
 		if err != nil {
 			return nil, err
 		}

--- a/integration/ps_test.go
+++ b/integration/ps_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"fmt"
+	"strings"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *RunSuite) TestPs(c *C) {
+	p := s.ProjectFromText(c, "up", SimpleTemplate)
+
+	name := fmt.Sprintf("%s_%s_1", p, "hello")
+
+	_, out := s.FromTextCaptureOutput(c, p, "ps", SimpleTemplate)
+
+	c.Assert(strings.Contains(out,
+		fmt.Sprintf(`%s  sh       Up Less than a second`, name)),
+		Equals, true, Commentf("%s", out))
+}
+
+func (s *RunSuite) TestPsQuiet(c *C) {
+	p := s.ProjectFromText(c, "up", SimpleTemplate)
+
+	name := fmt.Sprintf("%s_%s_1", p, "hello")
+	container := s.GetContainerByName(c, name)
+
+	_, out := s.FromTextCaptureOutput(c, p, "ps", "-q", SimpleTemplate)
+
+	c.Assert(strings.Contains(out,
+		fmt.Sprintf(`%s`, container.ID)),
+		Equals, true, Commentf("%s", out))
+}

--- a/project/empty.go
+++ b/project/empty.go
@@ -65,6 +65,6 @@ func (e *EmptyService) Scale(count int) error {
 }
 
 // Info implements Service.Info but does nothing.
-func (e *EmptyService) Info() (InfoSet, error) {
+func (e *EmptyService) Info(qFlag bool) (InfoSet, error) {
 	return InfoSet{}, nil
 }

--- a/project/info.go
+++ b/project/info.go
@@ -6,14 +6,14 @@ import (
 	"text/tabwriter"
 )
 
-func (infos InfoSet) String() string {
+func (infos InfoSet) String(titleFlag bool) string {
 	//no error checking, none of this should fail
 	buffer := bytes.NewBuffer(make([]byte, 0, 1024))
 	tabwriter := tabwriter.NewWriter(buffer, 4, 4, 2, ' ', 0)
 
 	first := true
 	for _, info := range infos {
-		if first {
+		if first && titleFlag {
 			writeLine(tabwriter, true, info)
 		}
 		first = false

--- a/project/types.go
+++ b/project/types.go
@@ -230,7 +230,7 @@ type Project struct {
 
 // Service defines what a libcompose service provides.
 type Service interface {
-	Info() (InfoSet, error)
+	Info(qFlag bool) (InfoSet, error)
 	Name() string
 	Build() error
 	Create() error


### PR DESCRIPTION
Carry #82 (and thus closes it).

Add a `-q` flag to the libcompose cli to only display id : from compose `-q    Only display IDs`.

Adds integration tests to it.