### PR TITLE
Stringify int yaml types

### DIFF
--- a/project/types_yaml.go
+++ b/project/types_yaml.go
@@ -7,10 +7,10 @@ import (
 	"github.com/flynn/go-shlex"
 )
 
-// stringer converts ints, strings and bools to a string
+// stringer converts ints and strings to a string type
 func stringer(v interface{}) (string, error) {
 	switch v.(type) {
-	case string, int64, int32, int, bool:
+	case string, int64, int32, int:
 		return fmt.Sprint(v), nil
 	default:
 		return "", fmt.Errorf("Value of type %T can't be converted to a string", v)

--- a/project/types_yaml.go
+++ b/project/types_yaml.go
@@ -20,11 +20,11 @@ func stringer(v interface{}) (string, error) {
 func sliceStringer(value []interface{}) ([]string, error) {
 	slice := make([]string, len(value))
 	for k, v := range value {
-		if vstr, err := stringer(v); err != nil {
+		vstr, err := stringer(v)
+		if err != nil {
 			return nil, err
-		} else {
-			slice[k] = vstr
 		}
+		slice[k] = vstr
 	}
 	return slice, nil
 }
@@ -36,11 +36,11 @@ func mapStringer(value map[interface{}]interface{}) (map[string]string, error) {
 		if !ok {
 			return nil, fmt.Errorf("Map must have string keys only, had %T", k)
 		}
-		if vstr, err := stringer(v); err != nil {
+		vstr, err := stringer(v)
+		if err != nil {
 			return nil, err
-		} else {
-			parts[kstr] = vstr
 		}
+		parts[kstr] = vstr
 	}
 	return parts, nil
 }

--- a/project/types_yaml.go
+++ b/project/types_yaml.go
@@ -7,6 +7,52 @@ import (
 	"github.com/flynn/go-shlex"
 )
 
+// stringer converts ints, strings and bools to a string
+func stringer(v interface{}) (string, error) {
+	switch v.(type) {
+	case string, int64, int32, int, bool:
+		return fmt.Sprint(v), nil
+	default:
+		return "", fmt.Errorf("Value of type %T can't be converted to a string", v)
+	}
+}
+
+func sliceStringer(value []interface{}) ([]string, error) {
+	slice := make([]string, len(value))
+	for k, v := range value {
+		if vstr, err := stringer(v); err != nil {
+			return nil, err
+		} else {
+			slice[k] = vstr
+		}
+	}
+	return slice, nil
+}
+
+func mapStringer(value map[interface{}]interface{}) (map[string]string, error) {
+	parts := map[string]string{}
+	for k, v := range value {
+		kstr, ok := k.(string)
+		if !ok {
+			return nil, fmt.Errorf("Map must have string keys only, had %T", k)
+		}
+		if vstr, err := stringer(v); err != nil {
+			return nil, err
+		} else {
+			parts[kstr] = vstr
+		}
+	}
+	return parts, nil
+}
+
+func mapToSlice(m map[string]string, joinStr string) []string {
+	slice := []string{}
+	for k, v := range m {
+		slice = append(slice, strings.Join([]string{k, v}, joinStr))
+	}
+	return slice
+}
+
 // Stringorslice represents a string or an array of strings.
 // TODO use docker/docker/pkg/stringutils.StrSlice once 1.9.x is released.
 type Stringorslice struct {
@@ -18,36 +64,18 @@ func (s Stringorslice) MarshalYAML() (tag string, value interface{}, err error) 
 	return "", s.parts, nil
 }
 
-func toStrings(s []interface{}) ([]string, error) {
-	if len(s) == 0 {
-		return nil, nil
-	}
-	r := make([]string, len(s))
-	for k, v := range s {
-		if sv, ok := v.(string); ok {
-			r[k] = sv
-		} else {
-			return nil, fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", v, v)
-		}
-	}
-	return r, nil
-}
-
 // UnmarshalYAML implements the Unmarshaller interface.
 func (s *Stringorslice) UnmarshalYAML(tag string, value interface{}) error {
+	var err error
 	switch value := value.(type) {
 	case []interface{}:
-		parts, err := toStrings(value)
-		if err != nil {
-			return err
-		}
-		s.parts = parts
+		s.parts, err = sliceStringer(value)
 	case string:
 		s.parts = []string{value}
 	default:
 		return fmt.Errorf("Failed to unmarshal Stringorslice: %#v", value)
 	}
-	return nil
+	return err
 }
 
 // Len returns the number of parts of the Stringorslice.
@@ -86,11 +114,7 @@ func (s Command) MarshalYAML() (tag string, value interface{}, err error) {
 func (s *Command) UnmarshalYAML(tag string, value interface{}) error {
 	switch value := value.(type) {
 	case []interface{}:
-		parts, err := toStrings(value)
-		if err != nil {
-			return err
-		}
-		s.parts = parts
+		s.parts, err = sliceStringer(value)
 	case string:
 		parts, err := shlex.Split(value)
 		if err != nil {
@@ -130,43 +154,29 @@ func (s SliceorMap) MarshalYAML() (tag string, value interface{}, err error) {
 
 // UnmarshalYAML implements the Unmarshaller interface.
 func (s *SliceorMap) UnmarshalYAML(tag string, value interface{}) error {
+	var err error
 	switch value := value.(type) {
 	case map[interface{}]interface{}:
-		parts := map[string]string{}
-		for k, v := range value {
-			if sk, ok := k.(string); ok {
-				if sv, ok := v.(string); ok {
-					parts[sk] = sv
-				} else {
-					return fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", v, v)
-				}
-			} else {
-				return fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", k, k)
-			}
-		}
-		s.parts = parts
+		s.parts, err = mapStringer(value)
 	case []interface{}:
 		parts := map[string]string{}
-		for _, s := range value {
-			if str, ok := s.(string); ok {
-				str := strings.TrimSpace(str)
-				keyValueSlice := strings.SplitN(str, "=", 2)
-
-				key := keyValueSlice[0]
-				val := ""
-				if len(keyValueSlice) == 2 {
-					val = keyValueSlice[1]
-				}
-				parts[key] = val
-			} else {
-				return fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", s, s)
+		values, err := sliceStringer(value)
+		if err != nil {
+			return err
+		}
+		for _, v := range values {
+			keyValueSlice := strings.SplitN(strings.TrimSpace(v), "=", 2)
+			key := keyValueSlice[0]
+			val := ""
+			if len(keyValueSlice) == 2 {
+				val = keyValueSlice[1]
 			}
 		}
 		s.parts = parts
 	default:
 		return fmt.Errorf("Failed to unmarshal SliceorMap: %#v", value)
 	}
-	return nil
+	return err
 }
 
 // MapParts get the parts of the SliceorMap as a Map of string.
@@ -214,23 +224,20 @@ func toSepMapParts(value map[interface{}]interface{}, sep string) ([]string, err
 
 // UnmarshalYAML implements the Unmarshaller interface.
 func (s *MaporEqualSlice) UnmarshalYAML(tag string, value interface{}) error {
+	var err error
 	switch value := value.(type) {
 	case []interface{}:
-		parts, err := toStrings(value)
-		if err != nil {
-			return err
-		}
-		s.parts = parts
+		s.parts, err = sliceStringer(value)
 	case map[interface{}]interface{}:
-		parts, err := toSepMapParts(value, "=")
+		parts, err := mapStringer(value)
 		if err != nil {
 			return err
 		}
-		s.parts = parts
+		s.parts = mapToSlice(parts, "=")
 	default:
 		return fmt.Errorf("Failed to unmarshal MaporEqualSlice: %#v", value)
 	}
-	return nil
+	return err
 }
 
 // Slice gets the parts of the MaporEqualSlice as a Slice of string.
@@ -256,23 +263,20 @@ func (s MaporColonSlice) MarshalYAML() (tag string, value interface{}, err error
 
 // UnmarshalYAML implements the Unmarshaller interface.
 func (s *MaporColonSlice) UnmarshalYAML(tag string, value interface{}) error {
+	var err error
 	switch value := value.(type) {
 	case []interface{}:
-		parts, err := toStrings(value)
-		if err != nil {
-			return err
-		}
-		s.parts = parts
+		s.parts, err = sliceStringer(value)
 	case map[interface{}]interface{}:
-		parts, err := toSepMapParts(value, ":")
+		parts, err := mapStringer(value)
 		if err != nil {
 			return err
 		}
-		s.parts = parts
+		s.parts = mapToSlice(parts, ":")
 	default:
 		return fmt.Errorf("Failed to unmarshal MaporColonSlice: %#v", value)
 	}
-	return nil
+	return err
 }
 
 // Slice gets the parts of the MaporColonSlice as a Slice of string.
@@ -298,23 +302,20 @@ func (s MaporSpaceSlice) MarshalYAML() (tag string, value interface{}, err error
 
 // UnmarshalYAML implements the Unmarshaller interface.
 func (s *MaporSpaceSlice) UnmarshalYAML(tag string, value interface{}) error {
+	var err error
 	switch value := value.(type) {
 	case []interface{}:
-		parts, err := toStrings(value)
-		if err != nil {
-			return err
-		}
-		s.parts = parts
+		s.parts, err = sliceStringer(value)
 	case map[interface{}]interface{}:
-		parts, err := toSepMapParts(value, " ")
+		parts, err := mapStringer(value)
 		if err != nil {
 			return err
 		}
-		s.parts = parts
+		s.parts = mapToSlice(parts, " ")
 	default:
 		return fmt.Errorf("Failed to unmarshal MaporSpaceSlice: %#v", value)
 	}
-	return nil
+	return err
 }
 
 // Slice gets the parts of the MaporSpaceSlice as a Slice of string.

--- a/project/types_yaml_test.go
+++ b/project/types_yaml_test.go
@@ -89,12 +89,12 @@ func TestMarshalServiceConfig(t *testing.T) {
 }
 
 func TestStringorsliceStringersTypes(t *testing.T) {
-	str := `{foo: [false, 1024]}`
+	str := `{foo: ["bar", 1024]}`
 
 	s := StructStringorslice{}
-	yaml.Unmarshal([]byte(str), &s)
 
-	assert.Equal(t, []string{"false", "1024"}, s.Foo.parts)
+	yaml.Unmarshal([]byte(str), &s)
+	assert.Equal(t, []string{"bar", "1024"}, s.Foo.parts)
 }
 
 func TestStringorsliceYaml(t *testing.T) {
@@ -182,14 +182,15 @@ func contains(list []string, item string) bool {
 }
 
 func TestMaporsliceStringersTypes(t *testing.T) {
-	str := `{foo: {bar: false, far: 1024}}`
+	s1 := StructMaporslice{}
+	assert.Error(t, yaml.Unmarshal([]byte(`{foo: {bar: false}}`), &s1), "An error was expected. Unquoted bools aren't allowed")
 
-	s := StructMaporslice{}
-	yaml.Unmarshal([]byte(str), &s)
+	s2 := StructMaporslice{}
+	assert.NoError(t, yaml.Unmarshal([]byte(`{foo: {bar: "1234", far: 1024}}`), &s2))
 
-	assert.Equal(t, 2, len(s.Foo.parts))
-	assert.True(t, contains(s.Foo.parts, "bar=false"))
-	assert.True(t, contains(s.Foo.parts, "far=1024"))
+	assert.Equal(t, 2, len(s2.Foo.parts))
+	assert.True(t, contains(s2.Foo.parts, "bar=1234"))
+	assert.True(t, contains(s2.Foo.parts, "far=1024"))
 }
 
 func TestMaporsliceYaml(t *testing.T) {

--- a/project/types_yaml_test.go
+++ b/project/types_yaml_test.go
@@ -88,6 +88,15 @@ func TestMarshalServiceConfig(t *testing.T) {
 	assert.Equal(t, configPtr, configPtr2)
 }
 
+func TestStringorsliceStringersTypes(t *testing.T) {
+	str := `{foo: [false, 1024]}`
+
+	s := StructStringorslice{}
+	yaml.Unmarshal([]byte(str), &s)
+
+	assert.Equal(t, []string{"false", "1024"}, s.Foo.parts)
+}
+
 func TestStringorsliceYaml(t *testing.T) {
 	str := `{foo: [bar, baz]}`
 
@@ -170,6 +179,17 @@ func contains(list []string, item string) bool {
 		}
 	}
 	return false
+}
+
+func TestMaporsliceStringersTypes(t *testing.T) {
+	str := `{foo: {bar: false, far: 1024}}`
+
+	s := StructMaporslice{}
+	yaml.Unmarshal([]byte(str), &s)
+
+	assert.Equal(t, 2, len(s.Foo.parts))
+	assert.True(t, contains(s.Foo.parts, "bar=false"))
+	assert.True(t, contains(s.Foo.parts, "far=1024"))
 }
 
 func TestMaporsliceYaml(t *testing.T) {


### PR DESCRIPTION
Since #86 promotes any integers encoded as strings to integers, this change allows integers to convert back to strings in YAML.

This change also prevents panics as in #108. Fixes #113.

Signed-off-by: Lachlan Donald lachlan@ljd.cc