### PR TITLE
Refactor DeleteCommand to not need access to ListStoppedContainer

### DIFF
--- a/project/interface.go
+++ b/project/interface.go
@@ -28,10 +28,6 @@ type APIProject interface {
 
 	Parse() error
 
-	// FIXME(vdemeester) move outside this interface. Delete(…) should take a
-	// function for the force thingie (ask a question or not)
-	ListStoppedContainers(services ...string) ([]string, error)
-
 	// FIXME(vdemeester) should be moved outside this interface
 	// The listener/notify mecanism could/should be indenpendant from Project
 	AddListener(c chan<- events.Event)

--- a/project/options/types.go
+++ b/project/options/types.go
@@ -7,7 +7,8 @@ type Build struct {
 
 // Delete holds options of compose rm.
 type Delete struct {
-	RemoveVolume bool
+	RemoveVolume         bool
+	BeforeDeleteCallback func([]string) bool
 }
 
 // Down holds options of compose down.


### PR DESCRIPTION
It's now possible to pass a function that is used to request the validation (could be anything the take a list of string [container id / names] and returns true if the suppression should go on. If the function is not present, we do not ask. 🐯

I'm not sure about the name of the function though...

/cc @joshwget @ibuildthecloud @dnephin @thaJeztah 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>