### PR TITLE
Add support to test against multiple daemon version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,21 @@ RUN set -e; \
 # Set the default Docker to be run
 RUN ln -s /usr/local/bin/docker-${DEFAULT_DOCKER_VERSION} /usr/local/bin/docker
 
+WORKDIR /go/src/github.com/docker/libcompose
+
+# Compose COMMIT for acceptance test version, update that commit when
+# you want to update the acceptance test version to support.
+ENV COMPOSE_COMMIT e2cb7b0237085415ce48900309a61c73b5938520
+RUN virtualenv venv && \
+    git clone https://github.com/docker/compose.git venv/compose && \
+    cd venv/compose && \
+    git checkout -q "$COMPOSE_COMMIT" && \
+    ../bin/pip install \
+               -r requirements.txt \
+               -r requirements-dev.txt
+
 ENV COMPOSE_BINARY /go/src/github.com/docker/libcompose/libcompose-cli
 ENV USER root
-
-WORKDIR /go/src/github.com/docker/libcompose
 
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["script/dind"]

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ LIBCOMPOSE_MOUNT := $(if $(BIND_DIR),-v "$(CURDIR)/$(BIND_DIR):/go/src/github.co
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 LIBCOMPOSE_IMAGE := libcompose-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 
-DOCKER_RUN_LIBCOMPOSE := docker run --rm -it --privileged $(LIBCOMPOSE_ENVS) $(LIBCOMPOSE_MOUNT) "$(LIBCOMPOSE_IMAGE)"
+DAEMON_VERSION := $(if $(DAEMON_VERSION),$(DAEMON_VERSION),"default")
+DOCKER_RUN_LIBCOMPOSE := docker run --rm -it --privileged -e DAEMON_VERSION="$(DAEMON_VERSION)" $(LIBCOMPOSE_ENVS) $(LIBCOMPOSE_MOUNT) "$(LIBCOMPOSE_IMAGE)"
 
 default: binary
 

--- a/script/.integration-daemon-start
+++ b/script/.integration-daemon-start
@@ -1,12 +1,11 @@
 #!/bin/bash
-
 # see test-integration-cli for example usage of this script
 
-export PATH="$ABS_DEST/../binary:$ABS_DEST/../dynbinary:$ABS_DEST/../gccgo:$ABS_DEST/../dyngccgo:$PATH"
+export PATH="$ABS_DEST/../binary:/usr/local/bin/docker-${DOCKER_DAEMON_VERSION}:$PATH"
 
 if ! command -v docker &> /dev/null; then
-	echo >&2 'error: binary or dynbinary must be run before .integration-daemon-start'
-	false
+    echo >&2 'error: binary must be run before .integration-daemon-start'
+    false
 fi
 
 # intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
@@ -18,43 +17,45 @@ export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
 # example usage: DOCKER_STORAGE_OPTS="dm.basesize=20G,dm.loopdatasize=200G"
 storage_params=""
 if [ -n "$DOCKER_STORAGE_OPTS" ]; then
-	IFS=','
-	for i in ${DOCKER_STORAGE_OPTS}; do
-		storage_params="--storage-opt $i $storage_params"
-	done
-	unset IFS
+    IFS=','
+    for i in ${DOCKER_STORAGE_OPTS}; do
+        storage_params="--storage-opt $i $storage_params"
+    done
+    unset IFS
 fi
 
 if [ -z "$DOCKER_TEST_HOST" ]; then
-	export DOCKER_HOST="unix://$(cd "$DEST" && pwd)/docker.sock" # "pwd" tricks to make sure $DEST is an absolute path, not a relative one
-	( set -x; exec \
-		docker daemon --debug \
-		--host "$DOCKER_HOST" \
-		--storage-driver "$DOCKER_GRAPHDRIVER" \
-		--pidfile "$DEST/docker.pid" \
-		--userland-proxy="$DOCKER_USERLANDPROXY" \
-		$storage_params \
-			&> "$DEST/docker.log"
-	) &
-	# make sure that if the script exits unexpectedly, we stop this daemon we just started
-	trap 'bundle .integration-daemon-stop' EXIT
+    export DOCKER_HOST="unix://$(cd "$DEST" && pwd)/docker.sock" # "pwd" tricks to make sure $DEST is an absolute path, not a relative one
+    ( set -x; exec \
+                  docker daemon --debug \
+                  --host "$DOCKER_HOST" \
+                  --storage-driver "$DOCKER_GRAPHDRIVER" \
+                  --pidfile "$DEST/docker.pid" \
+                  --userland-proxy="$DOCKER_USERLANDPROXY" \
+                  $storage_params \
+      &> "$DEST/docker.log"
+    ) &
+    # make sure that if the script exits unexpectedly, we stop this daemon we just started
+    trap 'bundle .integration-daemon-stop' EXIT
 else
-	export DOCKER_HOST="$DOCKER_TEST_HOST"
+    export DOCKER_HOST="$DOCKER_TEST_HOST"
 fi
 
 # give it a second to come up so it's "ready"
 tries=5
 while ! docker version &> /dev/null; do
-	(( tries-- ))
-	if [ $tries -le 0 ]; then
-		if [ -z "$DOCKER_HOST" ]; then
-			echo >&2 "error: daemon failed to start"
-			echo >&2 "  check $DEST/docker.log for details"
-		else
-			echo >&2 "error: daemon at $DOCKER_HOST fails to 'docker version':"
-			docker version >&2 || true
-		fi
-		false
-	fi
-	sleep 2
+    (( tries-- ))
+    if [ $tries -le 0 ]; then
+        if [ -z "$DOCKER_HOST" ]; then
+            echo >&2 "error: daemon failed to start"
+            echo >&2 "  check $DEST/docker.log for details"
+        else
+            echo >&2 "error: daemon at $DOCKER_HOST fails to 'docker version':"
+            docker version >&2 || true
+        fi
+        false
+    fi
+    sleep 2
 done
+
+docker version

--- a/script/.integration-daemon-start
+++ b/script/.integration-daemon-start
@@ -4,7 +4,7 @@
 export PATH="$ABS_DEST/../binary:/usr/local/bin/docker-${DOCKER_DAEMON_VERSION}:$PATH"
 
 if ! command -v docker &> /dev/null; then
-    echo >&2 'error: binary must be run before .integration-daemon-start'
+    echo >&2 'error: docker binary should be present to be able to run test-integration'
     false
 fi
 

--- a/script/dind
+++ b/script/dind
@@ -13,96 +13,17 @@ set -e
 # apparmor sucks and Docker needs to know that it's in a container (c) @tianon
 export container=docker
 
-# First, make sure that cgroups are mounted correctly.
-CGROUP=/cgroup
-
-mkdir -p "$CGROUP"
-
-if ! mountpoint -q "$CGROUP"; then
-	mount -n -t tmpfs -o uid=0,gid=0,mode=0755 cgroup $CGROUP || {
-		echo >&2 'Could not make a tmpfs mount. Did you use --privileged?'
-		exit 1
-	}
-fi
-
 if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
 	mount -t securityfs none /sys/kernel/security || {
 		echo >&2 'Could not mount /sys/kernel/security.'
-		echo >&2 'AppArmor detection and -privileged mode might break.'
+		echo >&2 'AppArmor detection and --privileged mode might break.'
 	}
 fi
 
-# Mount the cgroup hierarchies exactly as they are in the parent system.
-for HIER in $(cut -d: -f2 /proc/1/cgroup); do
-
-	# The following sections address a bug which manifests itself
-	# by a cryptic "lxc-start: no ns_cgroup option specified" when
-	# trying to start containers within a container.
-	# The bug seems to appear when the cgroup hierarchies are not
-	# mounted on the exact same directories in the host, and in the
-	# container.
-
-	SUBSYSTEMS="${HIER%name=*}"
-
-	# If cgroup hierarchy is named(mounted with "-o name=foo") we
-	# need to mount it in $CGROUP/foo to create exect same
-	# directoryes as on host. Else we need to mount it as is e.g.
-	# "subsys1,subsys2" if it has two subsystems
-
-	# Named, control-less cgroups are mounted with "-o name=foo"
-	# (and appear as such under /proc/<pid>/cgroup) but are usually
-	# mounted on a directory named "foo" (without the "name=" prefix).
-	# Systemd and OpenRC (and possibly others) both create such a
-	# cgroup. So just mount them on directory $CGROUP/foo.
-
-	OHIER=$HIER
-	HIER="${HIER#*name=}"
-
-	mkdir -p "$CGROUP/$HIER"
-
-	if ! mountpoint -q "$CGROUP/$HIER"; then
-		mount -n -t cgroup -o "$OHIER" cgroup "$CGROUP/$HIER"
-	fi
-
-	# Likewise, on at least one system, it has been reported that
-	# systemd would mount the CPU and CPU accounting controllers
-	# (respectively "cpu" and "cpuacct") with "-o cpuacct,cpu"
-	# but on a directory called "cpu,cpuacct" (note the inversion
-	# in the order of the groups). This tries to work around it.
-
-	if [ "$HIER" = 'cpuacct,cpu' ]; then
-		ln -s "$HIER" "$CGROUP/cpu,cpuacct"
-	fi
-
-	# If hierarchy has multiple subsystems, in /proc/<pid>/cgroup
-	# we will see ":subsys1,subsys2,subsys3,name=foo:" substring,
-	# we need to mount it to "$CGROUP/foo" and if there were no
-	# name to "$CGROUP/subsys1,subsys2,subsys3", so we must create
-	# symlinks for docker daemon to find these subsystems:
-	# ln -s $CGROUP/foo $CGROUP/subsys1
-	# ln -s $CGROUP/subsys1,subsys2,subsys3 $CGROUP/subsys1
-
-	if [ "$SUBSYSTEMS" != "${SUBSYSTEMS//,/ }" ]; then
-		SUBSYSTEMS="${SUBSYSTEMS//,/ }"
-		for SUBSYS in $SUBSYSTEMS
-		do
-			ln -s "$CGROUP/$HIER" "$CGROUP/$SUBSYS"
-		done
-	fi
-done
-
-# Note: as I write those lines, the LXC userland tools cannot setup
-# a "sub-container" properly if the "devices" cgroup is not in its
-# own hierarchy. Let's detect this and issue a warning.
-if ! grep -q :devices: /proc/1/cgroup; then
-	echo >&2 'WARNING: the "devices" cgroup should be in its own hierarchy.'
+# Mount /tmp (conditionally)
+if ! mountpoint -q /tmp; then
+	mount -t tmpfs none /tmp
 fi
-if ! grep -qw devices /proc/1/cgroup; then
-	echo >&2 'WARNING: it looks like the "devices" cgroup is not mounted.'
-fi
-
-# Mount /tmp
-mount -t tmpfs none /tmp
 
 if [ $# -gt 0 ]; then
 	exec "$@"

--- a/script/make.sh
+++ b/script/make.sh
@@ -5,19 +5,18 @@ export LIBCOMPOSE_PKG='github.com/docker/libcompose'
 
 # List of bundles to create when no argument is passed
 DEFAULT_BUNDLES=(
-	validate-gofmt
-	#validate-git-marks
-	validate-dco
-	validate-git-marks
-	validate-lint
-	validate-vet
-	binary
+    validate-gofmt
+    validate-dco
+    validate-git-marks
+    validate-lint
+    validate-vet
+    binary
 
-	test-unit
-	test-integration
-	test-acceptance
+    test-unit
+    test-integration
+    test-acceptance
 
-	cross-binary
+    cross-binary
 )
 bundle() {
     local bundle="$1"; shift

--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -4,14 +4,10 @@ set -e
 export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export DEST=.
 
-bundle .integration-daemon-start
+# Temporarly only test on DEFAULT_DOCKER_VERSION
+export DOCKER_DAEMON_VERSION="${DEFAULT_DOCKER_VERSION}"
 
-rm -rf venv
-virtualenv venv
-git clone https://github.com/docker/compose.git venv/compose
-venv/bin/pip install \
-    -r venv/compose/requirements.txt \
-    -r venv/compose/requirements-dev.txt
+bundle .integration-daemon-start
 
 cp bundles/libcompose-cli venv/bin/docker-compose
 . venv/bin/activate

--- a/script/test-integration
+++ b/script/test-integration
@@ -3,12 +3,33 @@
 export SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export DEST=.
 
-bundle .integration-daemon-start
-
 TESTFLAGS="$TESTFLAGS -test.timeout=30m -check.v"
 
-cd integration
-TESTVERBOSE=$TESTVERBOSE go test $TESTFLAGS
-cd ..
+run_integration_test() {
+    echo "Running integration test against ${DOCKER_DAEMON_VERSION}"
+    
+    bundle .integration-daemon-start
 
-bundle .integration-daemon-stop
+    cd integration
+    TESTVERBOSE=$TESTVERBOSE go test $TESTFLAGS
+    cd ..
+
+    bundle .integration-daemon-stop
+    
+    echo
+}
+
+if test -n "${DAEMON_VERSION}" && test "${DAEMON_VERSION}" != "all"; then
+    if test "${DAEMON_VERSION}" = "default"; then
+        DAEMON_VERSION="${DEFAULT_DOCKER_VERSION}"
+    fi
+    for version in $(echo ${DAEMON_VERSION} | cut -f1); do
+        DOCKER_DAEMON_VERSION="${version}" run_integration_test
+    done
+else
+    for version in $(echo ${DOCKER_VERSIONS} | cut -f1); do
+        DOCKER_DAEMON_VERSION="${version}" run_integration_test
+    done
+fi
+
+


### PR DESCRIPTION
You can specify against which "supported" daemon you want to be tested against (test-integration). It happens through the `DAEMON_VERSION` environment variables 🐳.

You can specify one or more value to it ; the only value supported are those in the Dockefile (`ENV DOCKER_VERSION …`). It will fail if the version is not found. Thus :

- `DAEMON_VERSION="1.9.1" make test-integration` will run integration tests against a 1.9.1 daemon
- `DAEMON_VERSION="1.10.3 1.11.0" make test-integration` will run integration tests against a 1.10.3 daemon and a 1.11.0 daemon.
- `DAEMON_VERSION="default" make test-integration` or `make test-integration` will run integration tests against the default daemon (specified in the the `Dockerfile`)

`DAEMON_VERSION="all"` or empty, it will test against all support daemon version. On the CI, `DAEMON_VERSION` is empty, thus testing against all supported version as well.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>