### PR TITLE
Add support for missing composefile keys

### DIFF
--- a/docker/convert.go
+++ b/docker/convert.go
@@ -129,19 +129,34 @@ func Convert(c *project.ServiceConfig, ctx *Context) (*dockerclient.Config, *doc
 		WorkingDir:   c.WorkingDir,
 		VolumeDriver: c.VolumeDriver,
 		Volumes:      volumes(c, ctx),
+		MacAddress:   c.MacAddress,
 	}
+
+	ulimits := []dockerclient.ULimit{}
+	if c.Ulimits.Elements != nil {
+		for _, ulimit := range c.Ulimits.Elements {
+			ulimits = append(ulimits, dockerclient.ULimit{
+				Name: ulimit.Name,
+				Soft: ulimit.Soft,
+				Hard: ulimit.Hard,
+			})
+		}
+	}
+
 	hostConfig := &dockerclient.HostConfig{
-		VolumesFrom: utils.CopySlice(c.VolumesFrom),
-		CapAdd:      utils.CopySlice(c.CapAdd),
-		CapDrop:     utils.CopySlice(c.CapDrop),
-		CPUShares:   c.CPUShares,
-		CPUSetCPUs:  c.CPUSet,
-		ExtraHosts:  utils.CopySlice(c.ExtraHosts),
-		Privileged:  c.Privileged,
-		Binds:       Filter(c.Volumes, isBind),
-		Devices:     deviceMappings,
-		DNS:         utils.CopySlice(c.DNS.Slice()),
-		DNSSearch:   utils.CopySlice(c.DNSSearch.Slice()),
+		VolumesFrom:  utils.CopySlice(c.VolumesFrom),
+		CapAdd:       utils.CopySlice(c.CapAdd),
+		CapDrop:      utils.CopySlice(c.CapDrop),
+		CgroupParent: c.CgroupParent,
+		CPUQuota:     c.CPUQuota,
+		CPUShares:    c.CPUShares,
+		CPUSetCPUs:   c.CPUSet,
+		ExtraHosts:   utils.CopySlice(c.ExtraHosts),
+		Privileged:   c.Privileged,
+		Binds:        Filter(c.Volumes, isBind),
+		Devices:      deviceMappings,
+		DNS:          utils.CopySlice(c.DNS.Slice()),
+		DNSSearch:    utils.CopySlice(c.DNSSearch.Slice()),
 		LogConfig: dockerclient.LogConfig{
 			Type:   c.LogDriver,
 			Config: utils.CopyMap(c.LogOpt),
@@ -156,6 +171,7 @@ func Convert(c *project.ServiceConfig, ctx *Context) (*dockerclient.Config, *doc
 		PortBindings:   portBindings,
 		RestartPolicy:  *restartPolicy,
 		SecurityOpt:    utils.CopySlice(c.SecurityOpt),
+		Ulimits:        ulimits,
 	}
 
 	return config, hostConfig, nil

--- a/project/types.go
+++ b/project/types.go
@@ -171,6 +171,8 @@ type ServiceConfig struct {
 	Build         string            `yaml:"build,omitempty"`
 	CapAdd        []string          `yaml:"cap_add,omitempty"`
 	CapDrop       []string          `yaml:"cap_drop,omitempty"`
+	CgroupParent  string            `yaml:"cgroup_parent,omitempty"`
+	CPUQuota      int64             `yaml:"cpu_quota,omitempty"`
 	CPUSet        string            `yaml:"cpuset,omitempty"`
 	CPUShares     int64             `yaml:"cpu_shares,omitempty"`
 	Command       Command           `yaml:"command,flow,omitempty"`
@@ -188,6 +190,7 @@ type ServiceConfig struct {
 	Labels        SliceorMap        `yaml:"labels,omitempty"`
 	Links         MaporColonSlice   `yaml:"links,omitempty"`
 	LogDriver     string            `yaml:"log_driver,omitempty"`
+	MacAddress    string            `yaml:"mac_address,omitempty"`
 	MemLimit      int64             `yaml:"mem_limit,omitempty"`
 	MemSwapLimit  int64             `yaml:"memswap_limit,omitempty"`
 	Name          string            `yaml:"name,omitempty"`
@@ -211,6 +214,7 @@ type ServiceConfig struct {
 	ExternalLinks []string          `yaml:"external_links,omitempty"`
 	LogOpt        map[string]string `yaml:"log_opt,omitempty"`
 	ExtraHosts    []string          `yaml:"extra_hosts,omitempty"`
+	Ulimits       Ulimits           `yaml:"ulimits,omitemty"`
 }
 
 // EnvironmentLookup defines methods to provides environment variable loading.


### PR DESCRIPTION
This adds support for the following keys in `docker-compose.yml` files :

- [cpu_quota](https://github.com/docker/compose/blob/master/docs/compose-file.md#cpu_shares-cpu_quota-cpuset-domainname-entrypoint-hostname-ipc-mac_address-mem_limit-memswap_limit-privileged-read_only-restart-stdin_open-tty-user-working_dir)
- [mac_address](https://github.com/docker/compose/blob/master/docs/compose-file.md#cpu_shares-cpu_quota-cpuset-domainname-entrypoint-hostname-ipc-mac_address-mem_limit-memswap_limit-privileged-read_only-restart-stdin_open-tty-user-working_dir)
- [cgroup_parent](https://github.com/docker/compose/blob/master/docs/compose-file.md#cgroup_parent)
- [ulimits](https://github.com/docker/compose/blob/master/docs/compose-file.md#ulimits)

I'm not fan of the way I did the `ulimits` (it's a little bit too hacky) but ran a little bit out of ideas… 🐹 I'll look back at it with clean thoughts :wink:.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>