### PR TITLE
Fixes CI failures

### DIFF
--- a/integration/create_test.go
+++ b/integration/create_test.go
@@ -197,7 +197,8 @@ func (s *RunSuite) TestMultipleComposeFilesOneTwo(c *C) {
 
 	c.Assert(container.Config.Image, Equals, "busybox")
 	c.Assert(container.Config.Cmd.Slice(), DeepEquals, []string{"echo", "two"})
-	c.Assert(container.Config.Env, DeepEquals, []string{"KEY1=VAL1", "KEY2=VAL2"})
+	c.Assert(contains(container.Config.Env, "KEY2=VAL2"), Equals, true)
+	c.Assert(contains(container.Config.Env, "KEY1=VAL1"), Equals, true)
 }
 
 func (s *RunSuite) TestMultipleComposeFilesTwoOne(c *C) {
@@ -224,7 +225,17 @@ func (s *RunSuite) TestMultipleComposeFilesTwoOne(c *C) {
 
 	c.Assert(container.Config.Image, Equals, "tianon/true")
 	c.Assert(container.Config.Cmd.Slice(), DeepEquals, []string{"echo", "two"})
-	c.Assert(container.Config.Env, DeepEquals, []string{"KEY2=VAL2", "KEY1=VAL1"})
+	c.Assert(contains(container.Config.Env, "KEY2=VAL2"), Equals, true)
+	c.Assert(contains(container.Config.Env, "KEY1=VAL1"), Equals, true)
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *RunSuite) TestDefaultMultipleComposeFiles(c *C) {

--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -22,7 +22,7 @@ cd venv/compose
 # if the tests fail, we still want to execute a few cleanup commands
 # so we save the result for the exit command at the end.
 # the "or" ensures that return code isn't trapped by the parent script.
-py.test -vs --tb=short tests/acceptance || result=$?
+timeout 15m py.test -vs --tb=short tests/acceptance || result=$?
 
 cd -
 bundle .integration-daemon-stop


### PR DESCRIPTION
Fixes the current CI failures 🐻.

With docker 1.10, PATH is a default environment variable set by docker. Modifying the test to only check the presence of the wanted environment variables, not all of them.

---

Use `timeout 15m` for the `test-acceptance` script 🐌.

- It's currently "freezing" on the CI, so this makes it timeout after   some time
- It's also a good way to make sure it takes not too much time..

It should bring back CI to green (and not having CI run for 60min each time too).

---

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>