### PR TITLE
Fixes #168 by spliting down and stop commands

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -94,7 +94,15 @@ func ProjectPort(p *project.Project, c *cli.Context) {
 	fmt.Println(output)
 }
 
-// ProjectDown brings all services down.
+// ProjectStop stops all services.
+func ProjectStop(p *project.Project, c *cli.Context) {
+	err := p.Stop(c.Args()...)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+}
+
+// ProjectDown brings all services down (stops and clean containers).
 func ProjectDown(p *project.Project, c *cli.Context) {
 	err := p.Down(c.Args()...)
 	if err != nil {

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -168,10 +168,9 @@ func RestartCommand(factory app.ProjectFactory) cli.Command {
 // StopCommand defines the libcompose stop subcommand.
 func StopCommand(factory app.ProjectFactory) cli.Command {
 	return cli.Command{
-		Name:      "stop",
-		ShortName: "down",
-		Usage:     "Stop services",
-		Action:    app.WithProject(factory, app.ProjectDown),
+		Name:   "stop",
+		Usage:  "Stop services",
+		Action: app.WithProject(factory, app.ProjectStop),
 		Flags: []cli.Flag{
 			cli.IntFlag{
 				Name:  "timeout,t",
@@ -179,6 +178,16 @@ func StopCommand(factory app.ProjectFactory) cli.Command {
 				Value: 10,
 			},
 		},
+	}
+}
+
+// DownCommand defines the libcompose stop subcommand.
+func DownCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "down",
+		Usage:  "Stop and remove containers, networks, images, and volumes",
+		Action: app.WithProject(factory, app.ProjectDown),
+		Flags:  []cli.Flag{},
 	}
 }
 

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -29,6 +29,7 @@ func main() {
 		command.LogsCommand(factory),
 		command.RestartCommand(factory),
 		command.StopCommand(factory),
+		command.DownCommand(factory),
 		command.ScaleCommand(factory),
 		command.RmCommand(factory),
 		command.PullCommand(factory),

--- a/docker/container.go
+++ b/docker/container.go
@@ -186,10 +186,25 @@ func (c *Container) Create(imageName string) (*types.Container, error) {
 	return container, err
 }
 
-// Down stops the container.
-func (c *Container) Down() error {
+// Stop stops the container.
+func (c *Container) Stop() error {
 	return c.withContainer(func(container *types.Container) error {
 		return c.client.ContainerStop(context.Background(), container.ID, int(c.service.context.Timeout))
+	})
+}
+
+// Down stops and remove the container.
+func (c *Container) Down() error {
+	if err := c.Stop(); err != nil {
+		return err
+	}
+
+	return c.withContainer(func(container *types.Container) error {
+		return c.client.ContainerRemove(context.Background(), types.ContainerRemoveOptions{
+			ContainerID:   container.ID,
+			Force:         true,
+			RemoveVolumes: c.service.context.Volume,
+		})
 	})
 }
 

--- a/docker/service.go
+++ b/docker/service.go
@@ -301,7 +301,14 @@ func (s *Service) eachContainer(action func(*Container) error) error {
 	return tasks.Wait()
 }
 
-// Down implements Service.Down. It stops any containers related to the service.
+// Stop implements Service.Stop. It stops any containers related to the service.
+func (s *Service) Stop() error {
+	return s.eachContainer(func(c *Container) error {
+		return c.Stop()
+	})
+}
+
+// Down implements Service.Down. It stops any containers related to the service and removes them.
 func (s *Service) Down() error {
 	return s.eachContainer(func(c *Container) error {
 		return c.Down()

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -159,8 +159,6 @@ func (s *RunSuite) createCommand(c *C, projectName, command string, argsAndInput
 
 	if command == "up" {
 		args = append(args, "-d")
-	} else if command == "down" {
-		args = append(args, "--timeout", "0")
 	} else if command == "restart" {
 		args = append(args, "--timeout", "0")
 	} else if command == "stop" {

--- a/integration/down_test.go
+++ b/integration/down_test.go
@@ -17,7 +17,20 @@ func (s *RunSuite) TestDown(c *C) {
 
 	s.FromText(c, p, "down", SimpleTemplate)
 
-	cn = s.GetContainerByName(c, name)
-	c.Assert(cn, NotNil)
-	c.Assert(cn.State.Running, Equals, false)
+	containers := s.GetContainersByProject(c, p)
+	c.Assert(len(containers), Equals, 0)
+}
+
+func (s *RunSuite) TestDownMultiple(c *C) {
+	p := s.ProjectFromText(c, "up", SimpleTemplate)
+
+	s.FromText(c, p, "scale", "hello=2", SimpleTemplate)
+
+	containers := s.GetContainersByProject(c, p)
+	c.Assert(len(containers), Equals, 2)
+
+	s.FromText(c, p, "down", SimpleTemplate)
+
+	containers = s.GetContainersByProject(c, p)
+	c.Assert(len(containers), Equals, 0)
 }

--- a/project/empty.go
+++ b/project/empty.go
@@ -24,6 +24,11 @@ func (e *EmptyService) Start() error {
 	return nil
 }
 
+// Stop implements Service.Stop() but does nothing.
+func (e *EmptyService) Stop() error {
+	return nil
+}
+
 // Down implements Service.Down but does nothing.
 func (e *EmptyService) Down() error {
 	return nil

--- a/project/project.go
+++ b/project/project.go
@@ -183,7 +183,16 @@ func (p *Project) Create(services ...string) error {
 	}), nil)
 }
 
-// Down stops the specified services (like docker stop).
+// Stop stops the specified services (like docker stop).
+func (p *Project) Stop(services ...string) error {
+	return p.perform(EventProjectStopStart, EventProjectStopDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		wrapper.Do(nil, EventServiceStopStart, EventServiceStop, func(service Service) error {
+			return service.Stop()
+		})
+	}), nil)
+}
+
+// Down stops the specified services and clean related containers (like docker stop + docker rm).
 func (p *Project) Down(services ...string) error {
 	return p.perform(EventProjectDownStart, EventProjectDownDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
 		wrapper.Do(nil, EventServiceDownStart, EventServiceDown, func(service Service) error {

--- a/project/types.go
+++ b/project/types.go
@@ -36,6 +36,8 @@ const (
 	EventServicePause        = EventType(iota)
 	EventServiceUnpauseStart = EventType(iota)
 	EventServiceUnpause      = EventType(iota)
+	EventServiceStopStart    = EventType(iota)
+	EventServiceStop         = EventType(iota)
 
 	EventProjectDownStart     = EventType(iota)
 	EventProjectDownDone      = EventType(iota)
@@ -59,6 +61,8 @@ const (
 	EventProjectPauseDone     = EventType(iota)
 	EventProjectUnpauseStart  = EventType(iota)
 	EventProjectUnpauseDone   = EventType(iota)
+	EventProjectStopStart     = EventType(iota)
+	EventProjectStopDone      = EventType(iota)
 )
 
 func (e EventType) String() string {
@@ -85,6 +89,10 @@ func (e EventType) String() string {
 		m = "Deleting"
 	case EventServiceDelete:
 		m = "Deleted"
+	case EventServiceStopStart:
+		m = "Stopping"
+	case EventServiceStop:
+		m = "Stopped"
 	case EventServiceDownStart:
 		m = "Stopping"
 	case EventServiceDown:
@@ -113,6 +121,10 @@ func (e EventType) String() string {
 	case EventProjectDownStart:
 		m = "Stopping project"
 	case EventProjectDownDone:
+		m = "Project stopped"
+	case EventProjectStopStart:
+		m = "Stopping project"
+	case EventProjectStopDone:
 		m = "Project stopped"
 	case EventProjectCreateStart:
 		m = "Creating project"
@@ -249,6 +261,7 @@ type Service interface {
 	Create() error
 	Up() error
 	Start() error
+	Stop() error
 	Down() error
 	Delete() error
 	Restart() error


### PR DESCRIPTION
In docker-compose, stop and down commands are different, and so should they in libcompose. This is spliting down and stop commands 🐼.

- stop just stops the services
- down stops the services and remove the related containers

/cc @kunalkushwaha @ibuildthecloud @dnephin @joshwget 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>