### PR TITLE
Fixing rm command and API…

### DIFF
--- a/integration/rm_test.go
+++ b/integration/rm_test.go
@@ -15,15 +15,51 @@ func (s *RunSuite) TestDelete(c *C) {
 	c.Assert(cn, NotNil)
 	c.Assert(cn.State.Running, Equals, true)
 
-	s.FromText(c, p, "rm", "--force", `
-        hello:
-          image: busybox
-          stdin_open: true
-          tty: true
-        `)
+	s.FromText(c, p, "stop", SimpleTemplate)
+	s.FromText(c, p, "rm", "--force", SimpleTemplate)
 
 	cn = s.GetContainerByName(c, name)
 	c.Assert(cn, IsNil)
+}
+
+func (s *RunSuite) TestDeleteOnlyRemovesStopped(c *C) {
+	projectTemplate := `
+hello:
+  image: busybox
+  stdin_open: true
+  tty: true
+bye:
+  image: busybox
+  stdin_open: true
+  tty: true
+`
+
+	p := s.ProjectFromText(c, "up", projectTemplate)
+
+	helloName := fmt.Sprintf("%s_%s_1", p, "hello")
+	byeName := fmt.Sprintf("%s_%s_1", p, "bye")
+
+	helloContainer := s.GetContainerByName(c, helloName)
+	c.Assert(helloContainer, NotNil)
+	c.Assert(helloContainer.State.Running, Equals, true)
+
+	byeContainer := s.GetContainerByName(c, byeName)
+	c.Assert(byeContainer, NotNil)
+	c.Assert(byeContainer.State.Running, Equals, true)
+
+	s.FromText(c, p, "stop", "bye", projectTemplate)
+
+	byeContainer = s.GetContainerByName(c, byeName)
+	c.Assert(byeContainer, NotNil)
+	c.Assert(byeContainer.State.Running, Equals, false)
+
+	s.FromText(c, p, "rm", "--force", projectTemplate)
+
+	byeContainer = s.GetContainerByName(c, byeName)
+	c.Assert(byeContainer, IsNil)
+
+	helloContainer = s.GetContainerByName(c, helloName)
+	c.Assert(helloContainer, NotNil)
 }
 
 func (s *RunSuite) TestDeleteWithVol(c *C) {
@@ -35,12 +71,8 @@ func (s *RunSuite) TestDeleteWithVol(c *C) {
 	c.Assert(cn, NotNil)
 	c.Assert(cn.State.Running, Equals, true)
 
-	s.FromText(c, p, "rm", "--force", "-v", `
-	hello:
-	  image: busybox
-	  stdin_open: true
-	  tty: true
-	`)
+	s.FromText(c, p, "stop", SimpleTemplate)
+	s.FromText(c, p, "rm", "--force", "-v", SimpleTemplate)
 
 	cn = s.GetContainerByName(c, name)
 	c.Assert(cn, IsNil)

--- a/project/types.go
+++ b/project/types.go
@@ -264,6 +264,7 @@ type Container interface {
 	ID() (string, error)
 	Name() string
 	Port(port string) (string, error)
+	IsRunning() (bool, error)
 }
 
 // ServiceFactory is an interface factory to create Service object for the specified


### PR DESCRIPTION
… to behave more like docker-compose. Fixes #129 🐝.

```bash
$ libcompose-cli ps
# […]
Name           Command                         State         Ports
compose_db_1   /docker-entrypoint.sh postgres  Up 8 seconds  5432/tcp
compose_web_1  nginx -g 'daemon off;'          Up 8 seconds  443/tcp, 80/tcp
$ libcompose-cli rm
# […]                      
No stopped containers
$ libcompose-cli stop db
# […]
$ libcompose-cli rm
# […]
Going to remove compose_web_1, compose_db_1
Are you sure? [yN]
```

As `docker-compose` it will try to remove only containers that are stopped. And the `--force` flag is used to skip the confirmation only 🐞.

```bash
$ libcompose-cli stop db
# […]
$ libcompose-cli rm --force
# […]                  
Going to remove compose_db_1
$ libcompose-cli ps
# […]
Name           Command                 State          Ports
compose_web_1  nginx -g 'daemon off;'  Up 54 seconds  443/tcp, 80/tcp
```

It's not really done yet :
- [X] <del>Probably should add some log/information of each container removed (like `docker-compose` does).</del> This should be handled widely on the cli I think.
- [X] Should add more integration tests (making sure we don't remove non-stopped containers, etc…).

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>