### PR TITLE
Enable race detector on unit tests… and fixes races

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -47,7 +47,7 @@ func WithProject(factory ProjectFactory, action ProjectAction) func(context *cli
 func ProjectPs(p *project.Project, c *cli.Context) {
 	allInfo := project.InfoSet{}
 	qFlag := c.Bool("q")
-	for name := range p.Configs {
+	for _, name := range p.Configs.Keys() {
 		service, err := p.CreateService(name)
 		if err != nil {
 			logrus.Fatal(err)
@@ -147,7 +147,7 @@ func ProjectRun(p *project.Project, c *cli.Context) {
 	serviceName := c.Args()[0]
 	commandParts := c.Args()[1:]
 
-	if _, ok := p.Configs[serviceName]; !ok {
+	if !p.Configs.Has(serviceName) {
 		logrus.Fatalf("%s is not defined in the template", serviceName)
 	}
 
@@ -263,7 +263,7 @@ func ProjectScale(p *project.Project, c *cli.Context) {
 			logrus.Fatalf("Invalid scale parameter: %v", err)
 		}
 
-		if _, ok := p.Configs[name]; !ok {
+		if !p.Configs.Has(name) {
 			logrus.Fatalf("%s is not defined in the template", name)
 		}
 

--- a/docker/builder.go
+++ b/docker/builder.go
@@ -97,8 +97,8 @@ func (d *DaemonBuilder) Build(imageName string, p *project.Project, service proj
 // CreateTar create a build context tar for the specified project and service name.
 func CreateTar(p *project.Project, name string) (io.ReadCloser, error) {
 	// This code was ripped off from docker/api/client/build.go
+	serviceConfig, _ := p.Configs.Get(name)
 
-	serviceConfig := p.Configs[name]
 	root := serviceConfig.Build
 	dockerfileName := filepath.Join(root, serviceConfig.Dockerfile)
 

--- a/docker/container.go
+++ b/docker/container.go
@@ -553,7 +553,7 @@ func (c *Container) populateAdditionalHostConfig(hostConfig *container.HostConfi
 	links := map[string]string{}
 
 	for _, link := range c.service.DependentServices() {
-		if _, ok := c.service.context.Project.Configs[link.Target]; !ok {
+		if !c.service.context.Project.Configs.Has(link.Target) {
 			continue
 		}
 

--- a/docker/convert.go
+++ b/docker/convert.go
@@ -198,10 +198,10 @@ func Convert(c *project.ServiceConfig, ctx project.Context) (*container.Config, 
 	return config, hostConfig, nil
 }
 
-func getVolumesFrom(volumesFrom []string, services map[string]*project.ServiceConfig, projectName string) ([]string, error) {
+func getVolumesFrom(volumesFrom []string, serviceConfigs *project.Configs, projectName string) ([]string, error) {
 	volumes := []string{}
 	for _, volumeFrom := range volumesFrom {
-		if _, ok := services[volumeFrom]; ok {
+		if serviceConfigs.Has(volumeFrom) {
 			// It's a service - Use the first one
 			name := fmt.Sprintf("%s_%s_1", projectName, volumeFrom)
 			volumes = append(volumes, name)

--- a/project/listener.go
+++ b/project/listener.go
@@ -70,7 +70,7 @@ func (d *defaultListener) start() {
 		if event.ServiceName == "" {
 			logf("Project [%s]: %s %s", d.project.Name, event.EventType, buffer.Bytes())
 		} else {
-			logf("[%d/%d] [%s]: %s %s", d.upCount, len(d.project.Configs), event.ServiceName, event.EventType, buffer.Bytes())
+			logf("[%d/%d] [%s]: %s %s", d.upCount, d.project.Configs.Len(), event.ServiceName, event.EventType, buffer.Bytes())
 		}
 	}
 }

--- a/project/merge.go
+++ b/project/merge.go
@@ -57,9 +57,9 @@ func mergeProject(p *Project, file string, bytes []byte) (map[string]*ServiceCon
 			return nil, err
 		}
 
-		if _, ok := p.Configs[name]; ok {
+		if serviceConfig, ok := p.Configs.Get(name); ok {
 			var rawExistingService RawService
-			if err := utils.Convert(p.Configs[name], &rawExistingService); err != nil {
+			if err := utils.Convert(serviceConfig, &rawExistingService); err != nil {
 				return nil, err
 			}
 

--- a/project/project.go
+++ b/project/project.go
@@ -39,7 +39,7 @@ type serviceAction func(service Service) error
 func NewProject(context *Context) *Project {
 	p := &Project{
 		context: context,
-		Configs: make(map[string]*ServiceConfig),
+		Configs: NewConfigs(),
 	}
 
 	if context.LoggerFactory == nil {
@@ -87,7 +87,7 @@ func (p *Project) Parse() error {
 // CreateService creates a service with the specified name based. If there
 // is no config in the project for this service, it will return an error.
 func (p *Project) CreateService(name string) (Service, error) {
-	existing, ok := p.Configs[name]
+	existing, ok := p.Configs.Get(name)
 	if !ok {
 		return nil, fmt.Errorf("Failed to find service: %s", name)
 	}
@@ -122,7 +122,7 @@ func (p *Project) CreateService(name string) (Service, error) {
 func (p *Project) AddConfig(name string, config *ServiceConfig) error {
 	p.Notify(EventServiceAdd, name, nil)
 
-	p.Configs[name] = config
+	p.Configs.Add(name, config)
 	p.reload = append(p.reload, name)
 
 	return nil
@@ -415,7 +415,7 @@ func (p *Project) traverse(start bool, selected map[string]bool, wrappers map[st
 	wrapperList := []string{}
 
 	if start {
-		for name := range p.Configs {
+		for _, name := range p.Configs.Keys() {
 			wrapperList = append(wrapperList, name)
 		}
 	} else {

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -59,8 +59,10 @@ func TestTwoCall(t *testing.T) {
 	p := NewProject(&Context{
 		ServiceFactory: factory,
 	})
-	p.Configs = map[string]*ServiceConfig{
-		"foo": {},
+	p.Configs = &Configs{
+		m: map[string]*ServiceConfig{
+			"foo": {},
+		},
 	}
 
 	if err := p.Create("foo"); err != nil {
@@ -137,13 +139,15 @@ func TestEnvironmentResolve(t *testing.T) {
 		ServiceFactory:    factory,
 		EnvironmentLookup: &TestEnvironmentLookup{},
 	})
-	p.Configs = map[string]*ServiceConfig{
-		"foo": {
-			Environment: NewMaporEqualSlice([]string{
-				"A",
-				"A=",
-				"A=B",
-			}),
+	p.Configs = &Configs{
+		m: map[string]*ServiceConfig{
+			"foo": {
+				Environment: NewMaporEqualSlice([]string{
+					"A",
+					"A=",
+					"A=B",
+				}),
+			},
 		},
 	}
 
@@ -186,9 +190,10 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, "busybox", p.Configs["multiple"].Image)
-	assert.Equal(t, "multi", p.Configs["multiple"].ContainerName)
-	assert.Equal(t, []string{"8000", "9000"}, p.Configs["multiple"].Ports)
+	multipleConfig, _ := p.Configs.Get("multiple")
+	assert.Equal(t, "busybox", multipleConfig.Image)
+	assert.Equal(t, "multi", multipleConfig.ContainerName)
+	assert.Equal(t, []string{"8000", "9000"}, multipleConfig.Ports)
 
 	p = NewProject(&Context{
 		ComposeBytes: [][]byte{configTwo, configOne},
@@ -198,9 +203,10 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, "tianon/true", p.Configs["multiple"].Image)
-	assert.Equal(t, "multi", p.Configs["multiple"].ContainerName)
-	assert.Equal(t, []string{"9000", "8000"}, p.Configs["multiple"].Ports)
+	multipleConfig, _ = p.Configs.Get("multiple")
+	assert.Equal(t, "tianon/true", multipleConfig.Image)
+	assert.Equal(t, "multi", multipleConfig.ContainerName)
+	assert.Equal(t, []string{"9000", "8000"}, multipleConfig.Ports)
 
 	p = NewProject(&Context{
 		ComposeBytes: [][]byte{configOne, configTwo, configThree},
@@ -210,8 +216,9 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	assert.Nil(t, err)
 
-	assert.Equal(t, "busybox", p.Configs["multiple"].Image)
-	assert.Equal(t, "multi", p.Configs["multiple"].ContainerName)
-	assert.Equal(t, []string{"8000", "9000", "10000"}, p.Configs["multiple"].Ports)
-	assert.Equal(t, int64(40000000), p.Configs["multiple"].MemLimit)
+	multipleConfig, _ = p.Configs.Get("multiple")
+	assert.Equal(t, "busybox", multipleConfig.Image)
+	assert.Equal(t, "multi", multipleConfig.ContainerName)
+	assert.Equal(t, []string{"8000", "9000", "10000"}, multipleConfig.Ports)
+	assert.Equal(t, int64(40000000), multipleConfig.MemLimit)
 }

--- a/project/utils.go
+++ b/project/utils.go
@@ -61,7 +61,7 @@ func GetContainerFromIpcLikeConfig(p *Project, conf string) string {
 		return ""
 	}
 
-	if _, ok := p.Configs[name]; ok {
+	if p.Configs.Has(name) {
 		return name
 	}
 	return ""

--- a/script/test-unit
+++ b/script/test-unit
@@ -28,16 +28,28 @@ fi
 
 TESTS_FAILED=()
 
+set +e
 for dir in $TESTDIRS; do
     echo '+ go test' $TESTFLAGS "${LIBCOMPOSE_PKG}/${dir#./}"
     go test ${TESTFLAGS} "${LIBCOMPOSE_PKG}/${dir#./}"
     if [ $? != 0 ]; then
         TESTS_FAILED+=("$dir")
         echo
-        echo "${RED}Tests failed: $dir${TEXTRESET}"
+        echo "${RED}Tests failed: ${LIBCOMPOSE_PKG}${TEXTRESET}"
         sleep 1 # give it a second, so observers watching can take note
+    else
+        echo '+ go test -race' $TESTFLAGS "${LIBCOMPOSE_PKG}/${dir#./}"
+        go test -race ${TESTFLAGS} "${LIBCOMPOSE_PKG}/${dir#./}"
+        if [ $? != 0 ]; then
+            TESTS_FAILED+=("$dir")
+            echo
+            echo "${RED}Tests failed (race): ${LIBCOMPOSE_PKG}${TEXTRESET}"
+            sleep 1 # give it a second, so observers watching can take note
+        fi
     fi
 done
+set -e
+
 echo
 
 # if some tests fail, we want the bundlescript to fail, but we want to

--- a/utils/util_inparallel_test.go
+++ b/utils/util_inparallel_test.go
@@ -1,0 +1,84 @@
+// +build !race
+
+package utils
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+type safeMap struct {
+	mu sync.RWMutex
+	m  map[int]bool
+}
+
+func (s *safeMap) Add(index int, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.m[index] = ok
+}
+
+func (s *safeMap) Read() map[int]bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.m
+}
+
+func TestInParallel(t *testing.T) {
+	size := 5
+	booleanMap := safeMap{
+		m: make(map[int]bool, size+1),
+	}
+	tasks := InParallel{}
+	for i := 0; i < size; i++ {
+		task := func(index int) func() error {
+			return func() error {
+				booleanMap.Add(index, true)
+				return nil
+			}
+		}(i)
+		tasks.Add(task)
+	}
+	err := tasks.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Make sure every value is true
+	for _, value := range booleanMap.Read() {
+		if !value {
+			t.Fatalf("booleanMap expected to contain only true values, got at least one false")
+		}
+	}
+}
+
+func TestInParallelError(t *testing.T) {
+	size := 5
+	booleanMap := safeMap{
+		m: make(map[int]bool, size+1),
+	}
+	tasks := InParallel{}
+	for i := 0; i < size; i++ {
+		task := func(index int) func() error {
+			return func() error {
+				booleanMap.Add(index, true)
+				t.Log("index", index)
+				if index%2 == 0 {
+					t.Log("return an error for", index)
+					return fmt.Errorf("Error with %v", index)
+				}
+				return nil
+			}
+		}(i)
+		tasks.Add(task)
+	}
+	err := tasks.Wait()
+	if err == nil {
+		t.Fatalf("Expected an error on Wait, got nothing.")
+	}
+	for key, value := range booleanMap.Read() {
+		if key%2 != 0 && !value {
+			t.Fatalf("booleanMap expected to contain true values on odd number, got %v", booleanMap)
+		}
+	}
+}

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -17,58 +17,6 @@ type jsonto struct {
 	Elt3 int
 }
 
-func TestInParallel(t *testing.T) {
-	size := 5
-	booleanMap := make(map[int]bool, size+1)
-	tasks := InParallel{}
-	for i := 0; i < size; i++ {
-		task := func(index int) func() error {
-			return func() error {
-				booleanMap[index] = true
-				return nil
-			}
-		}(i)
-		tasks.Add(task)
-	}
-	err := tasks.Wait()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Make sure every value is true
-	for _, value := range booleanMap {
-		if !value {
-			t.Fatalf("booleanMap expected to contain only true values, got at least one false")
-		}
-	}
-}
-
-func TestInParallelError(t *testing.T) {
-	size := 5
-	booleanMap := make(map[int]bool, size+1)
-	tasks := InParallel{}
-	for i := 0; i < size; i++ {
-		task := func(index int) func() error {
-			return func() error {
-				booleanMap[index] = true
-				if index%2 == 0 {
-					return fmt.Errorf("Error with %v", index)
-				}
-				return nil
-			}
-		}(i)
-		tasks.Add(task)
-	}
-	err := tasks.Wait()
-	if err == nil {
-		t.Fatalf("Expected an error on Wait, got nothing.")
-	}
-	for key, value := range booleanMap {
-		if key%2 != 0 && !value {
-			t.Fatalf("booleanMap expected to contain true values on odd number, got %v", booleanMap)
-		}
-	}
-}
-
 func TestConvertByJSON(t *testing.T) {
 	valids := []struct {
 		src      jsonfrom


### PR DESCRIPTION
This fixes several data races 🐍 :
- with `Project.Configs` which is read and written from a bunch of methods, in different goroutines.
- with `TestInParallel*` tests. These are tricky with race detector, as `InParallel` relies on `sync.Pool` ; and `sync.Pool` is no-op when running with race detector, so thoses two test should be skipped with the race detector enabled.

This also update test-unit bundle to run unit tests with and without the race detector 🐙.

🐸