### PR TITLE
Run -race by default on test…

### DIFF
--- a/script/test-unit
+++ b/script/test-unit
@@ -30,20 +30,26 @@ TESTS_FAILED=()
 
 set +e
 for dir in $TESTDIRS; do
-    echo '+ go test' $TESTFLAGS "${LIBCOMPOSE_PKG}/${dir#./}"
-    go test ${TESTFLAGS} "${LIBCOMPOSE_PKG}/${dir#./}"
+    echo '+ go test -race' $TESTFLAGS "${LIBCOMPOSE_PKG}/${dir#./}"
+    go test -race ${TESTFLAGS} "${LIBCOMPOSE_PKG}/${dir#./}"
     if [ $? != 0 ]; then
         TESTS_FAILED+=("$dir")
         echo
         echo "${RED}Tests failed: ${LIBCOMPOSE_PKG}${TEXTRESET}"
         sleep 1 # give it a second, so observers watching can take note
-    else
-        echo '+ go test -race' $TESTFLAGS "${LIBCOMPOSE_PKG}/${dir#./}"
-        go test -race ${TESTFLAGS} "${LIBCOMPOSE_PKG}/${dir#./}"
+    fi
+done
+
+echo
+echo "Run non-race test (if any)"
+for dir in $TESTDIRS; do
+    if [ -n "$(grep --include '*_test.go' -l -ri '!race' ${dir})" ]; then
+        echo '+ go test ' $TESTFLAGS "${LIBCOMPOSE_PKG}/${dir#./}"
+        go test ${TESTFLAGS} "${LIBCOMPOSE_PKG}/${dir#./}"
         if [ $? != 0 ]; then
             TESTS_FAILED+=("$dir")
             echo
-            echo "${RED}Tests failed (race): ${LIBCOMPOSE_PKG}${TEXTRESET}"
+            echo "${RED}Tests failed: ${LIBCOMPOSE_PKG}${TEXTRESET}"
             sleep 1 # give it a second, so observers watching can take note
         fi
     fi


### PR DESCRIPTION
… and run test without race only when the build flag !race is set 🐼.

```
$ make test-unit
# […]
---> Making bundle: test-unit (in .)
+ go test -race -cover -coverprofile=cover.out github.com/docker/libcompose/config
ok      github.com/docker/libcompose/config     1.482s  coverage: 63.8% of statements
+ go test -race -cover -coverprofile=cover.out github.com/docker/libcompose/docker
ok      github.com/docker/libcompose/docker     1.048s  coverage: 6.5% of statements
+ go test -race -cover -coverprofile=cover.out github.com/docker/libcompose/lookup
ok      github.com/docker/libcompose/lookup     1.016s  coverage: 56.0% of statements
+ go test -race -cover -coverprofile=cover.out github.com/docker/libcompose/project
ok      github.com/docker/libcompose/project    1.112s  coverage: 35.7% of statements
+ go test -race -cover -coverprofile=cover.out github.com/docker/libcompose/utils
ok      github.com/docker/libcompose/utils      1.025s  coverage: 57.1% of statements
+ go test -race -cover -coverprofile=cover.out github.com/docker/libcompose/version
ok      github.com/docker/libcompose/version    1.008s  coverage: 0.0% of statements
+ go test -race -cover -coverprofile=cover.out github.com/docker/libcompose/yaml
ok      github.com/docker/libcompose/yaml       1.024s  coverage: 73.9% of statements

Run non-race test (if any)
+ go test  -cover -coverprofile=cover.out github.com/docker/libcompose/utils
ok      github.com/docker/libcompose/utils      0.011s  coverage: 76.8% of statements
```

🐸
Signed-off-by: Vincent Demeester <vincent@sbr.pm>