### PR TITLE
Switching from "0" tail arg to "all"

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -506,7 +506,7 @@ func (c *Container) Log() error {
 		ShowStdout:  true,
 		ShowStderr:  true,
 		Follow:      true,
-		Tail:        "0",
+		Tail:        "all",
 	}
 	responseBody, err := c.client.ContainerLogs(context.Background(), options)
 	if err != nil {


### PR DESCRIPTION
This fixes an issue where if the container has already exited, no logs are returned

Before this change no logs were returned 9 times out of 10 with a bare container. 

Closes #160 