### PR TITLE
Check project.serviceStart return for error

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -413,7 +413,9 @@ func (p *Project) traverse(start bool, selected map[string]bool, wrappers map[st
 	launched := map[string]bool{}
 
 	for _, wrapper := range wrappers {
-		p.startService(wrappers, []string{}, selected, launched, wrapper, action, cycleAction)
+		if err := p.startService(wrappers, []string{}, selected, launched, wrapper, action, cycleAction); err != nil {
+			return err
+		}
 	}
 
 	var firstError error


### PR DESCRIPTION
Not checking for an error here causes libcompose to hang when circular dependencies are present. It's better to fail with a relevant error message.

Signed-off-by: Josh Curl <hello@joshcurl.com>