### PR TITLE
Carry pr 116  Multiple -f

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ import (
 func main() {
 	project, err := docker.NewProject(&docker.Context{
 		Context: project.Context{
-			ComposeFile: "docker-compose.yml",
-			ProjectName: "my-compose",
+			ComposeFiles: []string{"docker-compose.yml"},
+			ProjectName:  "my-compose",
 		},
 	})
 

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -256,14 +256,13 @@ func CommonFlags() []cli.Flag {
 
 // Populate updates the specified project context based on command line arguments and subcommands.
 func Populate(context *project.Context, c *cli.Context) {
-	if len(c.GlobalStringSlice("file")) == 0 {
+	context.ComposeFiles = c.GlobalStringSlice("file")
+
+	if len(context.ComposeFiles) == 0 {
+		context.ComposeFiles = []string{"docker-compose.yml"}
 		if _, err := os.Stat("docker-compose.override.yml"); err == nil {
-			context.ComposeFiles = []string{"docker-compose.yml", "docker-compose.override.yml"}
-		} else {
-			context.ComposeFiles = []string{"docker-compose.yml"}
+			context.ComposeFiles = append(context.ComposeFiles, "docker-compose.override.yml")
 		}
-	} else {
-		context.ComposeFiles = c.GlobalStringSlice("file")
 	}
 
 	context.ProjectName = c.GlobalString("project-name")

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -239,10 +239,10 @@ func CommonFlags() []cli.Flag {
 		cli.BoolFlag{
 			Name: "verbose,debug",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:   "file,f",
-			Usage:  "Specify an alternate compose file (default: docker-compose.yml)",
-			Value:  "docker-compose.yml",
+			Usage:  "Specify one or more alternate compose files (default: docker-compose.yml)",
+			Value:  &cli.StringSlice{},
 			EnvVar: "COMPOSE_FILE",
 		},
 		cli.StringFlag{
@@ -254,7 +254,12 @@ func CommonFlags() []cli.Flag {
 
 // Populate updates the specified project context based on command line arguments and subcommands.
 func Populate(context *project.Context, c *cli.Context) {
-	context.ComposeFile = c.GlobalString("file")
+	if len(c.GlobalStringSlice("file")) == 0 {
+		context.ComposeFiles = []string{"docker-compose.yml"}
+	} else {
+		context.ComposeFiles = c.GlobalStringSlice("file")
+	}
+
 	context.ProjectName = c.GlobalString("project-name")
 
 	if c.Command.Name == "logs" {

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -1,6 +1,8 @@
 package command
 
 import (
+	"os"
+
 	"github.com/codegangsta/cli"
 	"github.com/docker/libcompose/cli/app"
 	"github.com/docker/libcompose/project"
@@ -255,7 +257,11 @@ func CommonFlags() []cli.Flag {
 // Populate updates the specified project context based on command line arguments and subcommands.
 func Populate(context *project.Context, c *cli.Context) {
 	if len(c.GlobalStringSlice("file")) == 0 {
-		context.ComposeFiles = []string{"docker-compose.yml"}
+		if _, err := os.Stat("docker-compose.override.yml"); err == nil {
+			context.ComposeFiles = []string{"docker-compose.yml", "docker-compose.override.yml"}
+		} else {
+			context.ComposeFiles = []string{"docker-compose.yml"}
+		}
 	} else {
 		context.ComposeFiles = c.GlobalStringSlice("file")
 	}

--- a/docker/convert.go
+++ b/docker/convert.go
@@ -48,7 +48,7 @@ func ConvertToAPI(s *Service, name string) (*dockerclient.CreateContainerOptions
 func volumes(c *project.ServiceConfig, ctx *Context) map[string]struct{} {
 	volumes := make(map[string]struct{}, len(c.Volumes))
 	for k, v := range c.Volumes {
-		vol := ctx.ResourceLookup.ResolvePath(v, ctx.ComposeFile)
+		vol := ctx.ResourceLookup.ResolvePath(v, ctx.ComposeFiles[0])
 
 		c.Volumes[k] = vol
 		if isVolume(vol) {

--- a/docker/convert_test.go
+++ b/docker/convert_test.go
@@ -19,7 +19,7 @@ func TestParseCommand(t *testing.T) {
 
 func TestParseBindsAndVolumes(t *testing.T) {
 	ctx := &Context{}
-	ctx.ComposeFile = "foo/docker-compose.yml"
+	ctx.ComposeFiles = []string{"foo/docker-compose.yml"}
 	ctx.ResourceLookup = &lookup.FileConfigLookup{}
 
 	abs, err := filepath.Abs(".")
@@ -34,7 +34,7 @@ func TestParseBindsAndVolumes(t *testing.T) {
 
 func TestParseLabels(t *testing.T) {
 	ctx := &Context{}
-	ctx.ComposeFile = "foo/docker-compose.yml"
+	ctx.ComposeFiles = []string{"foo/docker-compose.yml"}
 	ctx.ResourceLookup = &lookup.FileConfigLookup{}
 	bashCmd := "bash"
 	fooLabel := "foo.label"

--- a/example/main.go
+++ b/example/main.go
@@ -10,8 +10,8 @@ import (
 func main() {
 	project, err := docker.NewProject(&docker.Context{
 		Context: project.Context{
-			ComposeFile: "docker-compose.yml",
-			ProjectName: "yeah-compose",
+			ComposeFiles: []string{"docker-compose.yml"},
+			ProjectName:  "yeah-compose",
 		},
 	})
 

--- a/integration/assets/multiple-composefiles-default/docker-compose.override.yml
+++ b/integration/assets/multiple-composefiles-default/docker-compose.override.yml
@@ -1,0 +1,3 @@
+yetanother:
+  image: busybox:latest
+  command: top

--- a/integration/assets/multiple-composefiles-default/docker-compose.yml
+++ b/integration/assets/multiple-composefiles-default/docker-compose.yml
@@ -1,0 +1,6 @@
+simple:
+  image: busybox:latest
+  command: top
+another:
+  image: busybox:latest
+  command: top

--- a/integration/assets/multiple/one.yml
+++ b/integration/assets/multiple/one.yml
@@ -1,0 +1,4 @@
+multiple:
+  image: tianon/true
+  environment:
+    - KEY1=VAL1

--- a/integration/assets/multiple/one.yml
+++ b/integration/assets/multiple/one.yml
@@ -2,3 +2,9 @@ multiple:
   image: tianon/true
   environment:
     - KEY1=VAL1
+simple:
+  image: busybox:latest
+  command: top
+another:
+  image: busybox:latest
+  command: top

--- a/integration/assets/multiple/two.yml
+++ b/integration/assets/multiple/two.yml
@@ -1,0 +1,5 @@
+multiple:
+  image: busybox
+  command: echo two
+  environment:
+    - KEY2=VAL2

--- a/integration/assets/multiple/two.yml
+++ b/integration/assets/multiple/two.yml
@@ -3,3 +3,6 @@ multiple:
   command: echo two
   environment:
     - KEY2=VAL2
+yetanother:
+  image: busybox:latest
+  command: top

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"fmt"
 	"os"
+	"os/exec"
 
 	. "gopkg.in/check.v1"
 )
@@ -169,4 +170,42 @@ func (s *RunSuite) TestFieldTypeConversions(c *C) {
 	c.Assert(referenceContainer.Image, Equals, testContainer.Image)
 
 	os.Unsetenv("LIMIT")
+}
+
+func (s *RunSuite) TestMultipleComposeFiles(c *C) {
+	p := s.RandomProject()
+	cmd := exec.Command(s.command, "-f", "./assets/multiple/one.yml", "-f", "./assets/multiple/two.yml", "-p", p, "create")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	err := cmd.Run()
+
+	c.Assert(err, IsNil)
+
+	name := fmt.Sprintf("%s_%s_1", p, "multiple")
+	container := s.GetContainerByName(c, name)
+
+	c.Assert(container, NotNil)
+
+	c.Assert(container.Config.Image, Equals, "busybox")
+	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})
+	c.Assert(container.Config.Env, DeepEquals, []string{"KEY1=VAL1", "KEY2=VAL2"})
+
+	p = s.RandomProject()
+	cmd = exec.Command(s.command, "-f", "./assets/multiple/two.yml", "-f", "./assets/multiple/one.yml", "-p", p, "create")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	err = cmd.Run()
+
+	c.Assert(err, IsNil)
+
+	name = fmt.Sprintf("%s_%s_1", p, "multiple")
+	container = s.GetContainerByName(c, name)
+
+	c.Assert(container, NotNil)
+
+	c.Assert(container.Config.Image, Equals, "tianon/true")
+	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})
+	c.Assert(container.Config.Env, DeepEquals, []string{"KEY2=VAL2", "KEY1=VAL1"})
 }

--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -182,10 +182,17 @@ func (s *RunSuite) TestMultipleComposeFiles(c *C) {
 
 	c.Assert(err, IsNil)
 
+	containerNames := []string{"multiple", "simple", "another", "yetanother"}
+
+	for _, containerName := range containerNames {
+		name := fmt.Sprintf("%s_%s_1", p, containerName)
+		container := s.GetContainerByName(c, name)
+
+		c.Assert(container, NotNil)
+	}
+
 	name := fmt.Sprintf("%s_%s_1", p, "multiple")
 	container := s.GetContainerByName(c, name)
-
-	c.Assert(container, NotNil)
 
 	c.Assert(container.Config.Image, Equals, "busybox")
 	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})
@@ -200,10 +207,15 @@ func (s *RunSuite) TestMultipleComposeFiles(c *C) {
 
 	c.Assert(err, IsNil)
 
+	for _, containerName := range containerNames {
+		name := fmt.Sprintf("%s_%s_1", p, containerName)
+		container := s.GetContainerByName(c, name)
+
+		c.Assert(container, NotNil)
+	}
+
 	name = fmt.Sprintf("%s_%s_1", p, "multiple")
 	container = s.GetContainerByName(c, name)
-
-	c.Assert(container, NotNil)
 
 	c.Assert(container.Config.Image, Equals, "tianon/true")
 	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "two"})

--- a/project/context.go
+++ b/project/context.go
@@ -57,11 +57,11 @@ func (c *Context) readComposeFiles() error {
 
 	for _, composeFile := range c.ComposeFiles {
 		composeBytes, err := ioutil.ReadFile(composeFile)
-		if !os.IsNotExist(err) {
+		if err != nil && !os.IsNotExist(err) {
 			logrus.Errorf("Failed to open the compose file: %s", composeFile)
 			return err
 		}
-		if !c.IgnoreMissingConfig {
+		if err != nil && !c.IgnoreMissingConfig {
 			logrus.Errorf("Failed to find the compose file: %s", composeFile)
 			return err
 		}

--- a/project/context.go
+++ b/project/context.go
@@ -25,8 +25,8 @@ type Context struct {
 	NoRecreate          bool
 	NoCache             bool
 	Signal              int
-	ComposeFile         string
-	ComposeBytes        []byte
+	ComposeFiles        []string
+	ComposeBytes        [][]byte
 	ProjectName         string
 	isOpen              bool
 	ServiceFactory      ServiceFactory
@@ -37,32 +37,35 @@ type Context struct {
 	Project             *Project
 }
 
-func (c *Context) readComposeFile() error {
+func (c *Context) readComposeFiles() error {
 	if c.ComposeBytes != nil {
 		return nil
 	}
 
-	logrus.Debugf("Opening compose file: %s", c.ComposeFile)
+	logrus.Debugf("Opening compose files: %s", strings.Join(c.ComposeFiles, ","))
 
-	if c.ComposeFile == "-" {
+	if len(c.ComposeFiles) == 1 && c.ComposeFiles[0] == "-" {
 		composeBytes, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
 			logrus.Errorf("Failed to read compose file from stdin: %v", err)
 			return err
 		}
-		c.ComposeBytes = composeBytes
-	} else if c.ComposeFile != "" {
-		if composeBytes, err := ioutil.ReadFile(c.ComposeFile); os.IsNotExist(err) {
-			if c.IgnoreMissingConfig {
-				return nil
+		c.ComposeBytes = [][]byte{composeBytes}
+	} else {
+		for _, composeFile := range c.ComposeFiles {
+			if composeFile != "" {
+				if composeBytes, err := ioutil.ReadFile(composeFile); os.IsNotExist(err) {
+					if !c.IgnoreMissingConfig {
+						logrus.Errorf("Failed to find %s", composeFile)
+						return err
+					}
+				} else if err != nil {
+					logrus.Errorf("Failed to open %s", composeFile)
+					return err
+				} else {
+					c.ComposeBytes = append(c.ComposeBytes, composeBytes)
+				}
 			}
-			logrus.Errorf("Failed to find %s", c.ComposeFile)
-			return err
-		} else if err != nil {
-			logrus.Errorf("Failed to open %s", c.ComposeFile)
-			return err
-		} else {
-			c.ComposeBytes = composeBytes
 		}
 	}
 
@@ -97,9 +100,14 @@ func (c *Context) lookupProjectName() (string, error) {
 		return envProject, nil
 	}
 
-	f, err := filepath.Abs(c.ComposeFile)
+	file := ""
+	if len(c.ComposeFiles) > 0 {
+		file = c.ComposeFiles[0]
+	}
+
+	f, err := filepath.Abs(file)
 	if err != nil {
-		logrus.Errorf("Failed to get absolute directory for: %s", c.ComposeFile)
+		logrus.Errorf("Failed to get absolute directory for: %s", file)
 		return "", err
 	}
 
@@ -124,7 +132,7 @@ func (c *Context) open() error {
 		return nil
 	}
 
-	if err := c.readComposeFile(); err != nil {
+	if err := c.readComposeFiles(); err != nil {
 		return err
 	}
 

--- a/project/merge.go
+++ b/project/merge.go
@@ -56,10 +56,10 @@ func mergeProject(p *Project, file string, bytes []byte) (map[string]*ServiceCon
 				return nil, err
 			}
 
-			datas[name] = mergeConfig(rawExistingService, data)
-		} else {
-			datas[name] = data
+			data = mergeConfig(rawExistingService, data)
 		}
+
+		datas[name] = data
 	}
 
 	if err := utils.Convert(datas, &configs); err != nil {

--- a/project/merge.go
+++ b/project/merge.go
@@ -31,7 +31,7 @@ var (
 type rawService map[string]interface{}
 type rawServiceMap map[string]rawService
 
-func mergeProject(p *Project, bytes []byte) (map[string]*ServiceConfig, error) {
+func mergeProject(p *Project, file string, bytes []byte) (map[string]*ServiceConfig, error) {
 	configs := make(map[string]*ServiceConfig)
 
 	datas := make(rawServiceMap)
@@ -44,13 +44,22 @@ func mergeProject(p *Project, bytes []byte) (map[string]*ServiceConfig, error) {
 	}
 
 	for name, data := range datas {
-		data, err := parse(p.context.ResourceLookup, p.context.EnvironmentLookup, p.File, data, datas)
+		data, err := parse(p.context.ResourceLookup, p.context.EnvironmentLookup, file, data, datas)
 		if err != nil {
 			logrus.Errorf("Failed to parse service %s: %v", name, err)
 			return nil, err
 		}
 
-		datas[name] = data
+		if _, ok := p.Configs[name]; ok {
+			var rawExistingService rawService
+			if err := utils.Convert(p.Configs[name], &rawExistingService); err != nil {
+				return nil, err
+			}
+
+			datas[name] = mergeConfig(rawExistingService, data)
+		} else {
+			datas[name] = data
+		}
 	}
 
 	if err := utils.Convert(datas, &configs); err != nil {
@@ -58,6 +67,7 @@ func mergeProject(p *Project, bytes []byte) (map[string]*ServiceConfig, error) {
 	}
 
 	adjustValues(configs)
+
 	return configs, nil
 }
 
@@ -237,6 +247,14 @@ func parse(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup, i
 		}
 	}
 
+	baseService = mergeConfig(baseService, serviceData)
+
+	logrus.Debugf("Merged result %#v", baseService)
+
+	return baseService, nil
+}
+
+func mergeConfig(baseService, serviceData rawService) rawService {
 	for k, v := range serviceData {
 		// Image and build are mutually exclusive in merge
 		if k == "image" {
@@ -252,9 +270,7 @@ func parse(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup, i
 		}
 	}
 
-	logrus.Debugf("Merged result %#v", baseService)
-
-	return baseService, nil
+	return baseService
 }
 
 func merge(existing, value interface{}) interface{} {

--- a/project/merge_test.go
+++ b/project/merge_test.go
@@ -18,7 +18,7 @@ func TestExtendsInheritImage(t *testing.T) {
 		ResourceLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   image: foo
 child:
@@ -51,7 +51,7 @@ func TestExtendsInheritBuild(t *testing.T) {
 		ResourceLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   build: .
 child:
@@ -84,7 +84,7 @@ func TestExtendBuildOverImage(t *testing.T) {
 		ResourceLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   image: foo
 child:
@@ -118,7 +118,7 @@ func TestExtendImageOverBuild(t *testing.T) {
 		ResourceLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 parent:
   build: .
 child:
@@ -156,7 +156,7 @@ func TestRestartNo(t *testing.T) {
 		ResourceLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 test:
   restart: no
   image: foo
@@ -178,7 +178,7 @@ func TestRestartAlways(t *testing.T) {
 		ResourceLookup: &NullLookup{},
 	})
 
-	config, err := mergeProject(p, []byte(`
+	config, err := mergeProject(p, "", []byte(`
 test:
   restart: always
   image: foo

--- a/project/project.go
+++ b/project/project.go
@@ -63,22 +63,20 @@ func (p *Project) Parse() error {
 
 	p.Name = p.context.ProjectName
 
-	if len(p.context.ComposeFiles) == 1 && p.context.ComposeFiles[0] == "-" {
+	p.Files = p.context.ComposeFiles
+
+	if len(p.Files) == 1 && p.Files[0] == "-" {
 		p.Files = []string{"."}
-	} else {
-		p.Files = p.context.ComposeFiles
 	}
 
 	if p.context.ComposeBytes != nil {
 		for i, composeBytes := range p.context.ComposeBytes {
+			file := ""
 			if i < len(p.context.ComposeFiles) {
-				if err := p.load(p.Files[i], composeBytes); err != nil {
-					return err
-				}
-			} else {
-				if err := p.Load(composeBytes); err != nil {
-					return err
-				}
+				file = p.Files[i]
+			}
+			if err := p.load(file, composeBytes); err != nil {
+				return err
 			}
 		}
 	}
@@ -132,6 +130,7 @@ func (p *Project) AddConfig(name string, config *ServiceConfig) error {
 
 // Load loads the specified byte array (the composefile content) and adds the
 // service configuration to the project.
+// FIXME is it needed ?
 func (p *Project) Load(bytes []byte) error {
 	return p.load("", bytes)
 }

--- a/project/types.go
+++ b/project/types.go
@@ -228,7 +228,7 @@ type ResourceLookup interface {
 type Project struct {
 	Name           string
 	Configs        map[string]*ServiceConfig
-	File           string
+	Files          []string
 	ReloadCallback func() error
 	context        *Context
 	reload         []string


### PR DESCRIPTION
Carrying #116 🐮, rebased, adpated to latest changes and some more integration tests added.

/cc @dnephin @ibuildthecloud 

🐸

---

Fixes #98. This changes some properties of `Context` (`string ComposeFile` to `[]string ComposeFiles` and `[]byte ComposeBytes` to `[][]byte ComposeBytes`) as well as `Project` (`string File` to `[]string Files`).

Signed-off-by: Josh Curl <hello@joshcurl.com>