### PR TITLE
Call ProjectStop instead of Down in exitOnSignal

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -301,7 +301,7 @@ func exitOnSignal(p *project.Project, c *cli.Context) {
 	go func() {
 		for range signalChan {
 			fmt.Printf("\nGracefully stopping...\n")
-			ProjectDown(p, c)
+			ProjectStop(p, c)
 			cleanupDone <- true
 		}
 	}()


### PR DESCRIPTION
Signed-off-by: Vincent Demeester <vincent@sbr.pm>