### PR TITLE
Only resolve relative volumes if a Compose file is specified

### DIFF
--- a/docker/convert.go
+++ b/docker/convert.go
@@ -58,11 +58,13 @@ func ConvertToAPI(s *Service) (*ConfigWrapper, error) {
 func volumes(c *config.ServiceConfig, ctx project.Context) map[string]struct{} {
 	volumes := make(map[string]struct{}, len(c.Volumes))
 	for k, v := range c.Volumes {
-		vol := ctx.ResourceLookup.ResolvePath(v, ctx.ComposeFiles[0])
+		if len(ctx.ComposeFiles) > 0 {
+			v = ctx.ResourceLookup.ResolvePath(v, ctx.ComposeFiles[0])
+		}
 
-		c.Volumes[k] = vol
-		if isVolume(vol) {
-			volumes[vol] = struct{}{}
+		c.Volumes[k] = v
+		if isVolume(v) {
+			volumes[v] = struct{}{}
 		}
 	}
 	return volumes

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -1,0 +1,29 @@
+package integration
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/docker/libcompose/docker"
+	"github.com/docker/libcompose/project"
+)
+
+func (s *RunSuite) TestVolumeWithoutComposeFile(c *C) {
+	service := `
+service:
+  image: busybox
+  command: echo Hello world!
+  volumes:
+    - /etc/selinux:/etc/selinux`
+
+	project, err := docker.NewProject(&docker.Context{
+		Context: project.Context{
+			ComposeBytes: [][]byte{[]byte(service)},
+			ProjectName:  "test-volume-without-compose-file",
+		},
+	})
+
+	c.Assert(err, IsNil)
+
+	err = project.Up()
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Relative volumes are currently based on the path of the first Compose file. If libcompose is used as a library and a Compose file isn't specified then this causes a panic.

This checks to see if a Compose file was specified, and if not then it skips attempting to resolve relative volumes.

```
package main

import (
	"log"

	"github.com/docker/libcompose/docker"
	"github.com/docker/libcompose/project"
)

func main() {
	service := `
service:
  image: ubuntu
  command: echo Hello world!
  volumes:
    - /etc/selinux:/etc/selinux`

	project, err := docker.NewProject(&docker.Context{
		Context: project.Context{
			ComposeBytes: [][]byte{[]byte(service)},
			ProjectName:  "yeah-compose",
		},
	})

	if err != nil {
		log.Fatal(err)
	}

	project.Up()
}
```

```
panic: runtime error: index out of range

goroutine 15 [running]:
panic(0x912960, 0xc82000a0f0)
	/usr/local/go/src/runtime/panic.go:464 +0x3e6
github.com/docker/libcompose/docker.volumes(0xc82039d180, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc8202ce3e0, 0x1, ...)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/convert.go:61 +0x2c5
github.com/docker/libcompose/docker.Convert(0xc82039d180, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc8202ce3e0, 0x1, ...)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/convert.go:148 +0x541
github.com/docker/libcompose/docker.ConvertToAPI(0xc820373420, 0xc8203c4f50, 0x0, 0x0)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/convert.go:46 +0x63
github.com/docker/libcompose/docker.(*Container).createContainer(0xc8203f0150, 0xc820390c08, 0x6, 0xc8202f8780, 0x40, 0x0, 0x23, 0x0, 0x0)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/container.go:500 +0xf9
github.com/docker/libcompose/docker.(*Container).Recreate(0xc8203f0150, 0xc820390c08, 0x6, 0x1, 0x0, 0x0)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/container.go:150 +0x888
github.com/docker/libcompose/docker.(*Service).recreateIfNeeded(0xc820373420, 0xc820390c08, 0x6, 0xc8203f0150, 0x0, 0x0)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/service.go:297 +0x507
github.com/docker/libcompose/docker.(*Service).up.func1(0xc8203f0150, 0x0, 0x0)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/service.go:272 +0x6f
github.com/docker/libcompose/docker.(*Service).eachContainer.func1.1(0x0, 0x0)
	/home/joshwget/go/src/github.com/docker/libcompose/docker/service.go:315 +0x33
github.com/docker/libcompose/utils.(*InParallel).Add.func1(0xc8203f0180, 0xc820426040)
	/home/joshwget/go/src/github.com/docker/libcompose/utils/util.go:26 +0x54
created by github.com/docker/libcompose/utils.(*InParallel).Add
	/home/joshwget/go/src/github.com/docker/libcompose/utils/util.go:30 +0x5d
```

Signed-off-by: Josh Curl <hello@joshcurl.com>