### PR TITLE
Implement run command

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -161,6 +161,27 @@ func ProjectPull(p *project.Project, c *cli.Context) {
 	}
 }
 
+// ProjectRun runs a given command within a service's container.
+func ProjectRun(p *project.Project, c *cli.Context) {
+	if len(c.Args()) == 1 {
+		logrus.Fatal("No service specified")
+	}
+
+	serviceName := c.Args()[0]
+	commandParts := c.Args()[1:]
+
+	if _, ok := p.Configs[serviceName]; !ok {
+		logrus.Fatalf("%s is not defined in the template", serviceName)
+	}
+
+	exitCode, err := p.Run(serviceName, commandParts)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	os.Exit(exitCode)
+}
+
 // ProjectDelete delete services.
 func ProjectDelete(p *project.Project, c *cli.Context) {
 	if !c.Bool("force") && len(c.Args()) == 0 {

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -178,6 +178,16 @@ func ScaleCommand(factory app.ProjectFactory) cli.Command {
 	}
 }
 
+// RunCommand defines the libcompose run subcommand.
+func RunCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "run",
+		Usage:  "Run a one-off command",
+		Action: app.WithProject(factory, app.ProjectRun),
+		Flags:  []cli.Flag{},
+	}
+}
+
 // RmCommand defines the libcompose rm subcommand.
 func RmCommand(factory app.ProjectFactory) cli.Command {
 	return cli.Command{

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -30,6 +30,7 @@ func main() {
 		command.RestartCommand(factory),
 		command.StopCommand(factory),
 		command.ScaleCommand(factory),
+		command.RunCommand(factory),
 		command.RmCommand(factory),
 		command.PullCommand(factory),
 		command.KillCommand(factory),

--- a/docker/convert.go
+++ b/docker/convert.go
@@ -129,6 +129,10 @@ func Convert(c *project.ServiceConfig, ctx *Context) (*dockerclient.Config, *doc
 		WorkingDir:   c.WorkingDir,
 		VolumeDriver: c.VolumeDriver,
 		Volumes:      volumes(c, ctx),
+		AttachStdin:  c.StdinOpen,
+		AttachStdout: c.Tty,
+		AttachStderr: c.Tty,
+		StdinOnce:    c.StdinOpen,
 	}
 	hostConfig := &dockerclient.HostConfig{
 		VolumesFrom: utils.CopySlice(c.VolumesFrom),

--- a/docker/pty/dockerpty.go
+++ b/docker/pty/dockerpty.go
@@ -1,0 +1,128 @@
+package pty
+
+import (
+	"errors"
+	"io"
+	"os"
+	gosignal "os/signal"
+	"time"
+
+	"github.com/docker/docker/pkg/signal"
+	"github.com/docker/docker/pkg/term"
+	"github.com/fsouza/go-dockerclient"
+)
+
+// Start starts and attach a pty (Pseudo-TTY) to the specified container.
+// It will take over the current process' TTY until the container's PTY is closed.
+func Start(client *docker.Client, container *docker.Container, hostConfig *docker.HostConfig) (err error) {
+	var (
+		terminalFd uintptr
+		oldState   *term.State
+		out        io.Writer = os.Stdout
+	)
+
+	if file, ok := out.(*os.File); ok {
+		terminalFd = file.Fd()
+	} else {
+		return errors.New("Not a terminal!")
+	}
+
+	// Set up the pseudo terminal
+	oldState, err = term.SetRawTerminal(terminalFd)
+	if err != nil {
+		return
+	}
+
+	// Clean up after the container has exited
+	defer term.RestoreTerminal(terminalFd, oldState)
+
+	// Attach to the container on a separate thread
+	attachChan := make(chan error)
+	go attachToContainer(client, container.ID, attachChan)
+
+	// Start it
+	err = client.StartContainer(container.ID, hostConfig)
+	if err != nil {
+		return
+	}
+
+	// Make sure terminal resizes are passed on to the container
+	monitorTty(client, container.ID, terminalFd)
+
+	return <-attachChan
+}
+
+func attachToContainer(client *docker.Client, containerID string, errorChan chan error) {
+	r, w := io.Pipe()
+	go io.Copy(w, os.Stdin)
+	err := client.AttachToContainer(docker.AttachToContainerOptions{
+		Container:    containerID,
+		InputStream:  r,
+		OutputStream: os.Stdout,
+		ErrorStream:  os.Stderr,
+		Stdin:        true,
+		Stdout:       true,
+		Stderr:       true,
+		Stream:       true,
+		RawTerminal:  true,
+	})
+	errorChan <- err
+}
+
+// From https://github.com/docker/docker/blob/0d70706b4b6bf9d5a5daf46dd147ca71270d0ab7/api/client/utils.go#L222-L233
+func monitorTty(client *docker.Client, containerID string, terminalFd uintptr) {
+	resizeTty(client, containerID, terminalFd)
+
+	sigchan := make(chan os.Signal, 1)
+	gosignal.Notify(sigchan, signal.SIGWINCH)
+	go func() {
+		for range sigchan {
+			resizeTty(client, containerID, terminalFd)
+		}
+	}()
+}
+
+// From https://github.com/docker/docker/blob/0d70706b4b6bf9d5a5daf46dd147ca71270d0ab7/api/client/utils.go#L222-L233
+func monitorExecTty(client *docker.Client, execID string, terminalFd uintptr) {
+	// HACK: For some weird reason on Docker 1.4.1 this resize is being triggered
+	//       before the Exec instance is running resulting in an error on the
+	//       Docker server. So we wait a little bit before triggering this first
+	//       resize
+	time.Sleep(50 * time.Millisecond)
+	resizeExecTty(client, execID, terminalFd)
+
+	sigchan := make(chan os.Signal, 1)
+	gosignal.Notify(sigchan, signal.SIGWINCH)
+	go func() {
+		for range sigchan {
+			resizeExecTty(client, execID, terminalFd)
+		}
+	}()
+}
+
+func resizeTty(client *docker.Client, containerID string, terminalFd uintptr) error {
+	height, width := getTtySize(terminalFd)
+	if height == 0 && width == 0 {
+		return nil
+	}
+	return client.ResizeContainerTTY(containerID, height, width)
+}
+
+func resizeExecTty(client *docker.Client, containerID string, terminalFd uintptr) error {
+	height, width := getTtySize(terminalFd)
+	if height == 0 && width == 0 {
+		return nil
+	}
+	return client.ResizeExecTTY(containerID, height, width)
+}
+
+// From https://github.com/docker/docker/blob/0d70706b4b6bf9d5a5daf46dd147ca71270d0ab7/api/client/utils.go#L235-L247
+func getTtySize(terminalFd uintptr) (int, int) {
+	ws, err := term.GetWinsize(terminalFd)
+	if err != nil {
+		if ws == nil {
+			return 0, 0
+		}
+	}
+	return int(ws.Height), int(ws.Width)
+}

--- a/integration/assets/run/docker-compose.yml
+++ b/integration/assets/run/docker-compose.yml
@@ -1,0 +1,2 @@
+hello:
+  image: busybox

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -117,11 +117,7 @@ func (s *RunSuite) FromText(c *C, projectName, command string, argsAndInput ...s
 	}
 
 	err := cmd.Run()
-	if err != nil {
-		logrus.Errorf("Failed to run %s %v: %v\n with input:\n%s", s.command, err, args, input)
-	}
-
-	c.Assert(err, IsNil)
+	c.Assert(err, IsNil, Commentf("Failed to run %s %v: %v\n with input:\n%s", s.command, err, args, input))
 
 	return projectName
 }

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -1,0 +1,24 @@
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+
+	. "gopkg.in/check.v1"
+)
+
+// FIXME find out why it fails with "inappropriate ioctl for device"
+func (s *RunSuite) TestRun(c *C) {
+	p := s.RandomProject()
+	cmd := exec.Command(s.command, "-f", "./assets/run/docker-compose.yml", "-p", p, "run", "hello", "ls")
+
+	output, err := cmd.CombinedOutput()
+	c.Assert(err, IsNil, Commentf("%s", output))
+
+	name := fmt.Sprintf("%s_%s_run_1", p, "hello")
+	cn := s.GetContainerByName(c, name)
+	c.Assert(cn, NotNil)
+
+	c.Assert(cn.State.Running, Equals, false)
+	c.Assert(string(output), Equals, "test")
+}

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -27,6 +27,10 @@ func (t *TestService) Name() string {
 	return t.name
 }
 
+func (t *TestService) Run(commandPats []string) (int, error) {
+	return 0, nil
+}
+
 func (t *TestService) Create() error {
 	key := t.name + ".create"
 	t.factory.Counts[key] = t.factory.Counts[key] + 1

--- a/project/types.go
+++ b/project/types.go
@@ -36,6 +36,8 @@ const (
 	EventServicePause        = EventType(iota)
 	EventServiceUnpauseStart = EventType(iota)
 	EventServiceUnpause      = EventType(iota)
+	EventServiceRunStart     = EventType(iota)
+	EventServiceRun          = EventType(iota)
 
 	EventProjectDownStart     = EventType(iota)
 	EventProjectDownDone      = EventType(iota)
@@ -109,6 +111,10 @@ func (e EventType) String() string {
 		m = "Building"
 	case EventServiceBuild:
 		m = "Built"
+	case EventServiceRunStart:
+		m = "Executing"
+	case EventServiceRun:
+		m = "Executed"
 
 	case EventProjectDownStart:
 		m = "Stopping project"
@@ -250,6 +256,7 @@ type Service interface {
 	Restart() error
 	Log() error
 	Pull() error
+	Run(commandParts []string) (int, error)
 	Kill() error
 	Config() *ServiceConfig
 	DependentServices() []ServiceRelationship


### PR DESCRIPTION
Carrying #45, add a basic `run` command (with no flags for now). 🐨

```bash
# libcompose run <service> <command>
$ ~docker/libcompose/libcompose-cli run web ls
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
$ ~docker/libcompose/libcompose-cli run web /bin/sh
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
# ls
bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
# echo foo > /bar    
# cat bar
foo
```

This is the first step to have a run command that is acting the same as docker-compose. I imported [go-dockerpty](https://github.com/fgrehm/go-dockerpty) in a non academic way (and clean it up) as it was not compiling under windows and redefining stuff that are already available on `docker/docker/pkg/…`. I'll probably make a PR to the repos and vendor it if it makes it and we think it's better to do.

- [ ] Need to fix/add some integration tests.

🐸
Signed-off-by: Frederic Branczyk <fbranczyk@gmail.com>