### PR TITLE
Fix test-unit target by creating a generate bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,16 +23,16 @@ all: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh
 
 binary: build
-	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh generate binary
 
 test: build
-	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-unit test-integration
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh generate binary test-unit test-integration
 
 test-unit: build
-	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh test-unit
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh generate test-unit
 
 test-integration: build
-	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-integration
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh generate binary test-integration
 
 validate-dco: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-dco

--- a/script/binary
+++ b/script/binary
@@ -16,10 +16,6 @@ fi
 # Get rid of existing binaries
 rm -f libcompose-cli*
 
-# Run go generate before building
-# FIXME Remove this at some point, this is a hack for docker/docker/autogen/dockerversion
-go generate
-
 # Build binaries
 gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" \
     -output="bundles/libcompose-cli_{{.OS}}-{{.Arch}}" \

--- a/script/generate
+++ b/script/generate
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+# Run go generate before building
+# FIXME Remove this at some point, this is a hack for docker/docker/autogen/dockerversion
+go generate

--- a/script/make.sh
+++ b/script/make.sh
@@ -11,6 +11,8 @@ DEFAULT_BUNDLES=(
 	validate-git-marks
 	validate-lint
 	validate-vet
+
+	generate
 	binary
 
 	test-unit


### PR DESCRIPTION
Seperate `generate` from `binary` from the binary bundle, to fix `make test-unit` runs only. And it will be easier to remove it once not needed. 🐯

```bash
# Before
$ make test-unit
# […]
---> Making bundle: test-unit (in .)
+ go test -cover -coverprofile=cover.out github.com/docker/libcompose/docker
vendor/github.com/docker/docker/registry/registry.go:21:2: cannot find package "github.com/docker/docker/autogen/dockerversion" in any of:
        /go/src/github.com/docker/libcompose/vendor/github.com/docker/docker/autogen/dockerversion (vendor tree)
        /usr/local/go/src/github.com/docker/docker/autogen/dockerversion (from $GOROOT)
        /go/src/github.com/docker/docker/autogen/dockerversion (from $GOPATH)
Makefile:32: recipe for target 'test-unit' failed
make: *** [test-unit] Error 1
# After 
$ make test-unit
# […]
---> Making bundle: generate (in .)

---> Making bundle: test-unit (in .)
+ go test -cover -coverprofile=cover.out github.com/docker/libcompose/docker
ok      github.com/docker/libcompose/docker     0.008s  coverage: 8.1% of statements
+ go test -cover -coverprofile=cover.out github.com/docker/libcompose/lookup
ok      github.com/docker/libcompose/lookup     0.004s  coverage: 100.0% of statements
+ go test -cover -coverprofile=cover.out github.com/docker/libcompose/project
ok      github.com/docker/libcompose/project    0.012s  coverage: 46.1% of statements
+ go test -cover -coverprofile=cover.out github.com/docker/libcompose/utils
ok      github.com/docker/libcompose/utils      0.003s  coverage: 93.9% of statements
+ go test -cover -coverprofile=cover.out github.com/docker/libcompose/version
ok      github.com/docker/libcompose/version    0.003s  coverage: 0.0% of statements
```

This will make it even easier to remove the generate thingy when no more needed :wink:.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>