### PR TITLE
Remove integer conversion when parsing configs

### DIFF
--- a/project/interpolation.go
+++ b/project/interpolation.go
@@ -3,7 +3,6 @@ package project
 import (
 	"bytes"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
@@ -108,20 +107,10 @@ func parseConfig(option, service string, data *interface{}, mapping func(string)
 	case string:
 		var success bool
 
-		interpolatedLine, success := parseLine(typedData, mapping)
+		*data, success = parseLine(typedData, mapping)
 
 		if !success {
 			return fmt.Errorf("Invalid interpolation format for \"%s\" option in service \"%s\": \"%s\"", option, service, typedData)
-		}
-
-		// If possible, convert the value to an integer
-		// If the type should be a string and not an int, go-yaml will convert it back into a string
-		lineAsInteger, err := strconv.Atoi(interpolatedLine)
-
-		if err == nil {
-			*data = lineAsInteger
-		} else {
-			*data = interpolatedLine
 		}
 	case []interface{}:
 		for k, v := range typedData {


### PR DESCRIPTION
This was originally introduced as a workaround to fix #85, but doesn't appear to be needed anymore. I'm not exactly sure what caused it to be no longer be necessary, but the tests I wrote are still passing. Since the conversion is causing problems such as #113, it's probably best to remove it.

Signed-off-by: Josh Curl <hello@joshcurl.com>