### PR TITLE
Fix the `volumes_from` behaviour

### DIFF
--- a/integration/assets/regression/60-volume_from.yml
+++ b/integration/assets/regression/60-volume_from.yml
@@ -1,0 +1,9 @@
+first:
+  image: busybox
+  volumes:
+    - /bundle
+second:
+  image: busybox
+  volumes_from:
+    - first
+

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"fmt"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"golang.org/x/net/context"
@@ -297,24 +296,6 @@ func (s *RunSuite) TestLink(c *C) {
 		fmt.Sprintf("/%s:/%s/%s", serverName, clientName, "server"),
 		fmt.Sprintf("/%s:/%s/%s", serverName, clientName, serverName),
 	}))
-}
-
-func (s *RunSuite) TestRelativeVolume(c *C) {
-	p := s.ProjectFromText(c, "up", `
-	server:
-	  image: busybox
-	  volumes:
-	    - .:/path
-	`)
-
-	absPath, err := filepath.Abs(".")
-	c.Assert(err, IsNil)
-	serverName := fmt.Sprintf("%s_%s_1", p, "server")
-	cn := s.GetContainerByName(c, serverName)
-
-	c.Assert(cn, NotNil)
-	c.Assert(len(cn.Mounts), DeepEquals, 1)
-	c.Assert(cn.Mounts[0].Source, DeepEquals, absPath)
 }
 
 func (s *RunSuite) TestUpNoBuildFailIfImageNotPresent(c *C) {

--- a/integration/volume_test.go
+++ b/integration/volume_test.go
@@ -1,0 +1,43 @@
+package integration
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *RunSuite) TestVolumeFromService(c *C) {
+	p := s.RandomProject()
+	cmd := exec.Command(s.command, "-f", "./assets/regression/60-volume_from.yml", "-p", p, "create")
+	err := cmd.Run()
+	c.Assert(err, IsNil)
+
+	volumeFromContainer := fmt.Sprintf("%s_%s_1", p, "first")
+	secondContainerName := p + "_second_1"
+
+	cn := s.GetContainerByName(c, secondContainerName)
+	c.Assert(cn, NotNil)
+
+	c.Assert(len(cn.HostConfig.VolumesFrom), Equals, 1)
+	c.Assert(cn.HostConfig.VolumesFrom[0], Equals, volumeFromContainer)
+}
+
+func (s *RunSuite) TestRelativeVolume(c *C) {
+	p := s.ProjectFromText(c, "up", `
+	server:
+	  image: busybox
+	  volumes:
+	    - .:/path
+	`)
+
+	absPath, err := filepath.Abs(".")
+	c.Assert(err, IsNil)
+	serverName := fmt.Sprintf("%s_%s_1", p, "server")
+	cn := s.GetContainerByName(c, serverName)
+
+	c.Assert(cn, NotNil)
+	c.Assert(len(cn.Mounts), DeepEquals, 1)
+	c.Assert(cn.Mounts[0].Source, DeepEquals, absPath)
+}


### PR DESCRIPTION
If it correspond to a service, it will get the container name from it, otherwise it will be used directly as is (and fail if not present) 🐹.

- [x] Add some integration test (based on `60-volume_from`).

Closes #60 

/cc @dnephin @joshwget @ibuildthecloud 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>