### PR TITLE
Use context.Context accross the library

### DIFF
--- a/docker/builder/builder_test.go
+++ b/docker/builder/builder_test.go
@@ -99,7 +99,7 @@ func TestBuildInvalidContextDirectoryOrDockerfile(t *testing.T) {
 			ContextDirectory: c.contextDirectory,
 			Dockerfile:       c.dockerfile,
 		}
-		err := builder.Build("image")
+		err := builder.Build(context.Background(), "image")
 		if err == nil || err.Error() != c.expected {
 			t.Fatalf("expected an error %q, got %s", c.expected, err)
 		}
@@ -124,7 +124,7 @@ func TestBuildWithClientBuildError(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	if err == nil || err.Error() != "Engine no longer exists" {
 		t.Fatalf("expected an 'Engine no longer exists', got %s", err)
 	}
@@ -153,7 +153,7 @@ func TestBuildWithDefaultDockerfile(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestBuildWithDefaultLowercaseDockerfile(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -212,7 +212,7 @@ func TestBuildWithSpecificDockerfile(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -245,7 +245,7 @@ func TestBuildWithDockerignoreNothing(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,7 +278,7 @@ func TestBuildWithDockerignoreDockerfileAndItself(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +312,7 @@ func TestBuildWithDockerignoreAfile(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -347,7 +347,7 @@ func TestBuildWithErrorJSONMessage(t *testing.T) {
 		Client:           client,
 	}
 
-	err = builder.Build(imageName)
+	err = builder.Build(context.Background(), imageName)
 	expectedError := "Status: error, Code: 1"
 	if err == nil || err.Error() != expectedError {
 		t.Fatalf("expected an error about %q, got %s", expectedError, err)

--- a/docker/functions.go
+++ b/docker/functions.go
@@ -10,7 +10,7 @@ import (
 
 // GetContainersByFilter looks up the hosts containers with the specified filters and
 // returns a list of container matching it, or an error.
-func GetContainersByFilter(clientInstance client.APIClient, containerFilters ...map[string][]string) ([]types.Container, error) {
+func GetContainersByFilter(ctx context.Context, clientInstance client.APIClient, containerFilters ...map[string][]string) ([]types.Container, error) {
 	filterArgs := filters.NewArgs()
 
 	// FIXME(vdemeester) I don't like 3 for loops >_<
@@ -22,7 +22,7 @@ func GetContainersByFilter(clientInstance client.APIClient, containerFilters ...
 		}
 	}
 
-	return clientInstance.ContainerList(context.Background(), types.ContainerListOptions{
+	return clientInstance.ContainerList(ctx, types.ContainerListOptions{
 		All:    true,
 		Filter: filterArgs,
 	})
@@ -30,8 +30,8 @@ func GetContainersByFilter(clientInstance client.APIClient, containerFilters ...
 
 // GetContainer looks up the hosts containers with the specified ID
 // or name and returns it, or an error.
-func GetContainer(clientInstance client.APIClient, id string) (*types.ContainerJSON, error) {
-	container, err := clientInstance.ContainerInspect(context.Background(), id)
+func GetContainer(ctx context.Context, clientInstance client.APIClient, id string) (*types.ContainerJSON, error) {
+	container, err := clientInstance.ContainerInspect(ctx, id)
 	if err != nil {
 		if client.IsErrContainerNotFound(err) {
 			return nil, nil

--- a/docker/image.go
+++ b/docker/image.go
@@ -18,12 +18,12 @@ import (
 	"github.com/docker/engine-api/types"
 )
 
-func removeImage(client client.APIClient, image string) error {
-	_, err := client.ImageRemove(context.Background(), image, types.ImageRemoveOptions{})
+func removeImage(ctx context.Context, client client.APIClient, image string) error {
+	_, err := client.ImageRemove(ctx, image, types.ImageRemoveOptions{})
 	return err
 }
 
-func pullImage(client client.APIClient, service *Service, image string) error {
+func pullImage(ctx context.Context, client client.APIClient, service *Service, image string) error {
 	fmt.Fprintf(os.Stderr, "Pulling %s (%s)...\n", service.name, image)
 	distributionRef, err := reference.ParseNamed(image)
 	if err != nil {
@@ -45,7 +45,7 @@ func pullImage(client client.APIClient, service *Service, image string) error {
 	options := types.ImagePullOptions{
 		RegistryAuth: encodedAuth,
 	}
-	responseBody, err := client.ImagePull(context.Background(), distributionRef.String(), options)
+	responseBody, err := client.ImagePull(ctx, distributionRef.String(), options)
 	if err != nil {
 		logrus.Errorf("Failed to pull image %s: %v", image, err)
 		return err

--- a/docker/name.go
+++ b/docker/name.go
@@ -37,7 +37,7 @@ func NewSingleNamer(name string) Namer {
 
 // NewNamer returns a namer that returns names based on the specified project and
 // service name and an inner counter, e.g. project_service_1, project_service_2…
-func NewNamer(client client.APIClient, project, service string, oneOff bool) (Namer, error) {
+func NewNamer(ctx context.Context, client client.APIClient, project, service string, oneOff bool) (Namer, error) {
 	namer := &defaultNamer{
 		project: project,
 		service: service,
@@ -53,7 +53,7 @@ func NewNamer(client client.APIClient, project, service string, oneOff bool) (Na
 		filter.Add("label", fmt.Sprintf("%s=%s", labels.ONEOFF.Str(), "False"))
 	}
 
-	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
+	containers, err := client.ContainerList(ctx, types.ContainerListOptions{
 		All:    true,
 		Filter: filter,
 	})

--- a/docker/name_test.go
+++ b/docker/name_test.go
@@ -56,7 +56,7 @@ func (client *NamerClient) ContainerList(ctx context.Context, options types.Cont
 
 func TestDefaultNamerClientError(t *testing.T) {
 	client := test.NewNopClient()
-	_, err := NewNamer(client, "project", "service", false)
+	_, err := NewNamer(context.Background(), client, "project", "service", false)
 	if err == nil || err.Error() != "Engine no longer exists" {
 		t.Fatalf("expected an error 'Engine no longer exists', got %s", err)
 	}
@@ -72,7 +72,7 @@ func TestDefaultNamerLabelNotANumber(t *testing.T) {
 			},
 		},
 	}
-	_, err := NewNamer(client, "project", "service", false)
+	_, err := NewNamer(context.Background(), client, "project", "service", false)
 	if err == nil {
 		t.Fatal("expected an error, got nothing")
 	}
@@ -159,7 +159,7 @@ func TestDefaultNamer(t *testing.T) {
 			expectedLabelFilters: c.expectedLabels,
 			containers:           c.containers,
 		}
-		namer, err := NewNamer(client, c.projectName, c.serviceName, c.oneOff)
+		namer, err := NewNamer(context.Background(), client, c.projectName, c.serviceName, c.oneOff)
 		if err != nil {
 			t.Error(err)
 		}

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -3,6 +3,8 @@ package integration
 import (
 	. "gopkg.in/check.v1"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/project/options"
@@ -31,6 +33,6 @@ service:
 
 	c.Assert(err, IsNil)
 
-	err = project.Up(options.Up{})
+	err = project.Up(context.Background(), options.Up{})
 	c.Assert(err, IsNil)
 }

--- a/integration/common_test.go
+++ b/integration/common_test.go
@@ -160,7 +160,7 @@ func GetClient(c *C) client.APIClient {
 
 func (s *CliSuite) GetContainerByName(c *C, name string) *types.ContainerJSON {
 	client := GetClient(c)
-	container, err := docker.GetContainer(client, name)
+	container, err := docker.GetContainer(context.Background(), client, name)
 
 	c.Assert(err, IsNil)
 
@@ -169,7 +169,7 @@ func (s *CliSuite) GetContainerByName(c *C, name string) *types.ContainerJSON {
 
 func (s *CliSuite) GetContainersByProject(c *C, project string) []types.Container {
 	client := GetClient(c)
-	containers, err := docker.GetContainersByFilter(client, labels.PROJECT.Eq(project))
+	containers, err := docker.GetContainersByFilter(context.Background(), client, labels.PROJECT.Eq(project))
 
 	c.Assert(err, IsNil)
 

--- a/project/container.go
+++ b/project/container.go
@@ -1,9 +1,13 @@
 package project
 
+import (
+	"golang.org/x/net/context"
+)
+
 // Container defines what a libcompose container provides.
 type Container interface {
 	ID() (string, error)
 	Name() string
-	Port(port string) (string, error)
-	IsRunning() (bool, error)
+	Port(ctx context.Context, port string) (string, error)
+	IsRunning(ctx context.Context) (bool, error)
 }

--- a/project/empty.go
+++ b/project/empty.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/docker/libcompose/project/options"
 )
 
@@ -9,86 +11,86 @@ type EmptyService struct {
 }
 
 // Create implements Service.Create but does nothing.
-func (e *EmptyService) Create(options options.Create) error {
+func (e *EmptyService) Create(ctx context.Context, options options.Create) error {
 	return nil
 }
 
 // Build implements Service.Build but does nothing.
-func (e *EmptyService) Build(buildOptions options.Build) error {
+func (e *EmptyService) Build(ctx context.Context, buildOptions options.Build) error {
 	return nil
 }
 
 // Up implements Service.Up but does nothing.
-func (e *EmptyService) Up(options options.Up) error {
+func (e *EmptyService) Up(ctx context.Context, options options.Up) error {
 	return nil
 }
 
 // Start implements Service.Start but does nothing.
-func (e *EmptyService) Start() error {
+func (e *EmptyService) Start(ctx context.Context) error {
 	return nil
 }
 
 // Stop implements Service.Stop() but does nothing.
-func (e *EmptyService) Stop(timeout int) error {
+func (e *EmptyService) Stop(ctx context.Context, timeout int) error {
 	return nil
 }
 
 // Delete implements Service.Delete but does nothing.
-func (e *EmptyService) Delete(options options.Delete) error {
+func (e *EmptyService) Delete(ctx context.Context, options options.Delete) error {
 	return nil
 }
 
 // Restart implements Service.Restart but does nothing.
-func (e *EmptyService) Restart(timeout int) error {
+func (e *EmptyService) Restart(ctx context.Context, timeout int) error {
 	return nil
 }
 
 // Log implements Service.Log but does nothing.
-func (e *EmptyService) Log(follow bool) error {
+func (e *EmptyService) Log(ctx context.Context, follow bool) error {
 	return nil
 }
 
 // Pull implements Service.Pull but does nothing.
-func (e *EmptyService) Pull() error {
+func (e *EmptyService) Pull(ctx context.Context) error {
 	return nil
 }
 
 // Kill implements Service.Kill but does nothing.
-func (e *EmptyService) Kill(signal string) error {
+func (e *EmptyService) Kill(ctx context.Context, signal string) error {
 	return nil
 }
 
 // Containers implements Service.Containers but does nothing.
-func (e *EmptyService) Containers() ([]Container, error) {
+func (e *EmptyService) Containers(ctx context.Context) ([]Container, error) {
 	return []Container{}, nil
 }
 
 // Scale implements Service.Scale but does nothing.
-func (e *EmptyService) Scale(count int, timeout int) error {
+func (e *EmptyService) Scale(ctx context.Context, count int, timeout int) error {
 	return nil
 }
 
 // Info implements Service.Info but does nothing.
-func (e *EmptyService) Info(qFlag bool) (InfoSet, error) {
+func (e *EmptyService) Info(ctx context.Context, qFlag bool) (InfoSet, error) {
 	return InfoSet{}, nil
 }
 
 // Pause implements Service.Pause but does nothing.
-func (e *EmptyService) Pause() error {
+func (e *EmptyService) Pause(ctx context.Context) error {
 	return nil
 }
 
 // Unpause implements Service.Pause but does nothing.
-func (e *EmptyService) Unpause() error {
+func (e *EmptyService) Unpause(ctx context.Context) error {
 	return nil
 }
 
 // Run implements Service.Run but does nothing.
-func (e *EmptyService) Run(commandParts []string) (int, error) {
+func (e *EmptyService) Run(ctx context.Context, commandParts []string) (int, error) {
 	return 0, nil
 }
 
 // RemoveImage implements Service.RemoveImage but does nothing.
-func (e *EmptyService) RemoveImage(imageType options.ImageType) error {
+func (e *EmptyService) RemoveImage(ctx context.Context, imageType options.ImageType) error {
 	return nil
 }

--- a/project/interface.go
+++ b/project/interface.go
@@ -1,6 +1,8 @@
 package project
 
 import (
+	"golang.org/x/net/context"
+
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
@@ -11,24 +13,24 @@ type APIProject interface {
 	events.Notifier
 	events.Emitter
 
-	Build(options options.Build, sevice ...string) error
-	Create(options options.Create, services ...string) error
-	Delete(options options.Delete, services ...string) error
-	Down(options options.Down, services ...string) error
-	Kill(signal string, services ...string) error
-	Log(follow bool, services ...string) error
-	Pause(services ...string) error
-	Ps(onlyID bool, services ...string) (InfoSet, error)
+	Build(ctx context.Context, options options.Build, sevice ...string) error
+	Create(ctx context.Context, options options.Create, services ...string) error
+	Delete(ctx context.Context, options options.Delete, services ...string) error
+	Down(ctx context.Context, options options.Down, services ...string) error
+	Kill(ctx context.Context, signal string, services ...string) error
+	Log(ctx context.Context, follow bool, services ...string) error
+	Pause(ctx context.Context, services ...string) error
+	Ps(ctx context.Context, onlyID bool, services ...string) (InfoSet, error)
 	// FIXME(vdemeester) we could use nat.Port instead ?
-	Port(index int, protocol, serviceName, privatePort string) (string, error)
-	Pull(services ...string) error
-	Restart(timeout int, services ...string) error
-	Run(serviceName string, commandParts []string) (int, error)
-	Scale(timeout int, servicesScale map[string]int) error
-	Start(services ...string) error
-	Stop(timeout int, services ...string) error
-	Unpause(services ...string) error
-	Up(options options.Up, services ...string) error
+	Port(ctx context.Context, index int, protocol, serviceName, privatePort string) (string, error)
+	Pull(ctx context.Context, services ...string) error
+	Restart(ctx context.Context, timeout int, services ...string) error
+	Run(ctx context.Context, serviceName string, commandParts []string) (int, error)
+	Scale(ctx context.Context, timeout int, servicesScale map[string]int) error
+	Start(ctx context.Context, services ...string) error
+	Stop(ctx context.Context, timeout int, services ...string) error
+	Unpause(ctx context.Context, services ...string) error
+	Up(ctx context.Context, options options.Up, services ...string) error
 
 	Parse() error
 	CreateService(name string) (Service, error)

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project/options"
 	"github.com/docker/libcompose/yaml"
@@ -32,11 +34,11 @@ func (t *TestService) Name() string {
 	return t.name
 }
 
-func (t *TestService) Run(commandParts []string) (int, error) {
+func (t *TestService) Run(ctx context.Context, commandParts []string) (int, error) {
 	return 0, nil
 }
 
-func (t *TestService) Create(options options.Create) error {
+func (t *TestService) Create(ctx context.Context, options options.Create) error {
 	key := t.name + ".create"
 	t.factory.Counts[key] = t.factory.Counts[key] + 1
 	return nil
@@ -65,11 +67,11 @@ func TestTwoCall(t *testing.T) {
 	p.ServiceConfigs = config.NewServiceConfigs()
 	p.ServiceConfigs.Add("foo", &config.ServiceConfig{})
 
-	if err := p.Create(options.Create{}, "foo"); err != nil {
+	if err := p.Create(context.Background(), options.Create{}, "foo"); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := p.Create(options.Create{}, "foo"); err != nil {
+	if err := p.Create(context.Background(), options.Create{}, "foo"); err != nil {
 		t.Fatal(err)
 	}
 

--- a/project/service.go
+++ b/project/service.go
@@ -3,33 +3,35 @@ package project
 import (
 	"errors"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project/options"
 )
 
 // Service defines what a libcompose service provides.
 type Service interface {
-	Info(qFlag bool) (InfoSet, error)
-	Name() string
-	Build(buildOptions options.Build) error
-	Create(options options.Create) error
-	Up(options options.Up) error
-	Start() error
-	Stop(timeout int) error
-	Delete(options options.Delete) error
-	Restart(timeout int) error
-	Log(follow bool) error
-	Pull() error
-	Kill(signal string) error
-	Config() *config.ServiceConfig
-	DependentServices() []ServiceRelationship
-	Containers() ([]Container, error)
-	Scale(count int, timeout int) error
-	Pause() error
-	Unpause() error
-	Run(commandParts []string) (int, error)
+	Build(ctx context.Context, buildOptions options.Build) error
+	Create(ctx context.Context, options options.Create) error
+	Delete(ctx context.Context, options options.Delete) error
+	Info(ctx context.Context, qFlag bool) (InfoSet, error)
+	Log(ctx context.Context, follow bool) error
+	Kill(ctx context.Context, signal string) error
+	Pause(ctx context.Context) error
+	Pull(ctx context.Context) error
+	Restart(ctx context.Context, timeout int) error
+	Run(ctx context.Context, commandParts []string) (int, error)
+	Scale(ctx context.Context, count int, timeout int) error
+	Start(ctx context.Context) error
+	Stop(ctx context.Context, timeout int) error
+	Unpause(ctx context.Context) error
+	Up(ctx context.Context, options options.Up) error
 
-	RemoveImage(imageType options.ImageType) error
+	RemoveImage(ctx context.Context, imageType options.ImageType) error
+	Containers(ctx context.Context) ([]Container, error)
+	DependentServices() []ServiceRelationship
+	Config() *config.ServiceConfig
+	Name() string
 }
 
 // ServiceState holds the state of a service.


### PR DESCRIPTION
Applications that require full plumbing of context, such as those that
rely on cancellation for resource cleanup, would be incompatible with
inconsistent plumbing 🐹.

This *connects* the net/context from the user of the libcompose API to
the engine-api and below (where request are cancellable for
example). This should also allow us to some cool and safe stuff with
concurrent goroutines and cancellation :angel: 

This will allow to handle, for example, when a user hits CTRL+C on `up` : it will cancel/close the request, etc… and could be used for more usefulness.

<del>Depends on #239 (for the refactoring on `Delete`)</del>

🐸

/cc @joshwget @ibuildthecloud @dnephin 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>