### PR TITLE
Use project.Context interface for argument to docker.Convert

### DIFF
--- a/docker/convert.go
+++ b/docker/convert.go
@@ -41,7 +41,7 @@ func isVolume(s string) bool {
 
 // ConvertToAPI converts a service configuration to a docker API container configuration.
 func ConvertToAPI(s *Service) (*ConfigWrapper, error) {
-	config, hostConfig, err := Convert(s.serviceConfig, s.context)
+	config, hostConfig, err := Convert(s.serviceConfig, s.context.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +53,7 @@ func ConvertToAPI(s *Service) (*ConfigWrapper, error) {
 	return &result, nil
 }
 
-func volumes(c *project.ServiceConfig, ctx *Context) map[string]struct{} {
+func volumes(c *project.ServiceConfig, ctx project.Context) map[string]struct{} {
 	volumes := make(map[string]struct{}, len(c.Volumes))
 	for k, v := range c.Volumes {
 		vol := ctx.ResourceLookup.ResolvePath(v, ctx.ComposeFiles[0])
@@ -106,7 +106,7 @@ func ports(c *project.ServiceConfig) (map[nat.Port]struct{}, nat.PortMap, error)
 }
 
 // Convert converts a service configuration to an docker API structures (Config and HostConfig)
-func Convert(c *project.ServiceConfig, ctx *Context) (*container.Config, *container.HostConfig, error) {
+func Convert(c *project.ServiceConfig, ctx project.Context) (*container.Config, *container.HostConfig, error) {
 	restartPolicy, err := restartPolicy(c)
 	if err != nil {
 		return nil, nil, err

--- a/docker/convert_test.go
+++ b/docker/convert_test.go
@@ -26,7 +26,7 @@ func TestParseBindsAndVolumes(t *testing.T) {
 	assert.Nil(t, err)
 	cfg, hostCfg, err := Convert(&project.ServiceConfig{
 		Volumes: []string{"/foo", "/home:/home", "/bar/baz", ".:/home", "/usr/lib:/usr/lib:ro"},
-	}, ctx)
+	}, ctx.Context)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]struct{}{"/foo": {}, "/bar/baz": {}}, cfg.Volumes)
 	assert.Equal(t, []string{"/home:/home", abs + "/foo:/home", "/usr/lib:/usr/lib:ro"}, hostCfg.Binds)
@@ -43,7 +43,7 @@ func TestParseLabels(t *testing.T) {
 		Entrypoint: project.NewCommand(bashCmd),
 		Labels:     project.NewSliceorMap(map[string]string{fooLabel: "service.config.value"}),
 	}
-	cfg, _, err := Convert(sc, ctx)
+	cfg, _, err := Convert(sc, ctx.Context)
 	assert.Nil(t, err)
 
 	cfg.Labels[fooLabel] = "FUN"


### PR DESCRIPTION
The function `docker.Convert` currently takes in a context of type `docker.Context`, which is an implementation of `project.Context`. It's probably best to use the latter instead so alternative implementations of `project.Context` can be used, as is the case in Rancher Compose.

Signed-off-by: Josh Curl <hello@joshcurl.com>