### PR TITLE
Some refactoring on container.go

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -30,12 +30,6 @@ import (
 	util "github.com/docker/libcompose/utils"
 )
 
-// DefaultTag is the name of the default tag of an image.
-const DefaultTag = "latest"
-
-// ComposeVersion is name of docker-compose.yml file syntax supported version
-const ComposeVersion = "1.5.0"
-
 // Container holds information about a docker container and the service it is tied on.
 // It implements Service interface by encapsulating a EmptyService.
 type Container struct {

--- a/docker/image.go
+++ b/docker/image.go
@@ -1,0 +1,74 @@
+package docker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"golang.org/x/net/context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/docker/docker/pkg/term"
+	"github.com/docker/docker/reference"
+	"github.com/docker/docker/registry"
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+)
+
+func pullImage(client client.APIClient, service *Service, image string) error {
+	distributionRef, err := reference.ParseNamed(image)
+	if err != nil {
+		return err
+	}
+
+	repoInfo, err := registry.ParseRepositoryInfo(distributionRef)
+	if err != nil {
+		return err
+	}
+
+	authConfig := service.context.AuthLookup.Lookup(repoInfo)
+
+	encodedAuth, err := encodeAuthToBase64(authConfig)
+	if err != nil {
+		return err
+	}
+
+	options := types.ImagePullOptions{
+		RegistryAuth: encodedAuth,
+	}
+	responseBody, err := client.ImagePull(context.Background(), distributionRef.String(), options)
+	if err != nil {
+		logrus.Errorf("Failed to pull image %s: %v", image, err)
+		return err
+	}
+	defer responseBody.Close()
+
+	var writeBuff io.Writer = os.Stdout
+
+	outFd, isTerminalOut := term.GetFdInfo(os.Stdout)
+
+	err = jsonmessage.DisplayJSONMessagesStream(responseBody, writeBuff, outFd, isTerminalOut, nil)
+	if err != nil {
+		if jerr, ok := err.(*jsonmessage.JSONError); ok {
+			// If no error code is set, default to 1
+			if jerr.Code == 0 {
+				jerr.Code = 1
+			}
+			fmt.Fprintf(os.Stderr, "%s", writeBuff)
+			return fmt.Errorf("Status: %s, Code: %d", jerr.Message, jerr.Code)
+		}
+	}
+	return err
+}
+
+// encodeAuthToBase64 serializes the auth configuration as JSON base64 payload
+func encodeAuthToBase64(authConfig types.AuthConfig) (string, error) {
+	buf, err := json.Marshal(authConfig)
+	if err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(buf), nil
+}

--- a/docker/name.go
+++ b/docker/name.go
@@ -2,23 +2,27 @@ package docker
 
 import (
 	"fmt"
-	"io"
-	"time"
+	"strconv"
+
+	"golang.org/x/net/context"
 
 	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/filters"
 )
 
 const format = "%s_%s_%d"
 
 // Namer defines method to provide container name.
 type Namer interface {
-	io.Closer
-	Next() string
+	Next() (string, int)
 }
 
-type inOrderNamer struct {
-	names chan string
-	done  chan bool
+type defaultNamer struct {
+	project       string
+	service       string
+	oneOff        bool
+	currentNumber int
 }
 
 type singleNamer struct {
@@ -32,50 +36,56 @@ func NewSingleNamer(name string) Namer {
 
 // NewNamer returns a namer that returns names based on the specified project and
 // service name and an inner counter, e.g. project_service_1, project_service_2…
-func NewNamer(client client.APIClient, project, service string) Namer {
-	namer := &inOrderNamer{
-		names: make(chan string),
-		done:  make(chan bool),
+func NewNamer(client client.APIClient, project, service string, oneOff bool) (Namer, error) {
+	namer := &defaultNamer{
+		project: project,
+		service: service,
+		oneOff:  oneOff,
 	}
 
-	go func() {
-		for i := 1; true; i++ {
-			name := fmt.Sprintf(format, project, service, i)
-			c, err := GetContainer(client, name)
-			if err != nil {
-				// Sleep here to avoid crazy tight loop when things go south
-				time.Sleep(time.Second * 1)
-				continue
-			}
-			if c != nil {
-				continue
-			}
+	filter := filters.NewArgs()
+	filter.Add("label", fmt.Sprintf("%s=%s", PROJECT.Str(), project))
+	filter.Add("label", fmt.Sprintf("%s=%s", SERVICE.Str(), service))
+	if oneOff {
+		filter.Add("label", fmt.Sprintf("%s=%s", ONEOFF.Str(), "True"))
+	} else {
+		filter.Add("label", fmt.Sprintf("%s=%s", ONEOFF.Str(), "False"))
+	}
 
-			select {
-			case namer.names <- name:
-			case <-namer.done:
-				close(namer.names)
-				return
-			}
+	containers, err := client.ContainerList(context.Background(), types.ContainerListOptions{
+		All:    true,
+		Filter: filter,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	maxNumber := 0
+	for _, container := range containers {
+		number, err := strconv.Atoi(container.Labels[NUMBER.Str()])
+		if err != nil {
+			return nil, err
 		}
-	}()
+		if number > maxNumber {
+			maxNumber = number
+		}
+	}
+	namer.currentNumber = maxNumber + 1
 
-	return namer
+	return namer, nil
 }
 
-func (i *inOrderNamer) Next() string {
-	return <-i.names
+func (i *defaultNamer) Next() (string, int) {
+	service := i.service
+	if i.oneOff {
+		service = i.service + "_run"
+	}
+	name := fmt.Sprintf(format, i.project, service, i.currentNumber)
+	number := i.currentNumber
+	i.currentNumber = i.currentNumber + 1
+	return name, number
 }
 
-func (i *inOrderNamer) Close() error {
-	close(i.done)
-	return nil
-}
-
-func (s *singleNamer) Next() string {
-	return s.name
-}
-
-func (s *singleNamer) Close() error {
-	return nil
+func (s *singleNamer) Next() (string, int) {
+	return s.name, 1
 }

--- a/docker/name_test.go
+++ b/docker/name_test.go
@@ -1,0 +1,177 @@
+package docker
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/libcompose/test"
+)
+
+func TestSingleNamer(t *testing.T) {
+	expectedName := "myName"
+	expectedNumber := 1
+	namer := NewSingleNamer("myName")
+	for i := 0; i < 10; i++ {
+		name, number := namer.Next()
+		if name != expectedName {
+			t.Fatalf("expected %s, got %s", expectedName, name)
+		}
+		if number != expectedNumber {
+			t.Fatalf("expected %d, got %d", expectedNumber, number)
+		}
+	}
+}
+
+type NamerClient struct {
+	test.NopClient
+	expectedLabelFilters []string
+	containers           []types.Container
+}
+
+func (client *NamerClient) ContainerList(ctx context.Context, options types.ContainerListOptions) ([]types.Container, error) {
+	if len(client.expectedLabelFilters) > 1 {
+		labelFilters := options.Filter.Get("label")
+		if len(labelFilters) != len(client.expectedLabelFilters) {
+			return []types.Container{}, fmt.Errorf("expected filters %v, got %v", client.expectedLabelFilters, labelFilters)
+		}
+		for _, expectedLabelFilter := range client.expectedLabelFilters {
+			found := false
+			for _, labelFilter := range labelFilters {
+				if labelFilter == expectedLabelFilter {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return []types.Container{}, fmt.Errorf("expected to find filter %s, did not in %v", expectedLabelFilter, labelFilters)
+			}
+		}
+	}
+	return client.containers, nil
+}
+
+func TestDefaultNamerClientError(t *testing.T) {
+	client := test.NewNopClient()
+	_, err := NewNamer(client, "project", "service", false)
+	if err == nil || err.Error() != "Engine no longer exists" {
+		t.Fatalf("expected an error 'Engine no longer exists', got %s", err)
+	}
+}
+
+func TestDefaultNamerLabelNotANumber(t *testing.T) {
+	client := &NamerClient{
+		containers: []types.Container{
+			{
+				Labels: map[string]string{
+					ONEOFF.Str(): "IAmAString",
+				},
+			},
+		},
+	}
+	_, err := NewNamer(client, "project", "service", false)
+	if err == nil {
+		t.Fatal("expected an error, got nothing")
+	}
+}
+
+func TestDefaultNamer(t *testing.T) {
+	cases := []struct {
+		projectName    string
+		serviceName    string
+		oneOff         bool
+		containers     []types.Container
+		expectedLabels []string
+		expectedName   string
+		expectedNumber int
+	}{
+		{
+			projectName: "",
+			serviceName: "",
+			oneOff:      false,
+			containers:  []types.Container{},
+			expectedLabels: []string{
+				fmt.Sprintf("%s=", PROJECT.Str()),
+				fmt.Sprintf("%s=", SERVICE.Str()),
+				fmt.Sprintf("%s=False", ONEOFF.Str()),
+			},
+			expectedName:   "__1",
+			expectedNumber: 1,
+		},
+		{
+			projectName: "project",
+			serviceName: "service",
+			oneOff:      false,
+			containers:  []types.Container{},
+			expectedLabels: []string{
+				fmt.Sprintf("%s=project", PROJECT.Str()),
+				fmt.Sprintf("%s=service", SERVICE.Str()),
+				fmt.Sprintf("%s=False", ONEOFF.Str()),
+			},
+			expectedName:   "project_service_1",
+			expectedNumber: 1,
+		},
+		{
+			projectName: "project",
+			serviceName: "service",
+			oneOff:      false,
+			containers: []types.Container{
+				{
+					Labels: map[string]string{
+						NUMBER.Str(): "1",
+					},
+				},
+			},
+			expectedLabels: []string{
+				fmt.Sprintf("%s=project", PROJECT.Str()),
+				fmt.Sprintf("%s=service", SERVICE.Str()),
+				fmt.Sprintf("%s=False", ONEOFF.Str()),
+			},
+			expectedName:   "project_service_2",
+			expectedNumber: 2,
+		},
+		{
+			projectName: "project",
+			serviceName: "anotherservice",
+			oneOff:      false,
+			containers: []types.Container{
+				{
+					Labels: map[string]string{
+						NUMBER.Str(): "10",
+					},
+				},
+			},
+			expectedLabels: []string{
+				fmt.Sprintf("%s=project", PROJECT.Str()),
+				fmt.Sprintf("%s=anotherservice", SERVICE.Str()),
+				fmt.Sprintf("%s=False", ONEOFF.Str()),
+			},
+			expectedName:   "project_anotherservice_11",
+			expectedNumber: 11,
+		},
+	}
+
+	for _, c := range cases {
+		client := &NamerClient{
+			expectedLabelFilters: c.expectedLabels,
+			containers:           c.containers,
+		}
+		namer, err := NewNamer(client, c.projectName, c.serviceName, c.oneOff)
+		if err != nil {
+			t.Error(err)
+		}
+		name, number := namer.Next()
+		if name != c.expectedName {
+			t.Errorf("Expected %s, got %s for %v", c.expectedName, name, c)
+		}
+		if number != c.expectedNumber {
+			t.Errorf("Expected %d, got %d for %v", c.expectedNumber, number, c)
+		}
+		_, number = namer.Next()
+		if number != c.expectedNumber+1 {
+			t.Errorf("Expected a 2nd call to increment numbre to %d, got %d for %v", c.expectedNumber+1, number, c)
+		}
+	}
+}

--- a/docker/project.go
+++ b/docker/project.go
@@ -8,6 +8,9 @@ import (
 	"github.com/docker/libcompose/project"
 )
 
+// ComposeVersion is name of docker-compose.yml file syntax supported version
+const ComposeVersion = "1.5.0"
+
 // NewProject creates a Project with the specified context.
 func NewProject(context *Context) (project.APIProject, error) {
 	if context.ResourceLookup == nil {

--- a/project/events/events.go
+++ b/project/events/events.go
@@ -5,6 +5,16 @@ import (
 	"fmt"
 )
 
+// Notifier defines the methods an event notifier should have.
+type Notifier interface {
+	Notify(eventType EventType, serviceName string, data map[string]string)
+}
+
+// Emitter defines the methods an event emitter should have.
+type Emitter interface {
+	AddListener(c chan<- Event)
+}
+
 // Event holds project-wide event informations.
 type Event struct {
 	EventType   EventType

--- a/project/interface.go
+++ b/project/interface.go
@@ -7,6 +7,9 @@ import (
 
 // APIProject is an interface defining the methods a libcompose project should implement.
 type APIProject interface {
+	events.Notifier
+	events.Emitter
+
 	Build(options options.Build, sevice ...string) error
 	Create(options options.Create, services ...string) error
 	Delete(options options.Delete, services ...string) error
@@ -27,9 +30,4 @@ type APIProject interface {
 	Up(options options.Up, services ...string) error
 
 	Parse() error
-
-	// FIXME(vdemeester) should be moved outside this interface
-	// The listener/notify mecanism could/should be indenpendant from Project
-	AddListener(c chan<- events.Event)
-	Notify(eventType events.EventType, serviceName string, data map[string]string)
 }

--- a/project/project.go
+++ b/project/project.go
@@ -551,6 +551,7 @@ func (p *Project) traverse(start bool, selected map[string]bool, wrappers map[st
 }
 
 // AddListener adds the specified listener to the project.
+// This implements implicitly events.Emitter.
 func (p *Project) AddListener(c chan<- events.Event) {
 	if !p.hasListeners {
 		for _, l := range p.listeners {
@@ -564,6 +565,7 @@ func (p *Project) AddListener(c chan<- events.Event) {
 }
 
 // Notify notifies all project listener with the specified eventType, service name and datas.
+// This implements implicitly events.Notifier interface.
 func (p *Project) Notify(eventType events.EventType, serviceName string, data map[string]string) {
 	if eventType == events.NoEvent {
 		return


### PR DESCRIPTION
There is a few refactoring of the file `container.go` (and thus on related file too) here 🐰 :

- Moving some constants away (in `project.go`) as it felt a little bit out of place in `container.go`
- Add `evens.Notifier` and `events.Emitter` interface to be able te decouple the event emitting/notifying from the `Project` (we will pass a `Notifier` to `Container`).
- The `Container` struct does not *inherit* from `EmptyService` any more as it didn't make any sense to me (and didn't even was of use for anything).
- Remove pulling stuff from container and move `pullImage` into a new file `image.go`. The method `ensureImageExists` on `Service` is already taking care of making sure the image is present (by building or pulling it). It's the responsability of the service to create a new container once the image is already there.
- `Container` is now taking a `containerNumber` as argument (and attribute) and thus do not try to guess its number anymore (one daemon request less). `Namer`(s) have been refactor in that sence — a `Namer` now returns the name and the number of the container each `Next()` call. A big change though is that it's now doing less queries as it just filter using labels and get the maximum number of the existing ones (just like what `docker-compose` does). Added some tests on `Namer` too.

/cc @ibuildthecloud @joshwget 

🐸