### PR TITLE
Supporting logger factories for image build and pulls

### DIFF
--- a/cli/logger/color_logger.go
+++ b/cli/logger/color_logger.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strconv"
 
@@ -29,8 +30,23 @@ func NewColorLoggerFactory() *ColorLoggerFactory {
 	}
 }
 
-// Create implements logger.Factory.Create.
-func (c *ColorLoggerFactory) Create(name string) logger.Logger {
+// CreateContainerLogger implements logger.Factory.CreateContainerLogger.
+func (c *ColorLoggerFactory) CreateContainerLogger(name string) logger.Logger {
+	return c.create(name)
+}
+
+// CreateBuildLogger implements logger.Factory.CreateBuildLogger.
+func (c *ColorLoggerFactory) CreateBuildLogger(name string) logger.Logger {
+	return &logger.RawLogger{}
+}
+
+// CreatePullLogger implements logger.Factory.CreatePullLogger.
+func (c *ColorLoggerFactory) CreatePullLogger(name string) logger.Logger {
+	return &logger.NullLogger{}
+}
+
+// CreateBuildLogger implements logger.Factory.CreateContainerLogger.
+func (c *ColorLoggerFactory) create(name string) logger.Logger {
 	if c.maxLength < len(name) {
 		c.maxLength = len(name)
 	}
@@ -60,6 +76,16 @@ func (c *ColorLogger) Err(bytes []byte) {
 	logFmt, name := c.getLogFmt()
 	message := fmt.Sprintf(logFmt, name, string(bytes))
 	fmt.Fprint(os.Stderr, message)
+}
+
+// OutWriter returns the base writer
+func (c *ColorLogger) OutWriter() io.Writer {
+	return os.Stdout
+}
+
+// ErrWriter returns the base writer
+func (c *ColorLogger) ErrWriter() io.Writer {
+	return os.Stderr
 }
 
 func (c *ColorLogger) getLogFmt() (string, string) {

--- a/docker/service.go
+++ b/docker/service.go
@@ -193,6 +193,7 @@ func (s *Service) build(ctx context.Context, buildOptions options.Build) error {
 		NoCache:          buildOptions.NoCache,
 		ForceRemove:      buildOptions.ForceRemove,
 		Pull:             buildOptions.Pull,
+		LoggerFactory:    s.context.LoggerFactory,
 	}
 	return builder.Build(ctx, s.imageName())
 }
@@ -572,7 +573,7 @@ func (s *Service) Log(ctx context.Context, follow bool) error {
 			return err
 		}
 		name := fmt.Sprintf("%s_%d", s.name, containerNumber)
-		l := s.context.LoggerFactory.Create(name)
+		l := s.context.LoggerFactory.CreateContainerLogger(name)
 		return c.Log(ctx, l, follow)
 	})
 }

--- a/logger/null.go
+++ b/logger/null.go
@@ -1,5 +1,9 @@
 package logger
 
+import (
+	"io"
+)
+
 // NullLogger is a logger.Logger and logger.Factory implementation that does nothing.
 type NullLogger struct {
 }
@@ -12,7 +16,27 @@ func (n *NullLogger) Out(_ []byte) {
 func (n *NullLogger) Err(_ []byte) {
 }
 
-// Create implements logger.Factory and returns a NullLogger.
-func (n *NullLogger) Create(_ string) Logger {
+// CreateContainerLogger allows NullLogger to implement logger.Factory.
+func (n *NullLogger) CreateContainerLogger(_ string) Logger {
 	return &NullLogger{}
+}
+
+// CreateBuildLogger allows NullLogger to implement logger.Factory.
+func (n *NullLogger) CreateBuildLogger(_ string) Logger {
+	return &NullLogger{}
+}
+
+// CreatePullLogger allows NullLogger to implement logger.Factory.
+func (n *NullLogger) CreatePullLogger(_ string) Logger {
+	return &NullLogger{}
+}
+
+// OutWriter returns the base writer
+func (n *NullLogger) OutWriter() io.Writer {
+	return nil
+}
+
+// ErrWriter returns the base writer
+func (n *NullLogger) ErrWriter() io.Writer {
+	return nil
 }

--- a/logger/raw_logger.go
+++ b/logger/raw_logger.go
@@ -1,0 +1,48 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// RawLogger is a logger.Logger and logger.Factory implementation that prints raw data with no formatting.
+type RawLogger struct {
+}
+
+// Out is a no-op function.
+func (r *RawLogger) Out(message []byte) {
+	fmt.Print(string(message))
+
+}
+
+// Err is a no-op function.
+func (r *RawLogger) Err(message []byte) {
+	fmt.Fprint(os.Stderr, string(message))
+
+}
+
+// CreateContainerLogger allows RawLogger to implement logger.Factory.
+func (r *RawLogger) CreateContainerLogger(_ string) Logger {
+	return &RawLogger{}
+}
+
+// CreateBuildLogger allows RawLogger to implement logger.Factory.
+func (r *RawLogger) CreateBuildLogger(_ string) Logger {
+	return &RawLogger{}
+}
+
+// CreatePullLogger allows RawLogger to implement logger.Factory.
+func (r *RawLogger) CreatePullLogger(_ string) Logger {
+	return &RawLogger{}
+}
+
+// OutWriter returns the base writer
+func (r *RawLogger) OutWriter() io.Writer {
+	return os.Stdout
+}
+
+// ErrWriter returns the base writer
+func (r *RawLogger) ErrWriter() io.Writer {
+	return os.Stderr
+}

--- a/logger/types.go
+++ b/logger/types.go
@@ -1,15 +1,23 @@
 package logger
 
+import (
+	"io"
+)
+
 // Factory defines methods a factory should implement, to create a Logger
-// based on the specified name.
+// based on the specified container, image or service name.
 type Factory interface {
-	Create(name string) Logger
+	CreateContainerLogger(name string) Logger
+	CreateBuildLogger(name string) Logger
+	CreatePullLogger(name string) Logger
 }
 
 // Logger defines methods to implement for being a logger.
 type Logger interface {
 	Out(bytes []byte)
 	Err(bytes []byte)
+	OutWriter() io.Writer
+	ErrWriter() io.Writer
 }
 
 // Wrapper is a wrapper around Logger that implements the Writer interface,


### PR DESCRIPTION
This change updates how the container and builder write logs from docker, to use a provided LoggerFactory. This currently uses the following assumptions

1) Container loggers are requested using the format $PROJECTNAME_$SERVICENAME_$INSTANCENUM, eg myproject_app_1 as per the compose container name format.
2) Image build loggers are requested using the service name
3) Image pull loggers are requested using the image name

The problem with this is that it's highly likely someone would use the same image and service name, e.g. the redis service uses the image redis. 

Possible solutions:

* Using different logger factories for the different types of loggers
* Extending the logger factory interface to request different types of loggers

thoughts?