### PR TITLE
Allow int and bool types in most YAML types

### DIFF
--- a/project/types_yaml_test.go
+++ b/project/types_yaml_test.go
@@ -98,6 +98,15 @@ func TestMarshalServiceConfig(t *testing.T) {
 	assert.Equal(t, configPtr, configPtr2)
 }
 
+func TestStringorsliceStringersTypes(t *testing.T) {
+	str := `{foo: [false, 1024]}`
+
+	s := StructStringorslice{}
+	yaml.Unmarshal([]byte(str), &s)
+
+	assert.Equal(t, []string{"false", "1024"}, s.Foo.parts)
+}
+
 func TestStringorsliceYaml(t *testing.T) {
 	str := `{foo: [bar, baz]}`
 
@@ -175,6 +184,17 @@ func contains(list []string, item string) bool {
 		}
 	}
 	return false
+}
+
+func TestMaporsliceStringersTypes(t *testing.T) {
+	str := `{foo: {bar: false, far: 1024}}`
+
+	s := StructMaporslice{}
+	yaml.Unmarshal([]byte(str), &s)
+
+	assert.Equal(t, 2, len(s.Foo.parts))
+	assert.True(t, contains(s.Foo.parts, "bar=false"))
+	assert.True(t, contains(s.Foo.parts, "far=1024"))
 }
 
 func TestMaporsliceYaml(t *testing.T) {


### PR DESCRIPTION
Since #86 promotes any integers encoded as strings to integers, this change allows integers and bools to convert back to strings in YAML. 

This change also prevents panics as in #108. Fixes #113.

Signed-off-by: Lachlan Donald <lachlan@ljd.cc>