### PR TITLE
Remove logrus dependency in the core of the library

### DIFF
--- a/cli/docker/app/factory.go
+++ b/cli/docker/app/factory.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/docker/libcompose/cli/logger"
 	"github.com/docker/libcompose/docker"
@@ -19,6 +20,7 @@ type ProjectFactory struct {
 func (p *ProjectFactory) Create(c *cli.Context) (project.APIProject, error) {
 	context := &docker.Context{}
 	context.LoggerFactory = logger.NewColorLoggerFactory()
+	context.Logger = logrus.New()
 	Populate(context, c)
 
 	context.ComposeFiles = c.GlobalStringSlice("file")

--- a/cli/logger/color_logger.go
+++ b/cli/logger/color_logger.go
@@ -9,7 +9,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-// ColorLoggerFactory implements logger.Factory interface using ColorLogger.
+// ColorLoggerFactory implements logger.LogFormatterFactory interface using ColorLogger.
 type ColorLoggerFactory struct {
 	maxLength int
 	tty       bool
@@ -30,7 +30,7 @@ func NewColorLoggerFactory() *ColorLoggerFactory {
 }
 
 // Create implements logger.Factory.Create.
-func (c *ColorLoggerFactory) Create(name string) logger.Logger {
+func (c *ColorLoggerFactory) Create(name string) logger.LogFormatter {
 	if c.maxLength < len(name) {
 		c.maxLength = len(name)
 	}

--- a/config/interpolation.go
+++ b/config/interpolation.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-
-	"github.com/Sirupsen/logrus"
 )
 
 func isNum(c uint8) bool {
@@ -145,7 +143,7 @@ func Interpolate(environmentLookup EnvironmentLookup, config *RawServiceMap) err
 				values := environmentLookup.Lookup(s, k, nil)
 
 				if len(values) == 0 {
-					logrus.Warnf("The %s variable is not set. Substituting a blank string.", s)
+					// logrus.Warnf("The %s variable is not set. Substituting a blank string.", s)
 					return ""
 				}
 

--- a/config/merge.go
+++ b/config/merge.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/Sirupsen/logrus"
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
 	"github.com/docker/libcompose/utils"
 )
@@ -48,7 +47,8 @@ func MergeServices(existingServices *Configs, environmentLookup EnvironmentLooku
 	for name, data := range datas {
 		data, err := parse(resourceLookup, environmentLookup, file, data, datas)
 		if err != nil {
-			logrus.Errorf("Failed to parse service %s: %v", name, err)
+			// logrus.Errorf("Failed to parse service %s: %v", name, err)
+			// FIXME(vdemeester) wrap error
 			return nil, err
 		}
 
@@ -216,7 +216,8 @@ func parse(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup, i
 	} else {
 		bytes, resolved, err := resourceLookup.Lookup(file, inFile)
 		if err != nil {
-			logrus.Errorf("Failed to lookup file %s: %v", file, err)
+			// logrus.Errorf("Failed to lookup file %s: %v", file, err)
+			// FIXME(vdemeester) wrap error
 			return nil, err
 		}
 
@@ -248,7 +249,7 @@ func parse(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup, i
 
 	baseService = clone(baseService)
 
-	logrus.Debugf("Merging %#v, %#v", baseService, serviceData)
+	// logrus.Debugf("Merging %#v, %#v", baseService, serviceData)
 
 	for _, k := range noMerge {
 		if _, ok := baseService[k]; ok {
@@ -262,7 +263,7 @@ func parse(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup, i
 
 	baseService = mergeConfig(baseService, serviceData)
 
-	logrus.Debugf("Merged result %#v", baseService)
+	// logrus.Debugf("Merged result %#v", baseService)
 
 	return baseService, nil
 }

--- a/docker/builder/builder.go
+++ b/docker/builder/builder.go
@@ -10,7 +10,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/builder"
 	"github.com/docker/docker/builder/dockerignore"
 	"github.com/docker/docker/pkg/archive"
@@ -57,8 +56,6 @@ func (d *DaemonBuilder) Build(imageName string) error {
 	progressOutput := streamformatter.NewStreamFormatter().NewProgressOutput(progBuff, true)
 
 	var body io.Reader = progress.NewProgressReader(ctx, progressOutput, 0, "", "Sending build context to Docker daemon")
-
-	logrus.Infof("Building %s...", imageName)
 
 	outFd, isTerminalOut := term.GetFdInfo(os.Stdout)
 
@@ -143,7 +140,6 @@ func createTar(contextDirectory, dockerfile string) (io.ReadCloser, error) {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		logrus.Warnf("Error while reading .dockerignore (%s) : %s", dockerIgnorePath, err.Error())
 		excludes = make([]string, 0)
 	} else {
 		excludes, err = dockerignore.ReadAll(dockerIgnore)

--- a/docker/project.go
+++ b/docker/project.go
@@ -1,8 +1,7 @@
 package docker
 
 import (
-	"github.com/Sirupsen/logrus"
-
+	"github.com/docker/libcompose/logger"
 	"github.com/docker/libcompose/lookup"
 	"github.com/docker/libcompose/project"
 )
@@ -27,6 +26,13 @@ func NewProject(context *Context) (project.APIProject, error) {
 		}
 	}
 
+	var log logger.Logger = &logger.DefaultLogger{}
+	if context.Logger != nil {
+		log = context.Logger
+	} else {
+		context.Logger = log
+	}
+
 	if context.ClientFactory == nil {
 		factory, err := NewDefaultClientFactory(ClientOpts{})
 		if err != nil {
@@ -35,7 +41,7 @@ func NewProject(context *Context) (project.APIProject, error) {
 		context.ClientFactory = factory
 	}
 
-	p := project.NewProject(&context.Context)
+	p := project.NewProject(&context.Context, log)
 
 	err := p.Parse()
 	if err != nil {
@@ -43,7 +49,7 @@ func NewProject(context *Context) (project.APIProject, error) {
 	}
 
 	if err = context.open(); err != nil {
-		logrus.Errorf("Failed to open project %s: %v", p.Name, err)
+		log.Errorf("Failed to open project %s: %v", p.Name, err)
 		return nil, err
 	}
 

--- a/docker/service.go
+++ b/docker/service.go
@@ -6,11 +6,11 @@ import (
 
 	"golang.org/x/net/context"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/docker/engine-api/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/docker/builder"
+	"github.com/docker/libcompose/logger"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/project/options"
 	"github.com/docker/libcompose/utils"
@@ -21,14 +21,16 @@ type Service struct {
 	name          string
 	serviceConfig *config.ServiceConfig
 	context       *Context
+	logger        logger.Logger
 }
 
 // NewService creates a service
-func NewService(name string, serviceConfig *config.ServiceConfig, context *Context) *Service {
+func NewService(name string, serviceConfig *config.ServiceConfig, context *Context, log logger.Logger) *Service {
 	return &Service{
 		name:          name,
 		serviceConfig: serviceConfig,
 		context:       context,
+		logger:        log,
 	}
 }
 
@@ -82,7 +84,7 @@ func (s *Service) collectContainers() ([]*Container, error) {
 	for _, container := range containers {
 		// Compose add "/" before name, so Name[1] will store actaul name.
 		name := strings.SplitAfter(container.Names[0], "/")
-		result = append(result, NewContainer(client, name[1], s))
+		result = append(result, NewContainer(client, name[1], s, s.logger))
 	}
 
 	return result, nil
@@ -153,6 +155,7 @@ func (s *Service) build(buildOptions options.Build) error {
 		AuthConfigs:      s.context.AuthLookup.All(),
 		NoCache:          buildOptions.NoCache,
 	}
+	s.logger.Infof("Building %s...", s.imageName())
 	return builder.Build(s.imageName())
 }
 
@@ -168,7 +171,7 @@ func (s *Service) constructContainers(imageName string, count int) ([]*Container
 
 	if s.serviceConfig.ContainerName != "" {
 		if count > 1 {
-			logrus.Warnf(`The "%s" service is using the custom container name "%s". Docker requires each container to have a unique name. Remove the custom name to scale the service.`, s.name, s.serviceConfig.ContainerName)
+			s.logger.Warnf(`The "%s" service is using the custom container name "%s". Docker requires each container to have a unique name. Remove the custom name to scale the service.`, s.name, s.serviceConfig.ContainerName)
 		}
 		namer = NewSingleNamer(s.serviceConfig.ContainerName)
 	} else {
@@ -180,16 +183,16 @@ func (s *Service) constructContainers(imageName string, count int) ([]*Container
 	for i := len(result); i < count; i++ {
 		containerName := namer.Next()
 
-		c := NewContainer(client, containerName, s)
+		c := NewContainer(client, containerName, s, s.logger)
 
 		dockerContainer, err := c.Create(imageName)
 		if err != nil {
 			return nil, err
 		}
 
-		logrus.Debugf("Created container %s: %v", dockerContainer.ID, dockerContainer.Name)
+		s.logger.Debugf("Created container %s: %v", dockerContainer.ID, dockerContainer.Name)
 
-		result = append(result, NewContainer(client, containerName, s))
+		result = append(result, NewContainer(client, containerName, s, s.logger))
 	}
 
 	return result, nil
@@ -228,7 +231,7 @@ func (s *Service) Run(commandParts []string) (int, error) {
 
 	containerName := namer.Next()
 
-	c := NewContainer(client, containerName, s)
+	c := NewContainer(client, containerName, s, s.logger)
 
 	return c.Run(imageName, &config.ServiceConfig{Command: commandParts, Tty: true, StdinOpen: true})
 }
@@ -264,7 +267,7 @@ func (s *Service) up(imageName string, create bool, options options.Up) error {
 		return err
 	}
 
-	logrus.Debugf("Found %d existing containers for service %s", len(containers), s.name)
+	s.logger.Debugf("Found %d existing containers for service %s", len(containers), s.name)
 
 	if len(containers) == 0 && create {
 		c, err := s.createOne(imageName)
@@ -294,13 +297,13 @@ func (s *Service) recreateIfNeeded(imageName string, c *Container, noRecreate, f
 		return err
 	}
 
-	logrus.WithFields(logrus.Fields{
-		"outOfSync":     outOfSync,
-		"ForceRecreate": forceRecreate,
-		"NoRecreate":    noRecreate}).Debug("Going to decide if recreate is needed")
+	s.logger.Debugf("Going to decide if recreate is needed based on the following attributes")
+	s.logger.Debug("outOfSync", outOfSync)
+	s.logger.Debug("forceRecreate", forceRecreate)
+	s.logger.Debug("NoRecreate", noRecreate)
 
 	if forceRecreate || outOfSync {
-		logrus.Infof("Recreating %s", s.name)
+		s.logger.Infof("Recreating %s", s.name)
 		if _, err := c.Recreate(imageName); err != nil {
 			return err
 		}
@@ -379,7 +382,7 @@ func (s *Service) Log(follow bool) error {
 // of related container to the service to run.
 func (s *Service) Scale(scale int, timeout int) error {
 	if s.specificiesHostPort() {
-		logrus.Warnf("The \"%s\" service specifies a port on the host. If multiple containers for this service are created on a single host, the port will clash.", s.Name())
+		s.logger.Warnf("The \"%s\" service specifies a port on the host. If multiple containers for this service are created on a single host, the port will clash.", s.Name())
 	}
 
 	foundCount := 0

--- a/docker/service_factory.go
+++ b/docker/service_factory.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/logger"
 	"github.com/docker/libcompose/project"
 )
 
@@ -11,6 +12,6 @@ type ServiceFactory struct {
 }
 
 // Create creates a Service based on the specified project, name and service configuration.
-func (s *ServiceFactory) Create(project *project.Project, name string, serviceConfig *config.ServiceConfig) (project.Service, error) {
-	return NewService(name, serviceConfig, s.context), nil
+func (s *ServiceFactory) Create(project *project.Project, name string, serviceConfig *config.ServiceConfig, log logger.Logger) (project.Service, error) {
+	return NewService(name, serviceConfig, s.context, log), nil
 }

--- a/logger/default.go
+++ b/logger/default.go
@@ -1,0 +1,40 @@
+package logger
+
+import (
+	"log"
+)
+
+type DefaultLogger struct {
+}
+
+func (l *DefaultLogger) Errorf(format string, values ...interface{}) {
+	log.Printf("err:"+format, values...)
+}
+
+func (l *DefaultLogger) Error(values ...interface{}) {
+	log.Print("err:", values)
+}
+
+func (l *DefaultLogger) Infof(format string, values ...interface{}) {
+	log.Printf("info:"+format, values...)
+}
+
+func (l *DefaultLogger) Info(values ...interface{}) {
+	log.Print("info:", values)
+}
+
+func (l *DefaultLogger) Debugf(format string, values ...interface{}) {
+	log.Printf("debug:"+format, values...)
+}
+
+func (l *DefaultLogger) Debug(values ...interface{}) {
+	log.Print("debug:", values)
+}
+
+func (l *DefaultLogger) Warnf(format string, values ...interface{}) {
+	log.Printf("warn:"+format, values...)
+}
+
+func (l *DefaultLogger) Warn(values ...interface{}) {
+	log.Print("warn:", values)
+}

--- a/logger/null.go
+++ b/logger/null.go
@@ -12,7 +12,7 @@ func (n *NullLogger) Out(_ []byte) {
 func (n *NullLogger) Err(_ []byte) {
 }
 
-// Create implements logger.Factory and returns a NullLogger.
-func (n *NullLogger) Create(_ string) Logger {
+// Create implements logger.LogFormatterFactory and returns a NullLogger.
+func (n *NullLogger) Create(_ string) LogFormatter {
 	return &NullLogger{}
 }

--- a/logger/types.go
+++ b/logger/types.go
@@ -1,22 +1,34 @@
 package logger
 
-// Factory defines methods a factory should implement, to create a Logger
+// LogFormatterFactory defines methods a factory should implement, to create a Logger
 // based on the specified name.
-type Factory interface {
-	Create(name string) Logger
+type LogFormatterFactory interface {
+	Create(name string) LogFormatter
+}
+
+// LogFormatter defines methods to implement for being a compose log logger.
+type LogFormatter interface {
+	Out(bytes []byte)
+	Err(bytes []byte)
 }
 
 // Logger defines methods to implement for being a logger.
 type Logger interface {
-	Out(bytes []byte)
-	Err(bytes []byte)
+	Errorf(format string, values ...interface{})
+	Error(values ...interface{})
+	Infof(format string, values ...interface{})
+	Info(values ...interface{})
+	Debugf(format string, values ...interface{})
+	Debug(values ...interface{})
+	Warnf(format string, values ...interface{})
+	Warn(values ...interface{})
 }
 
 // Wrapper is a wrapper around Logger that implements the Writer interface,
 // mainly use by docker/pkg/stdcopy functions.
 type Wrapper struct {
 	Err    bool
-	Logger Logger
+	Logger LogFormatter
 }
 
 func (l *Wrapper) Write(bytes []byte) (int, error) {

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -6,7 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/logger"
 	"github.com/docker/libcompose/project/options"
 	"github.com/docker/libcompose/yaml"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +48,7 @@ func (t *TestService) DependentServices() []ServiceRelationship {
 	return nil
 }
 
-func (t *TestServiceFactory) Create(project *Project, name string, serviceConfig *config.ServiceConfig) (Service, error) {
+func (t *TestServiceFactory) Create(project *Project, name string, serviceConfig *config.ServiceConfig, logger logger.Logger) (Service, error) {
 	return &TestService{
 		factory: t,
 		config:  serviceConfig,
@@ -61,7 +63,7 @@ func TestTwoCall(t *testing.T) {
 
 	p := NewProject(&Context{
 		ServiceFactory: factory,
-	})
+	}, logrus.New())
 	p.Configs = config.NewConfigs()
 	p.Configs.Add("foo", &config.ServiceConfig{})
 
@@ -83,7 +85,7 @@ func TestParseWithBadContent(t *testing.T) {
 		ComposeBytes: [][]byte{
 			[]byte("garbage"),
 		},
-	})
+	}, logrus.New())
 
 	err := p.Parse()
 	if err == nil {
@@ -100,7 +102,7 @@ func TestParseWithGoodContent(t *testing.T) {
 		ComposeBytes: [][]byte{
 			[]byte("not-garbage:\n  image: foo"),
 		},
-	})
+	}, logrus.New())
 
 	err := p.Parse()
 	if err != nil {
@@ -123,7 +125,7 @@ func TestEnvironmentResolve(t *testing.T) {
 	p := NewProject(&Context{
 		ServiceFactory:    factory,
 		EnvironmentLookup: &TestEnvironmentLookup{},
-	})
+	}, logrus.New())
 	p.Configs = config.NewConfigs()
 	p.Configs.Add("foo", &config.ServiceConfig{
 		Environment: yaml.MaporEqualSlice([]string{
@@ -166,7 +168,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	p := NewProject(&Context{
 		ComposeBytes: [][]byte{configOne, configTwo},
-	})
+	}, logrus.New())
 
 	err := p.Parse()
 
@@ -179,7 +181,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	p = NewProject(&Context{
 		ComposeBytes: [][]byte{configTwo, configOne},
-	})
+	}, logrus.New())
 
 	err = p.Parse()
 
@@ -192,7 +194,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	p = NewProject(&Context{
 		ComposeBytes: [][]byte{configOne, configTwo, configThree},
-	})
+	}, logrus.New())
 
 	err = p.Parse()
 

--- a/project/service.go
+++ b/project/service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/logger"
 	"github.com/docker/libcompose/project/options"
 )
 
@@ -49,7 +50,7 @@ var (
 // ServiceFactory is an interface factory to create Service object for the specified
 // project, with the specified name and service configuration.
 type ServiceFactory interface {
-	Create(project *Project, name string, serviceConfig *config.ServiceConfig) (Service, error)
+	Create(project *Project, name string, serviceConfig *config.ServiceConfig, log logger.Logger) (Service, error)
 }
 
 // ServiceRelationshipType defines the type of service relationship.


### PR DESCRIPTION
A library should not use a specific logger over an other (logrus here), but let the users of the library choose theirs. If it really needs to log things, it should provide a composable way to do it. 🐼

This refactoring defines a new type Logger and rename the old one into LogFormatter. A default Logger (based on fmt/log) is defined and used if nothing is used and `logrus.New()` can be used directly as logger (and that's what used for the cli)

- [ ] Not sure this is the right time for this refactoring (I feel there is more needed in some other places before)
- [ ] Maybe the default *logger* should be a NullLogger instead

/cc @ibuildthecloud @joshwget @dnephin 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>