### PR TITLE
Do not forget to specify the container when calling c.client.Logs()

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -456,6 +456,7 @@ func (c *Container) Log() error {
 	l := c.service.context.LoggerFactory.Create(c.name)
 
 	err = c.client.Logs(dockerclient.LogsOptions{
+		Container:    c.name,
 		Follow:       true,
 		Stdout:       true,
 		Stderr:       true,
@@ -464,6 +465,7 @@ func (c *Container) Log() error {
 		ErrorStream:  &logger.Wrapper{Logger: l, Err: true},
 		RawTerminal:  info.Config.Tty,
 	})
+	logrus.WithFields(logrus.Fields{"Logger": l, "err": err}).Debug("c.client.Logs() returned error")
 
 	return err
 }


### PR DESCRIPTION
Do not forget to specify the container when calling c.client.Logs()

Signed-off-by: Ivan Mikushin <i.mikushin@gmail.com>