### PR TITLE
Add a version command

### DIFF
--- a/cli/app/version.go
+++ b/cli/app/version.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"text/template"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/docker/libcompose/version"
+)
+
+var versionTemplate = `Version:      {{.Version}} ({{.GitCommit}})
+Go version:   {{.GoVersion}}
+Built:        {{.BuildTime}}
+OS/Arch:      {{.Os}}/{{.Arch}}`
+
+// Version prints the libcompose version number and additionnal informations.
+func Version(c *cli.Context) {
+	if c.Bool("short") {
+		fmt.Println(version.VERSION)
+		return
+	}
+
+	tmpl, err := template.New("").Parse(versionTemplate)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	v := struct {
+		Version   string
+		GitCommit string
+		GoVersion string
+		BuildTime string
+		Os        string
+		Arch      string
+	}{
+		Version:   version.VERSION,
+		GitCommit: version.GITCOMMIT,
+		GoVersion: runtime.Version(),
+		BuildTime: version.BUILDTIME,
+		Os:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+
+	if err := tmpl.Execute(os.Stdout, v); err != nil {
+		logrus.Fatal(err)
+	}
+	fmt.Printf("\n")
+	return
+}

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -276,6 +276,21 @@ func UnpauseCommand(factory app.ProjectFactory) cli.Command {
 	}
 }
 
+// VersionCommand defines the libcompose version subcommand.
+func VersionCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "version",
+		Usage:  "Show version informations",
+		Action: app.Version,
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "short",
+				Usage: "Shows only Compose's version number.",
+			},
+		},
+	}
+}
+
 // CommonFlags defines the flags that are in common for all subcommands.
 func CommonFlags() []cli.Flag {
 	return []cli.Flag{

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -39,6 +39,7 @@ func main() {
 		command.StopCommand(factory),
 		command.UnpauseCommand(factory),
 		command.UpCommand(factory),
+		command.VersionCommand(factory),
 	}
 
 	app.Run(os.Args)

--- a/script/binary
+++ b/script/binary
@@ -6,8 +6,11 @@ rm -f libcompose-cli
 
 go generate
 
+BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/') &> /dev/null
+GITCOMMIT=$(git rev-parse --short HEAD)
+
 # Build binaries
 go build \
-   -ldflags="-w -X github.com/docker/libcompose/version.GITCOMMIT=`git rev-parse --short HEAD`" \
+   -ldflags="-w -X github.com/docker/libcompose/version.GITCOMMIT=${GITCOMMIT} -X github.com/docker/libcompose/version.BUILDTIME=${BUILDTIME}" \
    -o bundles/libcompose-cli \
    ./cli/main

--- a/version/version.go
+++ b/version/version.go
@@ -6,4 +6,7 @@ var (
 
 	// GITCOMMIT will be overwritten automatically by the build system
 	GITCOMMIT = "HEAD"
+
+	// BUILDTIME will be overwritten automatically by the build system
+	BUILDTIME = ""
 )


### PR DESCRIPTION
It prints the version, git commit, build time, go version used and os/arch 🐶.

```bash
$ ./bundles/libcompose-cli version
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
Version:      0.3.0-dev (97663e3)
Go version:   go1.6.2
Built:        2016-05-03T09:56:53.387558446+00:00
OS/Arch:      linux/amd64
```

Closes #205

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>