### PR TITLE
Remove goroutine for logs and use ProjectLog

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -132,8 +132,11 @@ func ProjectUp(p *project.Project, c *cli.Context) {
 	if err != nil {
 		logrus.Fatal(err)
 	}
-
 	if !c.Bool("d") {
+		err = p.Log(c.Args()...)
+		if err != nil {
+			logrus.Fatal(err)
+		}
 		exitOnSignal(p, c)
 	}
 }

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -309,10 +309,8 @@ func Populate(context *project.Context, c *cli.Context) {
 	context.ProjectName = c.GlobalString("project-name")
 
 	if c.Command.Name == "logs" {
-		context.Log = true
 		context.FollowLog = c.Bool("follow")
 	} else if c.Command.Name == "up" || c.Command.Name == "create" {
-		context.Log = !c.Bool("d")
 		context.NoRecreate = c.Bool("no-recreate")
 		context.ForceRecreate = c.Bool("force-recreate")
 		context.NoBuild = c.Bool("no-build")

--- a/docker/container.go
+++ b/docker/container.go
@@ -405,12 +405,6 @@ func holdHijackedConnection(tty bool, inputStream io.ReadCloser, outputStream, e
 func (c *Container) Up(imageName string) error {
 	var err error
 
-	defer func() {
-		if err == nil && c.service.context.Log {
-			go c.Log()
-		}
-	}()
-
 	container, err := c.Create(imageName)
 	if err != nil {
 		return err

--- a/project/context.go
+++ b/project/context.go
@@ -20,7 +20,6 @@ var projectRegexp = regexp.MustCompile("[^a-zA-Z0-9_.-]")
 // the project name, the compose file, etc.
 type Context struct {
 	Timeout             uint
-	Log                 bool
 	FollowLog           bool
 	Volume              bool
 	ForceRecreate       bool


### PR DESCRIPTION
`Project.Up(…)` is now creating and starting the containers, no logs in goroutines. And this, `ProjectUp` (from `app.go`) is now calling `Project.Log(…)` after 🐼.

Makes it clearer (and even the logs look better).

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>