### PR TITLE
Add an All method to AuthLookup

### DIFF
--- a/docker/auth.go
+++ b/docker/auth.go
@@ -7,6 +7,7 @@ import (
 
 // AuthLookup defines a method for looking up authentication information
 type AuthLookup interface {
+	All() map[string]types.AuthConfig
 	Lookup(repoInfo *registry.RepositoryInfo) types.AuthConfig
 }
 
@@ -21,4 +22,12 @@ func (c *ConfigAuthLookup) Lookup(repoInfo *registry.RepositoryInfo) types.AuthC
 		return types.AuthConfig{}
 	}
 	return registry.ResolveAuthConfig(c.context.ConfigFile.AuthConfigs, repoInfo.Index)
+}
+
+// All uses a Docker config file to get all authentication information
+func (c *ConfigAuthLookup) All() map[string]types.AuthConfig {
+	if c.context.ConfigFile == nil {
+		return map[string]types.AuthConfig{}
+	}
+	return c.context.ConfigFile.AuthConfigs
 }

--- a/docker/service.go
+++ b/docker/service.go
@@ -150,7 +150,7 @@ func (s *Service) build(buildOptions options.Build) error {
 		Client:           s.context.ClientFactory.Create(s),
 		ContextDirectory: s.Config().Build,
 		Dockerfile:       s.Config().Dockerfile,
-		AuthConfigs:      s.context.ConfigFile.AuthConfigs,
+		AuthConfigs:      s.context.AuthLookup.All(),
 		NoCache:          buildOptions.NoCache,
 	}
 	return builder.Build(s.imageName())


### PR DESCRIPTION
This extends AuthLookup to be used for the builder, that takes a map of all possible AuthConfig values.

/cc @ibuildthecloud @joshwget 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>