### PR TITLE
Carry #74 Expose Interpolate for external tools

### DIFF
--- a/project/interpolation.go
+++ b/project/interpolation.go
@@ -137,7 +137,8 @@ func parseConfig(option, service string, data *interface{}, mapping func(string)
 	return nil
 }
 
-func interpolate(environmentLookup EnvironmentLookup, config *rawServiceMap) error {
+// Interpolate replaces variables in the raw map representation of the project file
+func Interpolate(environmentLookup EnvironmentLookup, config *RawServiceMap) error {
 	for k, v := range *config {
 		for k2, v2 := range v {
 			err := parseConfig(k2, k, &v2, func(s string) string {

--- a/project/interpolation_test.go
+++ b/project/interpolation_test.go
@@ -93,13 +93,13 @@ func testInterpolatedConfig(t *testing.T, expectedConfig, interpolatedConfig str
 	expectedConfigBytes := []byte(expectedConfig)
 	interpolatedConfigBytes := []byte(interpolatedConfig)
 
-	expectedData := make(rawServiceMap)
-	interpolatedData := make(rawServiceMap)
+	expectedData := make(RawServiceMap)
+	interpolatedData := make(RawServiceMap)
 
 	yaml.Unmarshal(expectedConfigBytes, &expectedData)
 	yaml.Unmarshal(interpolatedConfigBytes, &interpolatedData)
 
-	_ = interpolate(MockEnvironmentLookup{envVariables}, &interpolatedData)
+	_ = Interpolate(MockEnvironmentLookup{envVariables}, &interpolatedData)
 
 	for k := range envVariables {
 		os.Unsetenv(k)
@@ -110,10 +110,10 @@ func testInterpolatedConfig(t *testing.T, expectedConfig, interpolatedConfig str
 
 func testInvalidInterpolatedConfig(t *testing.T, interpolatedConfig string) {
 	interpolatedConfigBytes := []byte(interpolatedConfig)
-	interpolatedData := make(rawServiceMap)
+	interpolatedData := make(RawServiceMap)
 	yaml.Unmarshal(interpolatedConfigBytes, &interpolatedData)
 
-	err := interpolate(new(MockEnvironmentLookup), &interpolatedData)
+	err := Interpolate(new(MockEnvironmentLookup), &interpolatedData)
 
 	assert.NotNil(t, err)
 }

--- a/project/validation.go
+++ b/project/validation.go
@@ -54,9 +54,9 @@ func getValue(val interface{}, context string) string {
 			if index, err := strconv.Atoi(k); err == nil {
 				val = typedVal[index]
 			}
-		case rawServiceMap:
+		case RawServiceMap:
 			val = typedVal[k]
-		case rawService:
+		case RawService:
 			val = typedVal[k]
 		case map[interface{}]interface{}:
 			val = typedVal[k]
@@ -72,8 +72,8 @@ func getValue(val interface{}, context string) string {
 
 // Converts map[interface{}]interface{} to map[string]interface{} recursively
 // gojsonschema only accepts map[string]interface{}
-func convertServiceMapKeysToStrings(serviceMap rawServiceMap) rawServiceMap {
-	newServiceMap := make(rawServiceMap)
+func convertServiceMapKeysToStrings(serviceMap RawServiceMap) RawServiceMap {
+	newServiceMap := make(RawServiceMap)
 
 	for k, v := range serviceMap {
 		newServiceMap[k] = convertServiceKeysToStrings(v)
@@ -82,8 +82,8 @@ func convertServiceMapKeysToStrings(serviceMap rawServiceMap) rawServiceMap {
 	return newServiceMap
 }
 
-func convertServiceKeysToStrings(service rawService) rawService {
-	newService := make(rawService)
+func convertServiceKeysToStrings(service RawService) RawService {
+	newService := make(RawService)
 
 	for k, v := range service {
 		newService[k] = convertKeysToStrings(v)
@@ -146,7 +146,7 @@ func unsupportedConfigMessage(key string, nextErr gojsonschema.ResultError) stri
 	return message
 }
 
-func oneOfMessage(serviceMap rawServiceMap, schema map[string]interface{}, err, nextErr gojsonschema.ResultError) string {
+func oneOfMessage(serviceMap RawServiceMap, schema map[string]interface{}, err, nextErr gojsonschema.ResultError) string {
 	switch nextErr.Type() {
 	case "additional_property_not_allowed":
 		property := nextErr.Details()["property"]
@@ -188,7 +188,7 @@ func invalidTypeMessage(service, key string, err gojsonschema.ResultError) strin
 	return fmt.Sprintf("Service '%s' configuration key '%s' contains an invalid type, it should be %s.", service, key, validTypesMsg)
 }
 
-func validate(serviceMap rawServiceMap) error {
+func validate(serviceMap RawServiceMap) error {
 	if err := setupSchemaLoaders(); err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func validate(serviceMap rawServiceMap) error {
 	return nil
 }
 
-func validateServiceConstraints(service rawService, serviceName string) error {
+func validateServiceConstraints(service RawService, serviceName string) error {
 	if err := setupSchemaLoaders(); err != nil {
 		return err
 	}

--- a/project/validation_test.go
+++ b/project/validation_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func testValidSchema(t *testing.T, serviceMap rawServiceMap) {
+func testValidSchema(t *testing.T, serviceMap RawServiceMap) {
 	err := validate(serviceMap)
 	assert.Nil(t, err)
 
@@ -19,7 +19,7 @@ func testValidSchema(t *testing.T, serviceMap rawServiceMap) {
 	}
 }
 
-func testInvalidSchema(t *testing.T, serviceMap rawServiceMap, errMsgs []string, errCount int) {
+func testInvalidSchema(t *testing.T, serviceMap RawServiceMap, errMsgs []string, errCount int) {
 	var combinedErrMsg bytes.Buffer
 
 	err := validate(serviceMap)
@@ -49,7 +49,7 @@ func TestInvalidServiceNames(t *testing.T) {
 	invalidServiceNames := []string{"?not?allowed", " ", "", "!", "/"}
 
 	for _, invalidServiceName := range invalidServiceNames {
-		testInvalidSchema(t, rawServiceMap{
+		testInvalidSchema(t, RawServiceMap{
 			invalidServiceName: map[string]interface{}{
 				"image": "busybox",
 			},
@@ -61,7 +61,7 @@ func TestValidServiceNames(t *testing.T) {
 	validServiceNames := []string{"_", "-", ".__.", "_what-up.", "what_.up----", "whatup"}
 
 	for _, validServiceName := range validServiceNames {
-		testValidSchema(t, rawServiceMap{
+		testValidSchema(t, RawServiceMap{
 			validServiceName: map[string]interface{}{
 				"image": "busybox",
 			},
@@ -80,7 +80,7 @@ func TestConfigInvalidPorts(t *testing.T) {
 	}
 
 	for _, portsValue := range portsValues {
-		testInvalidSchema(t, rawServiceMap{
+		testInvalidSchema(t, RawServiceMap{
 			"web": map[string]interface{}{
 				"image": "busybox",
 				"ports": portsValue,
@@ -88,7 +88,7 @@ func TestConfigInvalidPorts(t *testing.T) {
 		}, []string{"Service 'web' configuration key 'ports' contains an invalid type, it should be an array"}, 1)
 	}
 
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{
 			"image": "busybox",
 			"ports": []interface{}{
@@ -109,7 +109,7 @@ func TestConfigValidPorts(t *testing.T) {
 	}
 
 	for _, portsValue := range portsValues {
-		testValidSchema(t, rawServiceMap{
+		testValidSchema(t, RawServiceMap{
 			"web": map[string]interface{}{
 				"image": "busybox",
 				"ports": portsValue,
@@ -119,7 +119,7 @@ func TestConfigValidPorts(t *testing.T) {
 }
 
 func TestConfigHint(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo": map[string]interface{}{
 			"image":     "busybox",
 			"privilege": "something",
@@ -128,7 +128,7 @@ func TestConfigHint(t *testing.T) {
 }
 
 func TestTypeShouldBeAnArray(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo": map[string]interface{}{
 			"image": "busybox",
 			"links": "an_link",
@@ -137,7 +137,7 @@ func TestTypeShouldBeAnArray(t *testing.T) {
 }
 
 func TestInvalidTypeWithMultipleValidTypes(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{
 			"image": "busybox",
 			"mem_limit": []interface{}{
@@ -149,7 +149,7 @@ func TestInvalidTypeWithMultipleValidTypes(t *testing.T) {
 
 func TestInvalidNotUniqueItems(t *testing.T) {
 	// Test property with array as only valid type
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo": map[string]interface{}{
 			"image": "busybox",
 			"devices": []string{
@@ -160,7 +160,7 @@ func TestInvalidNotUniqueItems(t *testing.T) {
 	}, []string{"Service 'foo' configuration key 'devices' value [/dev/foo:/dev/foo /dev/foo:/dev/foo] has non-unique elements"}, 1)
 
 	// Test property with multiple valid types
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo": map[string]interface{}{
 			"image": "busybox",
 			"environment": []string{
@@ -172,7 +172,7 @@ func TestInvalidNotUniqueItems(t *testing.T) {
 }
 
 func TestInvalidListOfStringsFormat(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{
 			"build": ".",
 			"command": []interface{}{
@@ -183,7 +183,7 @@ func TestInvalidListOfStringsFormat(t *testing.T) {
 }
 
 func TestInvalidExtraHostsString(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{
 			"image":       "busybox",
 			"extra_hosts": "somehost:162.242.195.82",
@@ -193,7 +193,7 @@ func TestInvalidExtraHostsString(t *testing.T) {
 
 func TestValidConfigWhichAllowsTwoTypeDefinitions(t *testing.T) {
 	for _, exposeValue := range []interface{}{"8000", 9000} {
-		testValidSchema(t, rawServiceMap{
+		testValidSchema(t, RawServiceMap{
 			"web": map[string]interface{}{
 				"image": "busybox",
 				"expose": []interface{}{
@@ -213,7 +213,7 @@ func TestValidConfigOneOfStringOrList(t *testing.T) {
 	}
 
 	for _, entrypointValue := range entrypointValues {
-		testValidSchema(t, rawServiceMap{
+		testValidSchema(t, RawServiceMap{
 			"web": map[string]interface{}{
 				"image":      "busybox",
 				"entrypoint": entrypointValue,
@@ -223,7 +223,7 @@ func TestValidConfigOneOfStringOrList(t *testing.T) {
 }
 
 func TestInvalidServiceProperty(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{
 			"image":            "busybox",
 			"invalid_property": "value",
@@ -232,13 +232,13 @@ func TestInvalidServiceProperty(t *testing.T) {
 }
 
 func TestServiceInvalidMissingImageAndBuild(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{},
 	}, []string{"Service 'web' has neither an image nor a build path specified. Exactly one must be provided."}, 1)
 }
 
 func TestServiceInvalidSpecifiesImageAndBuild(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{
 			"image": "busybox",
 			"build": ".",
@@ -247,7 +247,7 @@ func TestServiceInvalidSpecifiesImageAndBuild(t *testing.T) {
 }
 
 func TestServiceInvalidSpecifiesImageAndDockerfile(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"web": map[string]interface{}{
 			"image":      "busybox",
 			"dockerfile": "Dockerfile",
@@ -256,7 +256,7 @@ func TestServiceInvalidSpecifiesImageAndDockerfile(t *testing.T) {
 }
 
 func TestInvalidServiceForMultipleErrors(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo": map[string]interface{}{
 			"image": "busybox",
 			"ports": "invalid_type",
@@ -274,7 +274,7 @@ func TestInvalidServiceForMultipleErrors(t *testing.T) {
 }
 
 func TestInvalidServiceWithAdditionalProperties(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo": map[string]interface{}{
 			"image": "busybox",
 			"ports": "invalid_type",
@@ -292,7 +292,7 @@ func TestInvalidServiceWithAdditionalProperties(t *testing.T) {
 }
 
 func TestMultipleInvalidServices(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo1": map[string]interface{}{
 			"image": "busybox",
 			"ports": "invalid_type",
@@ -308,7 +308,7 @@ func TestMultipleInvalidServices(t *testing.T) {
 }
 
 func TestMixedInvalidServicesAndInvalidServiceNames(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo1": map[string]interface{}{
 			"image": "busybox",
 			"ports": "invalid_type",
@@ -328,7 +328,7 @@ func TestMixedInvalidServicesAndInvalidServiceNames(t *testing.T) {
 }
 
 func TestMultipleInvalidServicesForMultipleErrors(t *testing.T) {
-	testInvalidSchema(t, rawServiceMap{
+	testInvalidSchema(t, RawServiceMap{
 		"foo1": map[string]interface{}{
 			"image": "busybox",
 			"ports": "invalid_type",


### PR DESCRIPTION
Changed a few new instances of `rawService` and `rawServiceMap`. As discussed in #99, interpolation will be moved into a `config` package separately from this PR.

---

It is quite useful to parse a text file in the same exact way that
compose does.  One can imagine this being useful for GUI applications or
custom parsers.

Signed-off-by: Darren Shepherd <darren@rancher.com>

Conflicts:
	project/merge.go