### PR TITLE
Add cross-binary target…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ all: build
 binary: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary
 
+cross-binary: build
+	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh cross-binary
+
 test: build
 	$(DOCKER_RUN_LIBCOMPOSE) ./script/make.sh binary test-unit test-integration test-acceptance
 

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -87,7 +87,7 @@ func (s *RunSuite) TearDownTest(c *C) {
 }
 
 var _ = Suite(&RunSuite{
-	command: "../bundles/libcompose-cli_linux-amd64",
+	command: "../bundles/libcompose-cli",
 })
 
 func (s *RunSuite) CreateProjectFromText(c *C, input string) string {

--- a/script/binary
+++ b/script/binary
@@ -1,24 +1,11 @@
 #!/bin/bash
 set -e
 
-if [ -z "$1" ]; then
-    OS_PLATFORM_ARG=(-os="darwin linux windows")
-else
-    OS_PLATFORM_ARG=($1)
-fi
-
-if [ -z "$2" ]; then
-    OS_ARCH_ARG=(-arch="386 amd64 arm")
-else
-    OS_ARCH_ARG=($2)
-fi
-
-# Get rid of existing binaries
-rm -f libcompose-cli*
+# Get rid of existing binary
+rm -f libcompose-cli
 
 # Build binaries
-gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" \
-    -output="bundles/libcompose-cli_{{.OS}}-{{.Arch}}" \
-    -ldflags="-w -X github.com/docker/libcompose/version.GITCOMMIT=`git rev-parse --short HEAD`" \
-    ./cli/main
-
+go build \
+   -ldflags="-w -X github.com/docker/libcompose/version.GITCOMMIT=`git rev-parse --short HEAD`" \
+   -o bundles/libcompose-cli \
+   ./cli/main

--- a/script/cross-binary
+++ b/script/cross-binary
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+if [ -z "$1" ]; then
+    OS_PLATFORM_ARG=(-os="darwin linux windows")
+else
+    OS_PLATFORM_ARG=($1)
+fi
+
+if [ -z "$2" ]; then
+    OS_ARCH_ARG=(-arch="386 amd64 arm")
+else
+    OS_ARCH_ARG=($2)
+fi
+
+# Get rid of existing binaries
+rm -f libcompose-cli*
+
+# Build binaries
+gox "${OS_PLATFORM_ARG[@]}" "${OS_ARCH_ARG[@]}" \
+    -output="bundles/libcompose-cli_{{.OS}}-{{.Arch}}" \
+    -ldflags="-w -X github.com/docker/libcompose/version.GITCOMMIT=`git rev-parse --short HEAD`" \
+    ./cli/main
+

--- a/script/make.sh
+++ b/script/make.sh
@@ -16,6 +16,8 @@ DEFAULT_BUNDLES=(
 	test-unit
 	test-integration
 	test-acceptance
+
+	cross-binary
 )
 bundle() {
     local bundle="$1"; shift

--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -13,7 +13,7 @@ venv/bin/pip install \
     -r venv/compose/requirements.txt \
     -r venv/compose/requirements-dev.txt
 
-cp bundles/libcompose-cli_linux-amd64 venv/bin/docker-compose
+cp bundles/libcompose-cli venv/bin/docker-compose
 . venv/bin/activate
 
 docker-compose --version
@@ -28,4 +28,4 @@ cd -
 bundle .integration-daemon-stop
 
 # TODO: exit with $result status when tests are more stable.
-exit 0
+return 0


### PR DESCRIPTION
… at the end of the build and update binary target to only build the
current arch to be quicker. 🐲

The basic idea is to make the feedback a little bit quicker (without waiting for building all binaries possible).

```bash
# […]
---> Making bundle: test-acceptance (in .)
---> Making bundle: .integration-daemon-start (in .)
# […]
---> Making bundle: cross-binary (in .)
Number of parallel builds: 1

-->   windows/amd64: github.com/docker/libcompose/cli/main
-->       linux/386: github.com/docker/libcompose/cli/main
-->      darwin/386: github.com/docker/libcompose/cli/main
-->    darwin/amd64: github.com/docker/libcompose/cli/main
-->       linux/arm: github.com/docker/libcompose/cli/main
-->     linux/amd64: github.com/docker/libcompose/cli/main
-->     windows/386: github.com/docker/libcompose/cli/main

```

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>