### PR TITLE
Complete pull command

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -209,7 +209,7 @@ func ProjectLog(p project.APIProject, c *cli.Context) error {
 // ProjectPull pulls images for services.
 func ProjectPull(p project.APIProject, c *cli.Context) error {
 	err := p.Pull(c.Args()...)
-	if err != nil {
+	if err != nil && !c.Bool("ignore-pull-failures") {
 		return cli.NewExitError(err.Error(), 1)
 	}
 	return nil

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -145,6 +145,12 @@ func PullCommand(factory app.ProjectFactory) cli.Command {
 		Name:   "pull",
 		Usage:  "Pulls images for services",
 		Action: app.WithProject(factory, app.ProjectPull),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "ignore-pull-failures",
+				Usage: "Pull what it can and ignores images with pull failures.",
+			},
+		},
 	}
 }
 

--- a/docker/image.go
+++ b/docker/image.go
@@ -19,6 +19,7 @@ import (
 )
 
 func pullImage(client client.APIClient, service *Service, image string) error {
+	fmt.Fprintf(os.Stderr, "Pulling %s (%s)...\n", service.name, image)
 	distributionRef, err := reference.ParseNamed(image)
 	if err != nil {
 		return err
@@ -46,9 +47,9 @@ func pullImage(client client.APIClient, service *Service, image string) error {
 	}
 	defer responseBody.Close()
 
-	var writeBuff io.Writer = os.Stdout
+	var writeBuff io.Writer = os.Stderr
 
-	outFd, isTerminalOut := term.GetFdInfo(os.Stdout)
+	outFd, isTerminalOut := term.GetFdInfo(os.Stderr)
 
 	err = jsonmessage.DisplayJSONMessagesStream(responseBody, writeBuff, outFd, isTerminalOut, nil)
 	if err != nil {


### PR DESCRIPTION
Add support for `ignore-pull-failures` 🐼.

- Implement ignore-pull-failures
- Write pulling information in stderr (like docker-compose)

Closes #213.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>