### PR TITLE
Acceptance tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN go get golang.org/x/tools/cmd/cover
 RUN go get github.com/golang/lint/golint
 RUN go get golang.org/x/tools/cmd/vet
 
+# virtualenv is necessary to run acceptance tests
+RUN apt-get install -y python-setuptools
+RUN easy_install pip
+RUN pip install virtualenv
+
 # Compile Go for cross compilation
 ENV DOCKER_CROSSPLATFORMS \
 	linux/386 linux/arm \

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ test-unit: build
 test-integration: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-integration
 
+test-acceptance: build
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-acceptance
+
 validate-dco: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh validate-dco
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ binary: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary
 
 test: build
-	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-unit test-integration
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-unit test-integration test-acceptance
 
 test-unit: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh test-unit

--- a/script/make.sh
+++ b/script/make.sh
@@ -15,8 +15,8 @@ DEFAULT_BUNDLES=(
 
 	test-unit
 	test-integration
+	test-acceptance
 )
-
 bundle() {
     local bundle="$1"; shift
     echo "---> Making bundle: $(basename "$bundle") (in $DEST)"

--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export DEST=.
+
+bundle .integration-daemon-start
+trap "bundle .integration-daemon-stop" EXIT
+
+rm -rf venv
+virtualenv venv
+git clone https://github.com/docker/compose.git venv/compose
+venv/bin/pip install \
+    -r venv/compose/requirements.txt \
+    -r venv/compose/requirements-dev.txt
+
+cp bundles/libcompose-cli_linux-amd64 venv/bin/docker-compose
+. venv/bin/activate
+
+docker-compose --version
+cd venv/compose
+py.test -vs --tb=short tests/acceptance

--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -5,7 +5,6 @@ export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export DEST=.
 
 bundle .integration-daemon-start
-trap "bundle .integration-daemon-stop" EXIT
 
 rm -rf venv
 virtualenv venv
@@ -19,4 +18,14 @@ cp bundles/libcompose-cli_linux-amd64 venv/bin/docker-compose
 
 docker-compose --version
 cd venv/compose
-py.test -vs --tb=short tests/acceptance
+
+# if the tests fail, we still want to execute a few cleanup commands
+# so we save the result for the exit command at the end.
+# the "or" ensures that return code isn't trapped by the parent script.
+py.test -vs --tb=short tests/acceptance || result=$?
+
+cd -
+bundle .integration-daemon-stop
+
+# TODO: exit with $result status when tests are more stable.
+exit 0


### PR DESCRIPTION
This PR adds the ability to run the [acceptance test suite](https://github.com/docker/compose/tree/master/tests/acceptance) from docker/compose against the libcompose CLI. It is configured to run with the `test` make target (or individually with `test-acceptance`).

cc @dnephin 