### PR TITLE
Convert map to colon seperated string in MaporColonSlice

### DIFF
--- a/project/types_yaml.go
+++ b/project/types_yaml.go
@@ -347,6 +347,18 @@ func (s MaporColonSlice) MarshalYAML() (tag string, value interface{}, err error
 func (s *MaporColonSlice) UnmarshalYAML(tag string, value interface{}) error {
 	switch value := value.(type) {
 	case []interface{}:
+		for i, part := range value {
+			switch part := part.(type) {
+			case map[interface{}]interface{}:
+				sepMapParts, err := toSepMapParts(part, ":")
+				if err != nil {
+					return err
+				}
+
+				value[i] = sepMapParts[0]
+			}
+		}
+
 		parts, err := toStrings(value)
 		if err != nil {
 			return err


### PR DESCRIPTION
Links that are of the form `"server: foo"` seem to not be parsed correctly by candiedyaml. Instead of being parsed as a string, they are parsed as a map. This was causing errors since maps within lists aren't a valid format for links.

This converts the map back into a string and is a workaround until candiedyaml can be fixed.