### PR TITLE
Define CI jobs in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,22 @@
+wrappedNode(label: 'linux && x86_64') {
+  deleteDir()
+  checkout scm
+  def image
+  try {
+    // TODO: split up into phases, create real test reports, etc.
+    stage "build image"
+    image = docker.build("dockerbuildbot/libcompose:${gitCommit()}")
+
+    stage "validate, test, build"
+    withEnv(["TESTVERBOSE=1", "LIBCOMPOSE_IMAGE=${image.id}"]) {
+      withChownWorkspace {
+        timeout(60) {
+          sh "make -e all"
+        }
+      }
+    }
+  } finally {
+    try { archive "bundles" } catch (Exception exc) {}
+    if (image) { sh "docker rmi ${image.id} ||:" }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
 LIBCOMPOSE_IMAGE := libcompose-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 
 DAEMON_VERSION := $(if $(DAEMON_VERSION),$(DAEMON_VERSION),"default")
-DOCKER_RUN_LIBCOMPOSE := docker run --rm -it --privileged -e DAEMON_VERSION="$(DAEMON_VERSION)" $(LIBCOMPOSE_ENVS) $(LIBCOMPOSE_MOUNT) "$(LIBCOMPOSE_IMAGE)"
+TTY := $(shell [ -t 0 ] && echo "-t")
+DOCKER_RUN_LIBCOMPOSE := docker run --rm -i $(TTY) --privileged -e DAEMON_VERSION="$(DAEMON_VERSION)" $(LIBCOMPOSE_ENVS) $(LIBCOMPOSE_MOUNT) "$(LIBCOMPOSE_IMAGE)"
 
 default: binary
 


### PR DESCRIPTION
The intent of this PR is to define the current CI jobs (located here: https://jenkins.dockerproject.org/view/Libcompose/) in a programmatic and source-controlled way. Once this is landed in master we could remove those existing jobs.

Additionally because this is defined in code we can implement and re-use common code across many projects as appropriate -- For example in this changeset you can see usage of `wrappedNode`, `withChownWorkspace`, and `gitCommit` which are defined in their respective groovy files [here](https://github.com/docker/jenkins-pipeline-scripts/tree/master/vars).

In the long run it would be good to expand this to take advantage of some of the parallelism features offered by the Jenkinsfile format and e.g. run the test suites in parallel. Another future improvement would be output proper test reports that can be recorded by Jenkins.