### PR TITLE
update maintainers file for parsing

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,58 @@
-Aanand Prasad <aanand@docker.com> (@aanand)
-Adrien Duermael <adrien@docker.com> (@aduermael)
-Daniel Nephin <dnephin@gmail.com> (@dnephin)
-Darren Shepherd <darren@rancher.com> (@ibuildthecloud)
-Gaetan de Villele <gaetan@docker.com> (@gdevillele)
-Vincent Demeester <vincent@sbr.pm> (@vdemeester)
+# Libcompose maintainers file
+#
+# This file describes who runs the docker/libcompose project and how.
+# This is a living document - if you see something out of date or missing, speak up!
+#
+# It is structured to be consumable by both humans and programs.
+# To extract its contents programmatically, use any TOML-compliant parser.
+#
+# This file is compiled into the MAINTAINERS file in docker/opensource.
+#
+[Org]
+	[Org."Core maintainers"]
+		people = [
+			"aanand",
+			"aduermael",
+			"dnephin",
+			"ibuildthecloud",
+			"gdevillele",
+			"vdemeester",
+		]
+
+[people]
+
+# A reference list of all people associated with the project.
+# All other sections should refer to people by their canonical key
+# in the people section.
+
+	# ADD YOURSELF HERE IN ALPHABETICAL ORDER
+
+	[people.aanand]
+	Name = "Aanand Prasad"
+	Email = "aanand@docker.com"
+	GitHub = "aanand"
+
+	[people.aduermael]
+	Name = "Adrien Duermael"
+	Email = "adrien@docker.com"
+	GitHub = "aduermael"
+
+	[people.dnephin]
+	Name = "Daniel Nephin"
+	Email = "dnephin@gmail.com"
+	GitHub = "dnephin"
+
+	[people.ibuildthecloud]
+	Name = "Darren Shepherd"
+	Email = "darren@rancher.com"
+	GitHub = "ibuildthecloud"
+
+	[people.gdevillele]
+	Name = "Gaetan de Villele"
+	Email = "gaetan@docker.com"
+	GitHub = "gdevillele"
+
+	[people.vdemeester]
+	Name = "Vincent Demeester"
+	Email = "vincent@sbr.pm"
+	GitHub = "vdemeester"


### PR DESCRIPTION
this updates the MAINTAINERS file to the new toml format,
so that it can be parsed and collected in the docker/opensource
repository.

see docker/opensource#35 and docker/docker#18321