### PR TITLE
Remove project in logs

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -636,7 +636,9 @@ func (c *Container) Log(follow bool) error {
 		return err
 	}
 
-	l := c.service.context.LoggerFactory.Create(c.name)
+	// FIXME(vdemeester) update container struct to do less API calls
+	name := c.service.name + "_" + getContainerNumber(c)
+	l := c.service.context.LoggerFactory.Create(name)
 
 	options := types.ContainerLogsOptions{
 		ShowStdout: true,


### PR DESCRIPTION
Compose prefixes logs using service name and number (service_1), aligning libcompose to do the same (instead of project_service_1) 🐼.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>