### PR TITLE
Minimize usage of ContainerList

### DIFF
--- a/docker/functions.go
+++ b/docker/functions.go
@@ -1,8 +1,6 @@
 package docker
 
 import (
-	"fmt"
-
 	"golang.org/x/net/context"
 
 	"github.com/docker/engine-api/client"
@@ -12,7 +10,7 @@ import (
 
 // GetContainersByFilter looks up the hosts containers with the specified filters and
 // returns a list of container matching it, or an error.
-func GetContainersByFilter(client client.APIClient, containerFilters ...map[string][]string) ([]types.Container, error) {
+func GetContainersByFilter(clientInstance client.APIClient, containerFilters ...map[string][]string) ([]types.Container, error) {
 	filterArgs := filters.NewArgs()
 
 	// FIXME(vdemeester) I don't like 3 for loops >_<
@@ -24,50 +22,21 @@ func GetContainersByFilter(client client.APIClient, containerFilters ...map[stri
 		}
 	}
 
-	return client.ContainerList(context.Background(), types.ContainerListOptions{
+	return clientInstance.ContainerList(context.Background(), types.ContainerListOptions{
 		All:    true,
 		Filter: filterArgs,
 	})
 }
 
-// GetContainerByName looks up the hosts containers with the specified name and
-// returns it, or an error.
-func GetContainerByName(client client.APIClient, name string) (*types.Container, error) {
-	filterArgs := filters.NewArgs()
-	filterArgs.Add("name", fmt.Sprintf("%s", name))
-
-	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
-		All:    true,
-		Filter: filterArgs,
-	})
+// GetContainer looks up the hosts containers with the specified ID
+// or name and returns it, or an error.
+func GetContainer(clientInstance client.APIClient, id string) (*types.ContainerJSON, error) {
+	container, err := clientInstance.ContainerInspect(context.Background(), id)
 	if err != nil {
+		if client.IsErrContainerNotFound(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
-
-	if len(containers) == 0 {
-		return nil, nil
-	}
-
-	return &containers[0], nil
-}
-
-// GetContainerByID looks up the hosts containers with the specified Id and
-// returns it, or an error.
-func GetContainerByID(client client.APIClient, id string) (*types.Container, error) {
-	filterArgs := filters.NewArgs()
-	filterArgs.Add("id", id)
-
-	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
-		All:    true,
-		Filter: filterArgs,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	if len(containers) == 0 {
-		return nil, nil
-	}
-
-	return &containers[0], nil
+	return &container, nil
 }

--- a/docker/name.go
+++ b/docker/name.go
@@ -41,7 +41,7 @@ func NewNamer(client client.APIClient, project, service string) Namer {
 	go func() {
 		for i := 1; true; i++ {
 			name := fmt.Sprintf(format, project, service, i)
-			c, err := GetContainerByName(client, name)
+			c, err := GetContainer(client, name)
 			if err != nil {
 				// Sleep here to avoid crazy tight loop when things go south
 				time.Sleep(time.Second * 1)

--- a/docker/service.go
+++ b/docker/service.go
@@ -179,7 +179,7 @@ func (s *Service) constructContainers(imageName string, count int) ([]*Container
 			return nil, err
 		}
 
-		logrus.Debugf("Created container %s: %v", dockerContainer.ID, dockerContainer.Names)
+		logrus.Debugf("Created container %s: %v", dockerContainer.ID, dockerContainer.Name)
 
 		result = append(result, NewContainer(client, containerName, s))
 	}

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -158,19 +158,11 @@ func GetClient(c *C) client.APIClient {
 
 func (s *CliSuite) GetContainerByName(c *C, name string) *types.ContainerJSON {
 	client := GetClient(c)
-	container, err := docker.GetContainerByName(client, name)
+	container, err := docker.GetContainer(client, name)
 
 	c.Assert(err, IsNil)
 
-	if container == nil {
-		return nil
-	}
-
-	info, err := client.ContainerInspect(context.Background(), container.ID)
-
-	c.Assert(err, IsNil)
-
-	return &info
+	return container
 }
 
 func (s *CliSuite) GetContainersByProject(c *C, project string) []types.Container {


### PR DESCRIPTION
Container lookups based on name are currently done using `ContainerList` with a filter. However, I've actually been running into cases where this is returning a container with a different name. I think the underlying issue is that `name` isn't a valid filter (at least according to the Docker API docs). This PR moves almost all name-based container lookups to `ContainerInspect`.

An added benefit of this is that `types.ContainerJSON` is now used consistently, as opposed to the current mix of `types.Container` and `types.ContainerJSON`. Despite the name, `types.ContainerJSON` seems to be the better choice between the two.

The only remaining usage of `ContainerList` is in `container.Info`. The type of information that is provided by the function matches the response from `ContainerList` really well, so it felt right to leave it in use here.

Signed-off-by: Josh Curl <josh@curl.me>