### PR TITLE
Extending container events

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -164,8 +164,11 @@ func (c *Container) Create(imageName string) (*types.Container, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		id, _ := c.ID()
 		c.service.context.Project.Notify(project.EventContainerCreated, c.service.Name(), map[string]string{
 			"name": c.Name(),
+			"id":   id,
 		})
 	}
 
@@ -273,9 +276,10 @@ func (c *Container) Up(imageName string) error {
 			logrus.WithFields(logrus.Fields{"container.ID": container.ID, "c.name": c.name}).Debug("Failed to start container")
 			return err
 		}
-
+		id, _ := c.ID()
 		c.service.context.Project.Notify(project.EventContainerStarted, c.service.Name(), map[string]string{
 			"name": c.Name(),
+			"id":   id,
 		})
 	}
 

--- a/project/types.go
+++ b/project/types.go
@@ -11,6 +11,7 @@ const (
 
 	EventContainerCreated = EventType(iota)
 	EventContainerStarted = EventType(iota)
+	EventContainerStopped = EventType(iota)
 
 	EventServiceAdd          = EventType(iota)
 	EventServiceUpStart      = EventType(iota)


### PR DESCRIPTION
This PR makes two changes

1) Adds container ID to the container events data map
2) Polls running containers when started to notify when they stop with a ContainerStopped event

These can be easily separated if needed. 

Adding the ID is pretty low risk, since its a dynamic, and currently empty data map. We can generally ignore any error when fetching container info.

For the poller, it is higher risk, however only because of the extra goroutine being utilized. I'll still need to verify the state strings, and probably move them to be constants, or reference them directly as external constants.

Let me know how to proceed with this.
