### PR TITLE
Carry #8 docker: support relative paths for volumes

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -302,7 +302,7 @@ func volumeBinds(volumes map[string]struct{}, container *dockerclient.Container)
 }
 
 func (c *Container) createContainer(imageName, oldContainer string) (*dockerclient.APIContainers, error) {
-	createOpts, err := ConvertToAPI(c.service.serviceConfig, c.name)
+	createOpts, err := ConvertToAPI(c.service, c.name)
 	if err != nil {
 		return nil, err
 	}

--- a/docker/convert_test.go
+++ b/docker/convert_test.go
@@ -1,10 +1,13 @@
 package docker
 
 import (
+	"path/filepath"
+	"testing"
+
+	"github.com/docker/libcompose/lookup"
 	"github.com/docker/libcompose/project"
 	shlex "github.com/flynn/go-shlex"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestParseCommand(t *testing.T) {
@@ -15,18 +18,33 @@ func TestParseCommand(t *testing.T) {
 }
 
 func TestParseBindsAndVolumes(t *testing.T) {
+	ctx := &Context{}
+	ctx.ComposeFile = "foo/docker-compose.yml"
+	ctx.ResourceLookup = &lookup.FileConfigLookup{}
+
+	abs, err := filepath.Abs(".")
+	assert.Nil(t, err)
+	cfg, hostCfg, err := Convert(&project.ServiceConfig{
+		Volumes: []string{"/foo", "/home:/home", "/bar/baz", ".:/home", "/usr/lib:/usr/lib:ro"},
+	}, ctx)
+	assert.Nil(t, err)
+	assert.Equal(t, map[string]struct{}{"/foo": {}, "/bar/baz": {}}, cfg.Volumes)
+	assert.Equal(t, []string{"/home:/home", abs + "/foo:/home", "/usr/lib:/usr/lib:ro"}, hostCfg.Binds)
+}
+
+func TestParseLabels(t *testing.T) {
+	ctx := &Context{}
+	ctx.ComposeFile = "foo/docker-compose.yml"
+	ctx.ResourceLookup = &lookup.FileConfigLookup{}
 	bashCmd := "bash"
 	fooLabel := "foo.label"
 	fooLabelValue := "service.config.value"
 	sc := &project.ServiceConfig{
 		Entrypoint: project.NewCommand(bashCmd),
-		Volumes:    []string{"/foo", "/home:/home", "/bar/baz", "/usr/lib:/usr/lib:ro"},
 		Labels:     project.NewSliceorMap(map[string]string{fooLabel: "service.config.value"}),
 	}
-	cfg, hostCfg, err := Convert(sc)
+	cfg, _, err := Convert(sc, ctx)
 	assert.Nil(t, err)
-	assert.Equal(t, map[string]struct{}{"/foo": {}, "/bar/baz": {}}, cfg.Volumes)
-	assert.Equal(t, []string{"/home:/home", "/usr/lib:/usr/lib:ro"}, hostCfg.Binds)
 
 	cfg.Labels[fooLabel] = "FUN"
 	cfg.Entrypoint[0] = "less"

--- a/docker/project.go
+++ b/docker/project.go
@@ -9,8 +9,8 @@ import (
 
 // NewProject creates a Project with the specified context.
 func NewProject(context *Context) (*project.Project, error) {
-	if context.ConfigLookup == nil {
-		context.ConfigLookup = &lookup.FileConfigLookup{}
+	if context.ResourceLookup == nil {
+		context.ResourceLookup = &lookup.FileConfigLookup{}
 	}
 
 	if context.EnvironmentLookup == nil {

--- a/integration/assets/volumes/relative-volumes.yml
+++ b/integration/assets/volumes/relative-volumes.yml
@@ -1,0 +1,4 @@
+server:
+    image: busybox
+    volumes:
+    - .:/path

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/libcompose/utils"
@@ -277,4 +278,22 @@ func (s *RunSuite) TestLink(c *C) {
 		fmt.Sprintf("/%s:/%s/%s", serverName, clientName, "server"),
 		fmt.Sprintf("/%s:/%s/%s", serverName, clientName, serverName),
 	}))
+}
+
+func (s *RunSuite) TestRelativeVolume(c *C) {
+	p := s.ProjectFromText(c, "up", `
+	server:
+	  image: busybox
+	  volumes:
+	    - .:/path
+	`)
+
+	absPath, err := filepath.Abs(".")
+	c.Assert(err, IsNil)
+	serverName := fmt.Sprintf("%s_%s_1", p, "server")
+	cn := s.GetContainerByName(c, serverName)
+
+	c.Assert(cn, NotNil)
+	c.Assert(len(cn.Mounts), DeepEquals, 1)
+	c.Assert(cn.Mounts[0].Source, DeepEquals, absPath)
 }

--- a/lookup/file.go
+++ b/lookup/file.go
@@ -2,13 +2,44 @@ package lookup
 
 import (
 	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
 )
 
-// FileConfigLookup is a "bare" structure that implements the project.ConfigLookup interface
+// relativePath returns the proper relative path for the given file path. If
+// the relativeTo string equals "-", then it means that it's from the stdin,
+// and the returned path will be the current working directory. Otherwise, if
+// file is really an absolute path, then it will be returned without any
+// changes. Otherwise, the returned path will be a combination of relativeTo
+// and file.
+func relativePath(file, relativeTo string) string {
+	// stdin: return the current working directory if possible.
+	if relativeTo == "-" {
+		if cwd, err := os.Getwd(); err == nil {
+			return cwd
+		}
+	}
+
+	// If the given file is already an absolute path, just return it.
+	// Otherwise, the returned path will be relative to the given relativeTo
+	// path.
+	if filepath.IsAbs(file) {
+		return file
+	}
+
+	abs, err := filepath.Abs(filepath.Join(path.Dir(relativeTo), file))
+	if err != nil {
+		logrus.Errorf("Failed to get absolute directory: %s", err)
+		return file
+	}
+	return abs
+}
+
+// FileConfigLookup is a "bare" structure that implements the project.ResourceLookup interface
 type FileConfigLookup struct {
 }
 
@@ -17,14 +48,27 @@ type FileConfigLookup struct {
 // If file starts with a slash ('/'), it tries to load it, otherwise it will build a
 // filename using the folder part of relativeTo joined with file.
 func (f *FileConfigLookup) Lookup(file, relativeTo string) ([]byte, string, error) {
-	if strings.HasPrefix(file, "/") {
-		logrus.Debugf("Reading file %s", file)
-		bytes, err := ioutil.ReadFile(file)
-		return bytes, file, err
+	file = relativePath(file, relativeTo)
+	logrus.Debugf("Reading file %s", file)
+	bytes, err := ioutil.ReadFile(file)
+	return bytes, file, err
+}
+
+// ResolvePath returns the path to be used for the given path volume. This
+// function already takes care of relative paths.
+func (f *FileConfigLookup) ResolvePath(path, inFile string) string {
+	vs := strings.SplitN(path, ":", 2)
+	if len(vs) != 2 || filepath.IsAbs(vs[0]) {
+		return path
 	}
 
-	fileName := path.Join(path.Dir(relativeTo), file)
-	logrus.Debugf("Reading file %s relative to %s", fileName, relativeTo)
-	bytes, err := ioutil.ReadFile(fileName)
-	return bytes, fileName, err
+	if !strings.HasPrefix(vs[0], "./") && !strings.HasPrefix(vs[0], "~/") &&
+		!strings.HasPrefix(vs[0], "/") {
+
+		logrus.Warnf("The mapping \"%s\" is ambiguous. In a future version of Docker, it will "+
+			"designate a \"named\" volume (see https://github.com/docker/docker/pull/14242). "+
+			"To prevent unexpected behaviour, change it to \"./%s\".", vs[0], vs[0])
+	}
+	vs[0] = relativePath(vs[0], inFile)
+	return strings.Join(vs, ":")
 }

--- a/lookup/file_test.go
+++ b/lookup/file_test.go
@@ -1,6 +1,7 @@
 package lookup
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
 	"testing"
@@ -12,8 +13,12 @@ type input struct {
 }
 
 func TestLookupError(t *testing.T) {
+	abs, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("Failed to get absolute directory: %s", err)
+	}
 	invalids := map[input]string{
-		input{"", ""}:                             "read .: is a directory",
+		input{"", ""}:                             fmt.Sprintf("read %s: is a directory", abs),
 		input{"", "/tmp/"}:                        "read /tmp: is a directory",
 		input{"file", "/does/not/exists/"}:        "open /does/not/exists/file: no such file or directory",
 		input{"file", "/does/not/something"}:      "open /does/not/file: no such file or directory",

--- a/project/context.go
+++ b/project/context.go
@@ -31,7 +31,7 @@ type Context struct {
 	isOpen              bool
 	ServiceFactory      ServiceFactory
 	EnvironmentLookup   EnvironmentLookup
-	ConfigLookup        ConfigLookup
+	ResourceLookup      ResourceLookup
 	LoggerFactory       logger.Factory
 	IgnoreMissingConfig bool
 	Project             *Project

--- a/project/merge_test.go
+++ b/project/merge_test.go
@@ -9,9 +9,13 @@ func (n *NullLookup) Lookup(file, relativeTo string) ([]byte, string, error) {
 	return nil, "", nil
 }
 
+func (n *NullLookup) ResolvePath(path, inFile string) string {
+	return ""
+}
+
 func TestExtendsInheritImage(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -44,7 +48,7 @@ child:
 
 func TestExtendsInheritBuild(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -77,7 +81,7 @@ child:
 
 func TestExtendBuildOverImage(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -111,7 +115,7 @@ child:
 
 func TestExtendImageOverBuild(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -149,7 +153,7 @@ child:
 
 func TestRestartNo(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`
@@ -171,7 +175,7 @@ test:
 
 func TestRestartAlways(t *testing.T) {
 	p := NewProject(&Context{
-		ConfigLookup: &NullLookup{},
+		ResourceLookup: &NullLookup{},
 	})
 
 	config, err := mergeProject(p, []byte(`

--- a/project/types.go
+++ b/project/types.go
@@ -218,9 +218,10 @@ type EnvironmentLookup interface {
 	Lookup(key, serviceName string, config *ServiceConfig) []string
 }
 
-// ConfigLookup defines methods to provides file loading.
-type ConfigLookup interface {
+// ResourceLookup defines methods to provides file loading.
+type ResourceLookup interface {
 	Lookup(file, relativeTo string) ([]byte, string, error)
+	ResolvePath(path, inFile string) string
 }
 
 // Project holds libcompose project information.


### PR DESCRIPTION
Carrying #8: docker: support relative paths for volumes. Rebased against master and fixed the conflicts. 🐸

Thanks @mssola for the work ! 🐼

/cc @dnephin @ibuildthecloud 

---

Consider the following yaml file:

```yaml
test:
  image: opensuse:13.2
  volumes:
    - foo:/foo
  command: sh -c 'echo Hello World'
```

docker-compose can handle the above configuration file. However this
implementation fails because it cannot handle the relative path "foo". This
commit fixes this by adding a new function `ResolvePath` to the
`ResourceLookup` interface (previously known as `ConfigLookup`) that is called
when converting the config file. The `FileConfigLookup` type implements this
function by converting relative paths to absolute paths.

Moreover, this commit also merges two for loops that were dealing with volumes.

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>