### PR TITLE
Complete build command

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -98,7 +98,9 @@ func ProjectDown(p project.APIProject, c *cli.Context) error {
 // ProjectBuild builds or rebuilds services.
 func ProjectBuild(p project.APIProject, c *cli.Context) error {
 	config := options.Build{
-		NoCache: c.Bool("no-cache"),
+		NoCache:     c.Bool("no-cache"),
+		ForceRemove: c.Bool("force-rm"),
+		Pull:        c.Bool("pull"),
 	}
 	err := p.Build(config, c.Args()...)
 	if err != nil {

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -39,6 +39,14 @@ func BuildCommand(factory app.ProjectFactory) cli.Command {
 				Name:  "no-cache",
 				Usage: "Do not use cache when building the image",
 			},
+			cli.BoolFlag{
+				Name:  "force-rm",
+				Usage: "Always remove intermediate containers",
+			},
+			cli.BoolFlag{
+				Name:  "pull",
+				Usage: "Always attempt to pull a newer version of the image",
+			},
 		},
 	}
 }

--- a/docker/builder/builder.go
+++ b/docker/builder/builder.go
@@ -39,6 +39,8 @@ type DaemonBuilder struct {
 	Dockerfile       string
 	AuthConfigs      map[string]types.AuthConfig
 	NoCache          bool
+	ForceRemove      bool
+	Pull             bool
 }
 
 // Build implements Builder. It consumes the docker build API endpoint and sends
@@ -66,6 +68,8 @@ func (d *DaemonBuilder) Build(imageName string) error {
 		Tags:        []string{imageName},
 		NoCache:     d.NoCache,
 		Remove:      true,
+		ForceRemove: d.ForceRemove,
+		PullParent:  d.Pull,
 		Dockerfile:  d.Dockerfile,
 		AuthConfigs: d.AuthConfigs,
 	})

--- a/docker/service.go
+++ b/docker/service.go
@@ -152,6 +152,8 @@ func (s *Service) build(buildOptions options.Build) error {
 		Dockerfile:       s.Config().Dockerfile,
 		AuthConfigs:      s.context.AuthLookup.All(),
 		NoCache:          buildOptions.NoCache,
+		ForceRemove:      buildOptions.ForceRemove,
+		Pull:             buildOptions.Pull,
 	}
 	return builder.Build(s.imageName())
 }

--- a/project/options/types.go
+++ b/project/options/types.go
@@ -2,7 +2,9 @@ package options
 
 // Build holds options of compose build.
 type Build struct {
-	NoCache bool
+	NoCache     bool
+	ForceRemove bool
+	Pull        bool
 }
 
 // Delete holds options of compose rm.


### PR DESCRIPTION
The build command/project build method, now supports 🐯:

- `force-rm` : Always remove intermediate containers.
- `pull`     : Always attempt to pull a newer version of the image.

Closes #206.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>