### PR TITLE
Expose IsValidRemotes instead of valid remote slices

### DIFF
--- a/config/merge.go
+++ b/config/merge.go
@@ -9,19 +9,11 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
+	"github.com/docker/docker/pkg/urlutil"
 	"github.com/docker/libcompose/utils"
 )
 
 var (
-	// ValidRemotes list the of valid prefixes that can be sent to Docker as a build remote location
-	// This is public for consumers of libcompose to use
-	ValidRemotes = []string{
-		"git://",
-		"git@github.com:",
-		"github.com",
-		"http:",
-		"https:",
-	}
 	noMerge = []string{
 		"links",
 		"volumes_from",
@@ -154,10 +146,8 @@ func resolveBuild(inFile string, serviceData RawService) (RawService, error) {
 		return serviceData, nil
 	}
 
-	for _, remote := range ValidRemotes {
-		if strings.HasPrefix(build, remote) {
-			return serviceData, nil
-		}
+	if IsValidRemote(build) {
+		return serviceData, nil
 	}
 
 	current := path.Dir(inFile)
@@ -325,4 +315,9 @@ func asString(obj interface{}) string {
 		return v
 	}
 	return ""
+}
+
+// IsValidRemote checks if the specified string is a valid remote (for builds)
+func IsValidRemote(remote string) bool {
+	return urlutil.IsGitURL(remote) || urlutil.IsURL(remote)
 }

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -170,3 +170,36 @@ test:
 		t.Fatal("Invalid restart policy", test.Restart)
 	}
 }
+
+func TestIsValidRemote(t *testing.T) {
+	gitUrls := []string{
+		"git://github.com/docker/docker",
+		"git@github.com:docker/docker.git",
+		"git@bitbucket.org:atlassianlabs/atlassian-docker.git",
+		"https://github.com/docker/docker.git",
+		"http://github.com/docker/docker.git",
+		"http://github.com/docker/docker.git#branch",
+		"http://github.com/docker/docker.git#:dir",
+	}
+	incompleteGitUrls := []string{
+		"github.com/docker/docker",
+	}
+	invalidGitUrls := []string{
+		"http://github.com/docker/docker.git:#branch",
+	}
+	for _, url := range gitUrls {
+		if !IsValidRemote(url) {
+			t.Fatalf("%q should have been a valid remote", url)
+		}
+	}
+	for _, url := range incompleteGitUrls {
+		if !IsValidRemote(url) {
+			t.Fatalf("%q should have been a valid remote", url)
+		}
+	}
+	for _, url := range invalidGitUrls {
+		if !IsValidRemote(url) {
+			t.Fatalf("%q should have been a valid remote", url)
+		}
+	}
+}


### PR DESCRIPTION
🐰

- Remove the public ValidRemotes struct
- Add a method IsValidRemotes that uses docker/docker/pkg/urlutil to
  check if the remote is valid or not (same way docker build does).

This should fix #95 in a clean way :angel: 

/cc @ibuildthecloud @joshwget @dnephin 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>