### PR TITLE
Make authentication more extensible

### DIFF
--- a/docker/auth.go
+++ b/docker/auth.go
@@ -1,0 +1,24 @@
+package docker
+
+import (
+	"github.com/docker/docker/registry"
+	"github.com/docker/engine-api/types"
+)
+
+// AuthLookup defines a method for looking up authentication information
+type AuthLookup interface {
+	Lookup(repoInfo *registry.RepositoryInfo) types.AuthConfig
+}
+
+// ConfigAuthLookup implements AuthLookup by reading a Docker config file
+type ConfigAuthLookup struct {
+	context *Context
+}
+
+// Lookup uses a Docker config file to lookup authentication information
+func (c *ConfigAuthLookup) Lookup(repoInfo *registry.RepositoryInfo) types.AuthConfig {
+	if c.context.ConfigFile == nil || repoInfo == nil || repoInfo.Index == nil {
+		return types.AuthConfig{}
+	}
+	return registry.ResolveAuthConfig(c.context.ConfigFile.AuthConfigs, repoInfo.Index)
+}

--- a/docker/container.go
+++ b/docker/container.go
@@ -688,10 +688,7 @@ func pullImage(client client.APIClient, service *Service, image string) error {
 		return err
 	}
 
-	authConfig := types.AuthConfig{}
-	if service.context.ConfigFile != nil && repoInfo != nil && repoInfo.Index != nil {
-		authConfig = registry.ResolveAuthConfig(service.context.ConfigFile.AuthConfigs, repoInfo.Index)
-	}
+	authConfig := service.context.AuthLookup.Lookup(repoInfo)
 
 	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {

--- a/docker/context.go
+++ b/docker/context.go
@@ -13,6 +13,7 @@ type Context struct {
 	ClientFactory ClientFactory
 	ConfigDir     string
 	ConfigFile    *cliconfig.ConfigFile
+	AuthLookup    AuthLookup
 }
 
 func (c *Context) open() error {

--- a/docker/project.go
+++ b/docker/project.go
@@ -17,6 +17,10 @@ func NewProject(context *Context) (*project.Project, error) {
 		context.EnvironmentLookup = &lookup.OsEnvLookup{}
 	}
 
+	if context.AuthLookup == nil {
+		context.AuthLookup = &ConfigAuthLookup{context}
+	}
+
 	if context.ServiceFactory == nil {
 		context.ServiceFactory = &ServiceFactory{
 			context: context,


### PR DESCRIPTION
Adds an `AuthLookup` interface that can be used to override the standard `config.json` authentication

Signed-off-by: Josh Curl <josh@curl.me>