### PR TITLE
Multiple -f

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ import (
 func main() {
 	project, err := docker.NewProject(&docker.Context{
 		Context: project.Context{
-			ComposeFile: "docker-compose.yml",
-			ProjectName: "my-compose",
+			ComposeFiles: []string{"docker-compose.yml"},
+			ProjectName:  "my-compose",
 		},
 	})
 

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"os"
+
 	"github.com/codegangsta/cli"
 	"github.com/docker/libcompose/cli/app"
 	"github.com/docker/libcompose/project"
@@ -229,7 +231,11 @@ func CommonFlags() []cli.Flag {
 // Populate updates the specified project context based on command line arguments and subcommands.
 func Populate(context *project.Context, c *cli.Context) {
 	if len(c.GlobalStringSlice("file")) == 0 {
-		context.ComposeFiles = []string{"docker-compose.yml"}
+		if _, err := os.Stat("docker-compose.override.yml"); err == nil {
+			context.ComposeFiles = []string{"docker-compose.yml", "docker-compose.override.yml"}
+		} else {
+			context.ComposeFiles = []string{"docker-compose.yml"}
+		}
 	} else {
 		context.ComposeFiles = c.GlobalStringSlice("file")
 	}

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -213,10 +213,10 @@ func CommonFlags() []cli.Flag {
 		cli.BoolFlag{
 			Name: "verbose,debug",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:   "file,f",
-			Usage:  "Specify an alternate compose file (default: docker-compose.yml)",
-			Value:  "docker-compose.yml",
+			Usage:  "Specify one or more alternate compose files (default: docker-compose.yml)",
+			Value:  &cli.StringSlice{},
 			EnvVar: "COMPOSE_FILE",
 		},
 		cli.StringFlag{
@@ -228,7 +228,12 @@ func CommonFlags() []cli.Flag {
 
 // Populate updates the specified project context based on command line arguments and subcommands.
 func Populate(context *project.Context, c *cli.Context) {
-	context.ComposeFile = c.GlobalString("file")
+	if len(c.GlobalStringSlice("file")) == 0 {
+		context.ComposeFiles = []string{"docker-compose.yml"}
+	} else {
+		context.ComposeFiles = c.GlobalStringSlice("file")
+	}
+
 	context.ProjectName = c.GlobalString("project-name")
 
 	if c.Command.Name == "logs" {

--- a/example/main.go
+++ b/example/main.go
@@ -10,8 +10,8 @@ import (
 func main() {
 	project, err := docker.NewProject(&docker.Context{
 		Context: project.Context{
-			ComposeFile: "docker-compose.yml",
-			ProjectName: "yeah-compose",
+			ComposeFiles: []string{"docker-compose.yml"},
+			ProjectName:  "yeah-compose",
 		},
 	})
 

--- a/integration/assets/multiple/one.yml
+++ b/integration/assets/multiple/one.yml
@@ -1,0 +1,4 @@
+multiple:
+  image: tianon/true
+  environment:
+    - KEY1=VAL1

--- a/integration/assets/multiple/one.yml
+++ b/integration/assets/multiple/one.yml
@@ -2,3 +2,9 @@ multiple:
   image: tianon/true
   environment:
     - KEY1=VAL1
+simple:
+  image: busybox:latest
+  command: top
+another:
+  image: busybox:latest
+  command: top

--- a/integration/assets/multiple/two.yml
+++ b/integration/assets/multiple/two.yml
@@ -1,0 +1,5 @@
+multiple:
+  image: busybox
+  command: echo two
+  environment:
+    - KEY2=VAL2

--- a/integration/assets/multiple/two.yml
+++ b/integration/assets/multiple/two.yml
@@ -3,3 +3,6 @@ multiple:
   command: echo two
   environment:
     - KEY2=VAL2
+yetanother:
+  image: busybox:latest
+  command: top

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	. "gopkg.in/check.v1"
 )
@@ -155,4 +156,42 @@ func (s *RunSuite) TestFieldTypeConversions(c *C) {
 	c.Assert(referenceContainer.Image, Equals, testContainer.Image)
 
 	os.Unsetenv("LIMIT")
+}
+
+func (s *RunSuite) TestMultipleComposeFiles(c *C) {
+	p := s.RandomProject()
+	cmd := exec.Command(s.command, "-f", "./assets/multiple/one.yml", "-f", "./assets/multiple/two.yml", "-p", p, "create")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	err := cmd.Run()
+
+	c.Assert(err, IsNil)
+
+	name := fmt.Sprintf("%s_%s_1", p, "multiple")
+	container := s.GetContainerByName(c, name)
+
+	c.Assert(container, NotNil)
+
+	c.Assert(container.Config.Image, Equals, "busybox")
+	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})
+	c.Assert(container.Config.Env, DeepEquals, []string{"KEY1=VAL1", "KEY2=VAL2"})
+
+	p = s.RandomProject()
+	cmd = exec.Command(s.command, "-f", "./assets/multiple/two.yml", "-f", "./assets/multiple/one.yml", "-p", p, "create")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	err = cmd.Run()
+
+	c.Assert(err, IsNil)
+
+	name = fmt.Sprintf("%s_%s_1", p, "multiple")
+	container = s.GetContainerByName(c, name)
+
+	c.Assert(container, NotNil)
+
+	c.Assert(container.Config.Image, Equals, "tianon/true")
+	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})
+	c.Assert(container.Config.Env, DeepEquals, []string{"KEY2=VAL2", "KEY1=VAL1"})
 }

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -168,10 +168,17 @@ func (s *RunSuite) TestMultipleComposeFiles(c *C) {
 
 	c.Assert(err, IsNil)
 
+	containerNames := []string{"multiple", "simple", "another", "yetanother"}
+
+	for _, containerName := range containerNames {
+		name := fmt.Sprintf("%s_%s_1", p, containerName)
+		container := s.GetContainerByName(c, name)
+
+		c.Assert(container, NotNil)
+	}
+
 	name := fmt.Sprintf("%s_%s_1", p, "multiple")
 	container := s.GetContainerByName(c, name)
-
-	c.Assert(container, NotNil)
 
 	c.Assert(container.Config.Image, Equals, "busybox")
 	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})
@@ -186,10 +193,15 @@ func (s *RunSuite) TestMultipleComposeFiles(c *C) {
 
 	c.Assert(err, IsNil)
 
+	for _, containerName := range containerNames {
+		name := fmt.Sprintf("%s_%s_1", p, containerName)
+		container := s.GetContainerByName(c, name)
+
+		c.Assert(container, NotNil)
+	}
+
 	name = fmt.Sprintf("%s_%s_1", p, "multiple")
 	container = s.GetContainerByName(c, name)
-
-	c.Assert(container, NotNil)
 
 	c.Assert(container.Config.Image, Equals, "tianon/true")
 	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})

--- a/project/merge_test.go
+++ b/project/merge_test.go
@@ -14,7 +14,7 @@ func TestExtendsInheritImage(t *testing.T) {
 		ConfigLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   image: foo
 child:
@@ -47,7 +47,7 @@ func TestExtendsInheritBuild(t *testing.T) {
 		ConfigLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   build: .
 child:
@@ -80,7 +80,7 @@ func TestExtendBuildOverImage(t *testing.T) {
 		ConfigLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   image: foo
 child:
@@ -114,7 +114,7 @@ func TestExtendImageOverBuild(t *testing.T) {
 		ConfigLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   build: .
 child:
@@ -152,7 +152,7 @@ func TestRestartNo(t *testing.T) {
 		ConfigLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 test:
   restart: no
   image: foo
@@ -174,7 +174,7 @@ func TestRestartAlways(t *testing.T) {
 		ConfigLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 test:
   restart: always
   image: foo

--- a/project/types.go
+++ b/project/types.go
@@ -219,7 +219,7 @@ type ConfigLookup interface {
 type Project struct {
 	Name           string
 	Configs        map[string]*ServiceConfig
-	File           string
+	Files          []string
 	ReloadCallback func() error
 	context        *Context
 	reload         []string


### PR DESCRIPTION
Fixes #98. This changes some properties of `Context` (`string ComposeFile` to `[]string ComposeFiles` and `[]byte ComposeBytes` to `[][]byte ComposeBytes`) as well as `Project` (`string File` to `[]string Files`).

Signed-off-by: Josh Curl <hello@joshcurl.com>