### PR TITLE
revise collect container name

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -79,7 +79,7 @@ func (s *Service) collectContainers() ([]*Container, error) {
 
 	for _, container := range containers {
 		// Compose add "/" before name, so Name[1] will store actaul name.
-		name := strings.SplitAfter(container.Names[0], "/")
+		name := strings.SplitAfterN(container.Names[0], "/", 2)
 		result = append(result, NewContainer(client, name[1], s))
 	}
 


### PR DESCRIPTION
containerName = /${node}/${service}${num} for swarm.
strings.SplitAfter(container.Names[0], "/") will get [/,${node},/${service}${num}], so that name[1] will get wrong container name. When the service up, the program will get crash.