### PR TITLE
Add flags for create command

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -12,6 +12,16 @@ func CreateCommand(factory app.ProjectFactory) cli.Command {
 		Name:   "create",
 		Usage:  "Create all services but do not start",
 		Action: app.WithProject(factory, app.ProjectCreate),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "no-recreate",
+				Usage: "If containers already exist, don't recreate them. Incompatible with --force-recreate.",
+			},
+			cli.BoolFlag{
+				Name:  "force-recreate",
+				Usage: "Recreate containers even if their configuration and image haven't changed. Incompatible with --no-recreate.",
+			},
+		},
 	}
 }
 
@@ -239,7 +249,7 @@ func Populate(context *project.Context, c *cli.Context) {
 
 	if c.Command.Name == "logs" {
 		context.Log = true
-	} else if c.Command.Name == "up" {
+	} else if c.Command.Name == "up" || c.Command.Name == "create" {
 		context.Log = !c.Bool("d")
 		context.NoRecreate = c.Bool("no-recreate")
 		context.ForceRecreate = c.Bool("force-recreate")

--- a/docker/service.go
+++ b/docker/service.go
@@ -41,9 +41,20 @@ func (s *Service) DependentServices() []project.ServiceRelationship {
 
 // Create implements Service.Create.
 func (s *Service) Create() error {
+	containers, err := s.collectContainers()
+	if err != nil {
+		return err
+	}
+
 	imageName, err := s.build()
 	if err != nil {
 		return err
+	}
+
+	if len(containers) != 0 {
+		return s.eachContainer(func(c *Container) error {
+			return s.recreateIfNeeded(imageName, c)
+		})
 	}
 
 	_, err = s.createOne(imageName)


### PR DESCRIPTION
This adds the following flags (and support) for the `create` command :

- `force-recreate`
- `no-recreate`

The `--no-build` flag is shared with the `up` command and will be worked on in another PR 🐙.

- [ ] Needs integration tests

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>