### PR TITLE
Add support for --no-build

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -23,6 +23,10 @@ func CreateCommand(factory app.ProjectFactory) cli.Command {
 				Name:  "force-recreate",
 				Usage: "Recreate containers even if their configuration and image haven't changed. Incompatible with --no-recreate.",
 			},
+			cli.BoolFlag{
+				Name:  "no-build",
+				Usage: "Don't build an image, even if it's missing.",
+			},
 		},
 	}
 }
@@ -88,6 +92,10 @@ func UpCommand(factory app.ProjectFactory) cli.Command {
 			cli.BoolFlag{
 				Name:  "d",
 				Usage: "Do not block and log",
+			},
+			cli.BoolFlag{
+				Name:  "no-build",
+				Usage: "Don't build an image, even if it's missing.",
 			},
 			cli.BoolFlag{
 				Name:  "no-recreate",
@@ -283,6 +291,7 @@ func Populate(context *project.Context, c *cli.Context) {
 		context.Log = !c.Bool("d")
 		context.NoRecreate = c.Bool("no-recreate")
 		context.ForceRecreate = c.Bool("force-recreate")
+		context.NoBuild = c.Bool("no-build")
 	} else if c.Command.Name == "stop" || c.Command.Name == "restart" || c.Command.Name == "scale" {
 		context.Timeout = uint(c.Int("timeout"))
 	} else if c.Command.Name == "kill" {

--- a/integration/assets/simple-build/docker-compose.yml
+++ b/integration/assets/simple-build/docker-compose.yml
@@ -1,0 +1,2 @@
+one:
+    build: one

--- a/integration/assets/simple-build/one/Dockerfile
+++ b/integration/assets/simple-build/one/Dockerfile
@@ -1,0 +1,2 @@
+FROM busybox
+CMD ["echo", "one"]

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -2,7 +2,6 @@ package integration
 
 import (
 	"fmt"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -12,9 +11,6 @@ import (
 func (s *RunSuite) TestBuild(c *C) {
 	p := s.RandomProject()
 	cmd := exec.Command(s.command, "-f", "./assets/build/docker-compose.yml", "-p", p, "build")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
 	err := cmd.Run()
 
 	oneImageName := fmt.Sprintf("%s_one", p)
@@ -67,9 +63,6 @@ func (s *RunSuite) TestBuildWithNoCache2(c *C) {
 func (s *RunSuite) TestBuildWithNoCache3(c *C) {
 	p := s.RandomProject()
 	cmd := exec.Command(s.command, "-f", "./assets/build/docker-compose.yml", "-p", p, "build", "--no-cache")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Stdin = os.Stdin
 	err := cmd.Run()
 
 	oneImageName := fmt.Sprintf("%s_one", p)

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -296,4 +297,25 @@ func (s *RunSuite) TestRelativeVolume(c *C) {
 	c.Assert(cn, NotNil)
 	c.Assert(len(cn.Mounts), DeepEquals, 1)
 	c.Assert(cn.Mounts[0].Source, DeepEquals, absPath)
+}
+
+func (s *RunSuite) TestUpNoBuildFailIfImageNotPresent(c *C) {
+	p := s.RandomProject()
+	cmd := exec.Command(s.command, "-f", "./assets/build/docker-compose.yml", "-p", p, "up", "--no-build")
+	err := cmd.Run()
+
+	c.Assert(err, NotNil)
+}
+
+func (s *RunSuite) TestUpNoBuildShouldWorkIfImageIsPresent(c *C) {
+	p := s.RandomProject()
+	cmd := exec.Command(s.command, "-f", "./assets/simple-build/docker-compose.yml", "-p", p, "build")
+	err := cmd.Run()
+
+	c.Assert(err, IsNil)
+
+	cmd = exec.Command(s.command, "-f", "./assets/simple-build/docker-compose.yml", "-p", p, "up", "-d", "--no-build")
+	err = cmd.Run()
+
+	c.Assert(err, IsNil)
 }

--- a/project/context.go
+++ b/project/context.go
@@ -24,6 +24,7 @@ type Context struct {
 	ForceRecreate       bool
 	NoRecreate          bool
 	NoCache             bool
+	NoBuild             bool
 	Signal              int
 	ComposeFiles        []string
 	ComposeBytes        [][]byte


### PR DESCRIPTION
This adds support for the `--no-build` flag for `create` and `up` commands.

Also contains a small refactoring on how libcompose decides to build or
not the image (it aligns with how docker-compose does). 🐠

- [X] What to do about the `FIXME`s
- [X] Add some integration tests

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>