### PR TITLE
Normalize project name from cli

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -1,11 +1,8 @@
 package command
 
 import (
-	"os"
-
 	"github.com/codegangsta/cli"
 	"github.com/docker/libcompose/cli/app"
-	"github.com/docker/libcompose/project"
 )
 
 // CreateCommand defines the libcompose create subcommand.
@@ -293,18 +290,4 @@ func CommonFlags() []cli.Flag {
 			Usage: "Specify an alternate project name (default: directory name)",
 		},
 	}
-}
-
-// Populate updates the specified project context based on command line arguments and subcommands.
-func Populate(context *project.Context, c *cli.Context) {
-	context.ComposeFiles = c.GlobalStringSlice("file")
-
-	if len(context.ComposeFiles) == 0 {
-		context.ComposeFiles = []string{"docker-compose.yml"}
-		if _, err := os.Stat("docker-compose.override.yml"); err == nil {
-			context.ComposeFiles = append(context.ComposeFiles, "docker-compose.override.yml")
-		}
-	}
-
-	context.ProjectName = c.GlobalString("project-name")
 }

--- a/cli/docker/app/factory_test.go
+++ b/cli/docker/app/factory_test.go
@@ -1,0 +1,58 @@
+package app
+
+import (
+	"flag"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/libcompose/project"
+)
+
+func TestProjectFactoryProjectNameIsNormalized(t *testing.T) {
+	projects := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "example",
+			expected: "example",
+		},
+		{
+			name:     "example-test",
+			expected: "exampletest",
+		},
+		{
+			name:     "aW3Ird_Project_with_$$",
+			expected: "aw3irdprojectwith",
+		},
+	}
+
+	tmpDir, err := ioutil.TempDir("", "project-factory-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	composeFile := filepath.Join(tmpDir, "docker-compose.yml")
+	ioutil.WriteFile(composeFile, []byte(`hello:
+    image: busybox`), 0700)
+
+	for _, projectCase := range projects {
+		set := flag.NewFlagSet("test", 0)
+		globalSet := flag.NewFlagSet("test", 0)
+		// Set the project-name flag
+		globalSet.String("project-name", projectCase.name, "doc")
+		// Set the compose file flag
+		globalSet.Var(&cli.StringSlice{composeFile}, "file", "doc")
+		c := cli.NewContext(nil, set, globalSet)
+		factory := &ProjectFactory{}
+		p, err := factory.Create(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if p.(*project.Project).Name != projectCase.expected {
+			t.Fatalf("expected %s, got %s", projectCase.expected, p.(*project.Project).Name)
+		}
+	}
+}

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -90,7 +90,7 @@ func (s *CliSuite) CreateProjectFromText(c *C, input string) string {
 }
 
 func (s *CliSuite) RandomProject() string {
-	return "test-project-" + RandStr(7)
+	return "testproject" + RandStr(7)
 }
 
 func (s *CliSuite) ProjectFromText(c *C, command, input string) string {


### PR DESCRIPTION
Normalize the project name from cli the same way `docker-compose` does 🐮 :

- Everything to lower case
- Remove any non alpha-numeric character

Adding unit-test on the factory for this normalization.

Fixes #228 (see https://github.com/docker/compose/blob/bd7ec24e2580f9805cd1561779b3b3d9e3b0bf4b/compose/cli/command.py#L86 for the way docker-compose normalize the project name).

/cc @ibuildthecloud @joshwget 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>