### PR TITLE
Refactor ProjectRun to stop if all container stop

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -314,6 +314,7 @@ func Populate(context *project.Context, c *cli.Context) {
 		context.NoRecreate = c.Bool("no-recreate")
 		context.ForceRecreate = c.Bool("force-recreate")
 		context.NoBuild = c.Bool("no-build")
+		context.FollowLog = !c.Bool("d")
 	} else if c.Command.Name == "stop" || c.Command.Name == "restart" || c.Command.Name == "scale" {
 		context.Timeout = uint(c.Int("timeout"))
 	} else if c.Command.Name == "kill" {


### PR DESCRIPTION
Aligning the behaviour to the current docker-compose 🐵. This fixes the hanging out of acceptance tests of log, now, run to handle.

🐸

The project package needs a whole lot more of refactoring, it will get there eventually.