### PR TITLE
Add a timeout to test-acceptance

### DIFF
--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -22,7 +22,7 @@ cd venv/compose
 # if the tests fail, we still want to execute a few cleanup commands
 # so we save the result for the exit command at the end.
 # the "or" ensures that return code isn't trapped by the parent script.
-py.test -vs --tb=short tests/acceptance || result=$?
+timeout 15m py.test -vs --tb=short tests/acceptance || result=$?
 
 cd -
 bundle .integration-daemon-stop


### PR DESCRIPTION
Use `timeout 15m` for the `test-acceptance` script 🐌.

- It's currently "freezing" on the CI, so this makes it timeout after   some time
- It's also a good way to make sure it takes not too much time..

It should bring back CI to green (and not having CI run for 60min each time too).

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>