### PR TITLE
Remove go get golang.org/x/tools/cmd/vet from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN go get github.com/mitchellh/gox
 RUN go get github.com/aktau/github-release
 RUN go get golang.org/x/tools/cmd/cover
 RUN go get github.com/golang/lint/golint
-RUN go get golang.org/x/tools/cmd/vet
 
 # virtualenv is necessary to run acceptance tests
 RUN apt-get install -y python-setuptools


### PR DESCRIPTION
This should fix the build failures :sweat: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>