### PR TITLE
Bump candiedyaml

### DIFF
--- a/script/vendor.sh
+++ b/script/vendor.sh
@@ -25,7 +25,7 @@ clone git golang.org/x/crypto 4d48e5fa3d62b5e6e71260571bf76c767198ca02 https://g
 clone git golang.org/x/net 47990a1ba55743e6ef1affd3a14e5bac8553615d https://github.com/golang/net.git
 clone git gopkg.in/check.v1 11d3bc7aa68e238947792f30573146a3231fc0f1
 clone git github.com/Azure/go-ansiterm 70b2c90b260171e829f1ebd7c17f600c11858dbe
-clone git github.com/cloudfoundry-incubator/candiedyaml 55a459c2d9da2b078f0725e5fb324823b2c71702
+clone git github.com/cloudfoundry-incubator/candiedyaml 5cef21e2e4f0fd147973b558d4db7395176bcd95
 clone git github.com/Microsoft/go-winio v0.1.0
 clone git github.com/xeipuuv/gojsonpointer e0fe6f68307607d540ed8eac07a342c33fa1b54a
 clone git github.com/xeipuuv/gojsonreference e02fc20de94c78484cd5ffb007f8af96be030a45

--- a/vendor/github.com/cloudfoundry-incubator/candiedyaml/LICENSE
+++ b/vendor/github.com/cloudfoundry-incubator/candiedyaml/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -175,29 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-   

--- a/vendor/github.com/cloudfoundry-incubator/candiedyaml/README.md
+++ b/vendor/github.com/cloudfoundry-incubator/candiedyaml/README.md
@@ -25,7 +25,8 @@ func main() {
     println("File does not exist:", err.Error())
     os.Exit(1)
   }
-  
+  defer file.Close()
+
   document := new(interface{})
   decoder := candiedyaml.NewDecoder(file)
   err = decoder.Decode(document)
@@ -41,7 +42,8 @@ func main() {
     println("Failed to open file for writing:", err.Error())
     os.Exit(1)
   }
-  
+  defer fileToWrite.Close()
+
   encoder := candiedyaml.NewEncoder(fileToWrite)
   err = encoder.Encode(document)
 

--- a/vendor/github.com/cloudfoundry-incubator/candiedyaml/decode.go
+++ b/vendor/github.com/cloudfoundry-incubator/candiedyaml/decode.go
@@ -572,7 +572,7 @@ func (d *Decoder) scalarInterface() interface{} {
 	return v
 }
 
-// arrayInterface is like array but returns []interface{}.
+// sequenceInterface is like sequence but returns []interface{}.
 func (d *Decoder) sequenceInterface() []interface{} {
 	var v = make([]interface{}, 0)
 
@@ -595,7 +595,7 @@ done:
 	return v
 }
 
-// objectInterface is like object but returns map[string]interface{}.
+// mappingInterface is like mapping but returns map[interface{}]interface{}.
 func (d *Decoder) mappingInterface() map[interface{}]interface{} {
 	m := make(map[interface{}]interface{})
 

--- a/vendor/github.com/cloudfoundry-incubator/candiedyaml/emitter.go
+++ b/vendor/github.com/cloudfoundry-incubator/candiedyaml/emitter.go
@@ -1276,7 +1276,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 
 	for i, w := 0, 0; i < len(value); i += w {
 		w = width(value[i])
-		followed_by_whitespace = i+w >= len(value) || is_blankz_at(value, w)
+		followed_by_whitespace = i+w >= len(value) || is_blankz_at(value, i+w)
 
 		if i == 0 {
 			switch value[i] {

--- a/vendor/github.com/cloudfoundry-incubator/candiedyaml/resolver.go
+++ b/vendor/github.com/cloudfoundry-incubator/candiedyaml/resolver.go
@@ -323,7 +323,7 @@ func resolve_time(val string, v reflect.Value, event yaml_event_t) (string, erro
 	} else {
 		matches = timestamp_regexp.FindStringSubmatch(val)
 		if len(matches) == 0 {
-			return "", fmt.Errorf("Invalid timestap: '%s' at %s", val, event.start_mark)
+			return "", fmt.Errorf("Invalid timestamp: '%s' at %s", val, event.start_mark)
 		}
 
 		year, _ := strconv.Atoi(matches[1])

--- a/vendor/github.com/cloudfoundry-incubator/candiedyaml/scanner.go
+++ b/vendor/github.com/cloudfoundry-incubator/candiedyaml/scanner.go
@@ -909,7 +909,7 @@ func yaml_parser_fetch_next_token(parser *yaml_parser_t) bool {
 		b == '@' || b == '`') ||
 		(b == '-' && !is_blank(buf[pos+1])) ||
 		(parser.flow_level == 0 &&
-			(buf[pos] == '?' || buf[pos+1] == ':') &&
+			(buf[pos] == '?' || buf[pos] == ':') &&
 			!is_blank(buf[pos+1])) {
 		return yaml_parser_fetch_plain_scalar(parser)
 	}

--- a/vendor/github.com/cloudfoundry-incubator/candiedyaml/tags.go
+++ b/vendor/github.com/cloudfoundry-incubator/candiedyaml/tags.go
@@ -306,10 +306,27 @@ func typeByIndex(t reflect.Type, index []int) reflect.Type {
 // It implements the methods to sort by string.
 type stringValues []reflect.Value
 
-func (sv stringValues) Len() int           { return len(sv) }
-func (sv stringValues) Swap(i, j int)      { sv[i], sv[j] = sv[j], sv[i] }
-func (sv stringValues) Less(i, j int) bool { return sv.get(i) < sv.get(j) }
-func (sv stringValues) get(i int) string   { return sv[i].String() }
+func (sv stringValues) Len() int      { return len(sv) }
+func (sv stringValues) Swap(i, j int) { sv[i], sv[j] = sv[j], sv[i] }
+func (sv stringValues) Less(i, j int) bool {
+	av, ak := getElem(sv[i])
+	bv, bk := getElem(sv[j])
+	if ak == reflect.String && bk == reflect.String {
+		return av.String() < bv.String()
+	}
+
+	return ak < bk
+}
+
+func getElem(v reflect.Value) (reflect.Value, reflect.Kind) {
+	k := v.Kind()
+	for k == reflect.Interface || k == reflect.Ptr && !v.IsNil() {
+		v = v.Elem()
+		k = v.Kind()
+	}
+
+	return v, k
+}
 
 // parseTag splits a struct field's json tag into its name and
 // comma-separated options.


### PR DESCRIPTION
As suggested in #173, I fixed the underlying issue in candiedyaml that was causing certain strings to be incorrectly parsed as maps. Since then I've also noticed that libcompose fails to parse strings that begin with a colon, so I put in a PR to address that issue too.

This bump includes both of the fixes, so libcompose shouldn't run into those parsing problems anymore.

Signed-off-by: Josh Curl <hello@joshcurl.com>