### PR TITLE
Add events command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,14 @@ RUN virtualenv venv && \
 ENV COMPOSE_BINARY /go/src/github.com/docker/libcompose/libcompose-cli
 ENV USER root
 
+# Compile Go for cross compilation
+# FIXME(vdemeester) This is mainly for the vendor script, should be shared somewhere else
+ENV DOCKER_CROSSPLATFORMS \
+	linux/386 linux/arm \
+	darwin/amd64 darwin/386 \
+	freebsd/amd64 freebsd/386 freebsd/arm \
+	windows/amd64 windows/386
+
 # Wrap all commands in the "docker-in-docker" script to allow nested containers
 ENTRYPOINT ["script/dind"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR /go/src/github.com/docker/libcompose
 
 # Compose COMMIT for acceptance test version, update that commit when
 # you want to update the acceptance test version to support.
-ENV COMPOSE_COMMIT e2cb7b0237085415ce48900309a61c73b5938520
+ENV COMPOSE_COMMIT f1603a3ee2b074df4cce61842bfc3dff2af8915e
 RUN virtualenv venv && \
     git clone https://github.com/docker/compose.git venv/compose && \
     cd venv/compose && \

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -300,6 +300,21 @@ func UnpauseCommand(factory app.ProjectFactory) cli.Command {
 	}
 }
 
+// EventsCommand defines the libcompose events subcommand
+func EventsCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "events",
+		Usage:  "Receive real time events from containers.",
+		Action: app.WithProject(factory, app.ProjectEvents),
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "json",
+				Usage: "Output events as a stream of json objects",
+			},
+		},
+	}
+}
+
 // VersionCommand defines the libcompose version subcommand.
 func VersionCommand(factory app.ProjectFactory) cli.Command {
 	return cli.Command{

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -24,6 +24,7 @@ func main() {
 	app.Commands = []cli.Command{
 		command.BuildCommand(factory),
 		command.CreateCommand(factory),
+		command.EventsCommand(factory),
 		command.DownCommand(factory),
 		command.KillCommand(factory),
 		command.LogsCommand(factory),

--- a/docker/container.go
+++ b/docker/container.go
@@ -49,8 +49,8 @@ func NewContainer(client client.APIClient, name string, containerNumber int, ser
 
 		// TODO(vdemeester) Move these to arguments
 		serviceName:   service.name,
-		projectName:   service.context.Project.Name,
-		eventNotifier: service.context.Project,
+		projectName:   service.project.Name,
+		eventNotifier: service.project,
 		loggerFactory: service.context.LoggerFactory,
 
 		// TODO(vdemeester) Remove this dependency
@@ -513,11 +513,11 @@ func (c *Container) populateAdditionalHostConfig(hostConfig *container.HostConfi
 	links := map[string]string{}
 
 	for _, link := range c.service.DependentServices() {
-		if !c.service.context.Project.ServiceConfigs.Has(link.Target) {
+		if !c.service.project.ServiceConfigs.Has(link.Target) {
 			continue
 		}
 
-		service, err := c.service.context.Project.CreateService(link.Target)
+		service, err := c.service.project.CreateService(link.Target)
 		if err != nil {
 			return err
 		}

--- a/docker/image.go
+++ b/docker/image.go
@@ -35,7 +35,7 @@ func pullImage(ctx context.Context, client client.APIClient, service *Service, i
 		return err
 	}
 
-	authConfig := service.context.AuthLookup.Lookup(repoInfo)
+	authConfig := service.authLookup.Lookup(repoInfo)
 
 	encodedAuth, err := encodeAuthToBase64(authConfig)
 	if err != nil {

--- a/integration/api_event_test.go
+++ b/integration/api_event_test.go
@@ -4,7 +4,7 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
-	. "gopkg.in/check.v1"
+	check "gopkg.in/check.v1"
 
 	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/docker"
@@ -12,7 +12,8 @@ import (
 	"github.com/docker/libcompose/project/options"
 )
 
-func (s *APISuite) TestEvents(c *C) {
+func (s *APISuite) TestEvents(c *check.C) {
+	testRequires(c, not(DaemonVersionIs("1.9")))
 	composeFile := `
 simple:
   image: busybox:latest
@@ -27,15 +28,15 @@ another:
 			ProjectName:  "test-api-events",
 		},
 	}, nil)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	ctx, cancelFun := context.WithCancel(context.Background())
 
 	messages, err := project.Events(ctx)
-	c.Assert(err, IsNil)
+	c.Assert(err, check.IsNil)
 
 	go func() {
-		c.Assert(project.Up(ctx, options.Up{}), IsNil)
+		c.Assert(project.Up(ctx, options.Up{}), check.IsNil)
 		// Close after everything is done
 		time.Sleep(250 * time.Millisecond)
 		cancelFun()
@@ -48,5 +49,5 @@ another:
 	}
 
 	// Should be 4 events (2 create, 2 start)
-	c.Assert(len(events), Equals, 4, Commentf("%v", events))
+	c.Assert(len(events), check.Equals, 4, check.Commentf("%v", events))
 }

--- a/integration/api_event_test.go
+++ b/integration/api_event_test.go
@@ -1,0 +1,52 @@
+package integration
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+	. "gopkg.in/check.v1"
+
+	eventtypes "github.com/docker/engine-api/types/events"
+	"github.com/docker/libcompose/docker"
+	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/project/options"
+)
+
+func (s *APISuite) TestEvents(c *C) {
+	composeFile := `
+simple:
+  image: busybox:latest
+  command: top
+another:
+  image: busybox:latest
+  command: top
+`
+	project, err := docker.NewProject(&docker.Context{
+		Context: project.Context{
+			ComposeBytes: [][]byte{[]byte(composeFile)},
+			ProjectName:  "test-api-events",
+		},
+	}, nil)
+	c.Assert(err, IsNil)
+
+	ctx, cancelFun := context.WithCancel(context.Background())
+
+	messages, err := project.Events(ctx)
+	c.Assert(err, IsNil)
+
+	go func() {
+		c.Assert(project.Up(ctx, options.Up{}), IsNil)
+		// Close after everything is done
+		time.Sleep(250 * time.Millisecond)
+		cancelFun()
+		close(messages)
+	}()
+
+	events := []eventtypes.Message{}
+	for message := range messages {
+		events = append(events, message)
+	}
+
+	// Should be 4 events (2 create, 2 start)
+	c.Assert(len(events), Equals, 4, Commentf("%v", events))
+}

--- a/integration/requirements.go
+++ b/integration/requirements.go
@@ -1,0 +1,80 @@
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+	"time"
+
+	check "gopkg.in/check.v1"
+)
+
+type testCondition func() bool
+
+type testRequirement struct {
+	Condition   testCondition
+	SkipMessage string
+}
+
+// List test requirements
+var (
+	IsWindows = testRequirement{
+		func() bool { return runtime.GOOS == "windows" },
+		"Test requires a Windows daemon",
+	}
+	IsLinux = testRequirement{
+		func() bool { return runtime.GOOS == "linux" },
+		"Test requires a Linux daemon",
+	}
+	Network = testRequirement{
+		func() bool {
+			// Set a timeout on the GET at 15s
+			var timeout = 15 * time.Second
+			var url = "https://hub.docker.com"
+
+			client := http.Client{
+				Timeout: timeout,
+			}
+
+			resp, err := client.Get(url)
+			if err != nil && strings.Contains(err.Error(), "use of closed network connection") {
+				panic(fmt.Sprintf("Timeout for GET request on %s", url))
+			}
+			if resp != nil {
+				resp.Body.Close()
+			}
+			return err == nil
+		},
+		"Test requires network availability, environment variable set to none to run in a non-network enabled mode.",
+	}
+)
+
+func not(r testRequirement) testRequirement {
+	return testRequirement{
+		func() bool {
+			return !r.Condition()
+		},
+		fmt.Sprintf("Not(%s)", r.SkipMessage),
+	}
+}
+
+func DaemonVersionIs(version string) testRequirement {
+	return testRequirement{
+		func() bool {
+			return strings.Contains(os.Getenv("DOCKER_DAEMON_VERSION"), version)
+		},
+		"Test requires the daemon version to be " + version,
+	}
+}
+
+// testRequires checks if the environment satisfies the requirements
+// for the test to run or skips the tests.
+func testRequires(c *check.C, requirements ...testRequirement) {
+	for _, r := range requirements {
+		if !r.Condition() {
+			c.Skip(r.SkipMessage)
+		}
+	}
+}

--- a/project/empty.go
+++ b/project/empty.go
@@ -3,6 +3,7 @@ package project
 import (
 	"golang.org/x/net/context"
 
+	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/project/options"
 )
 
@@ -92,5 +93,10 @@ func (e *EmptyService) Run(ctx context.Context, commandParts []string) (int, err
 
 // RemoveImage implements Service.RemoveImage but does nothing.
 func (e *EmptyService) RemoveImage(ctx context.Context, imageType options.ImageType) error {
+	return nil
+}
+
+// Events implements Service.Events but does nothing.
+func (e *EmptyService) Events(ctx context.Context, events chan eventtypes.Message) error {
 	return nil
 }

--- a/project/interface.go
+++ b/project/interface.go
@@ -3,6 +3,7 @@ package project
 import (
 	"golang.org/x/net/context"
 
+	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
@@ -17,6 +18,7 @@ type APIProject interface {
 	Create(ctx context.Context, options options.Create, services ...string) error
 	Delete(ctx context.Context, options options.Delete, services ...string) error
 	Down(ctx context.Context, options options.Down, services ...string) error
+	Events(ctx context.Context, services ...string) (chan eventtypes.Message, error)
 	Kill(ctx context.Context, signal string, services ...string) error
 	Log(ctx context.Context, follow bool, services ...string) error
 	Pause(ctx context.Context, services ...string) error

--- a/project/project_events.go
+++ b/project/project_events.go
@@ -1,0 +1,24 @@
+package project
+
+import (
+	"golang.org/x/net/context"
+
+	eventtypes "github.com/docker/engine-api/types/events"
+)
+
+// Events listen for real time events from containers (of the project).
+func (p *Project) Events(ctx context.Context, services ...string) (chan eventtypes.Message, error) {
+	events := make(chan eventtypes.Message)
+	if len(services) == 0 {
+		services = p.ServiceConfigs.Keys()
+	}
+	// FIXME(vdemeester) handle errors (chan) here
+	for _, service := range services {
+		s, err := p.CreateService(service)
+		if err != nil {
+			return nil, err
+		}
+		go s.Events(ctx, events)
+	}
+	return events, nil
+}

--- a/project/service.go
+++ b/project/service.go
@@ -5,6 +5,7 @@ import (
 
 	"golang.org/x/net/context"
 
+	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project/options"
 )
@@ -14,6 +15,7 @@ type Service interface {
 	Build(ctx context.Context, buildOptions options.Build) error
 	Create(ctx context.Context, options options.Create) error
 	Delete(ctx context.Context, options options.Delete) error
+	Events(ctx context.Context, messages chan eventtypes.Message) error
 	Info(ctx context.Context, qFlag bool) (InfoSet, error)
 	Log(ctx context.Context, follow bool) error
 	Kill(ctx context.Context, signal string) error

--- a/script/vendor.sh
+++ b/script/vendor.sh
@@ -14,6 +14,7 @@ clone git github.com/docker/docker 9837ec4da53f15f9120d53a6e1517491ba8b0261
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
 clone git github.com/docker/engine-api fd7f99d354831e7e809386087e7ec3129fdb1520
+clone git github.com/vdemeester/docker-events b308d2e8d639d928c882913bcb4f85b3a84c7a07
 clone git github.com/flynn/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
 clone git github.com/gorilla/context 14f550f51a
 clone git github.com/gorilla/mux e444e69cbd

--- a/vendor/github.com/docker/engine-api/types/events/events.go
+++ b/vendor/github.com/docker/engine-api/types/events/events.go
@@ -1,0 +1,38 @@
+package events
+
+const (
+	// ContainerEventType is the event type that containers generate
+	ContainerEventType = "container"
+	// ImageEventType is the event type that images generate
+	ImageEventType = "image"
+	// VolumeEventType is the event type that volumes generate
+	VolumeEventType = "volume"
+	// NetworkEventType is the event type that networks generate
+	NetworkEventType = "network"
+)
+
+// Actor describes something that generates events,
+// like a container, or a network, or a volume.
+// It has a defined name and a set or attributes.
+// The container attributes are its labels, other actors
+// can generate these attributes from other properties.
+type Actor struct {
+	ID         string
+	Attributes map[string]string
+}
+
+// Message represents the information an event contains
+type Message struct {
+	// Deprecated information from JSONMessage.
+	// With data only in container events.
+	Status string `json:"status,omitempty"`
+	ID     string `json:"id,omitempty"`
+	From   string `json:"from,omitempty"`
+
+	Type   string
+	Action string
+	Actor  Actor
+
+	Time     int64 `json:"time,omitempty"`
+	TimeNano int64 `json:"timeNano,omitempty"`
+}

--- a/vendor/github.com/vdemeester/docker-events/.pre-commit-config.yaml
+++ b/vendor/github.com/vdemeester/docker-events/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+-   repo: git://github.com/pre-commit/pre-commit-hooks
+    sha: 44e1753f98b0da305332abe26856c3e621c5c439
+    hooks:
+    -   id: detect-private-key
+-   repo: git://github.com/containous/pre-commit-hooks
+    sha: 35e641b5107671e94102b0ce909648559e568d61
+    hooks:
+    -   id: goFmt
+    -   id: goLint

--- a/vendor/github.com/vdemeester/docker-events/.travis.yml
+++ b/vendor/github.com/vdemeester/docker-events/.travis.yml
@@ -1,0 +1,9 @@
+---
+  language: go
+  sudo: false
+  notifications:
+    email: false
+  go:
+    - 1.6
+  install: make deps
+  script: make validate && make test

--- a/vendor/github.com/vdemeester/docker-events/LICENSE
+++ b/vendor/github.com/vdemeester/docker-events/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2015-2016 Vincent Demeester
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/vdemeester/docker-events/Makefile
+++ b/vendor/github.com/vdemeester/docker-events/Makefile
@@ -1,0 +1,28 @@
+.PHONY: all deps test validate vet lint fmt
+
+all: deps validate test-unit ## get dependencies, validate all checks and run tests
+
+deps: ## get dependencies
+	go get -t ./...
+	go get github.com/golang/lint/golint
+
+test-unit: ## run tests
+	go test -timeout 10s -v -race -cover ./...
+
+validate: vet lint fmt ## validate gofmt, golint and go vet
+
+vet:
+	go vet ./...
+
+lint:
+	out="$$(golint ./...)"; \
+	if [ -n "$$(golint ./...)" ]; then \
+		echo "$$out"; \
+		exit 1; \
+	fi
+
+fmt:
+	test -z "$(gofmt -s -l . | tee /dev/stderr)"
+
+help: ## this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/vendor/github.com/vdemeester/docker-events/README.md
+++ b/vendor/github.com/vdemeester/docker-events/README.md
@@ -1,0 +1,80 @@
+# docker-events
+[![GoDoc](https://godoc.org/github.com/vdemeester/docker-events?status.png)](https://godoc.org/github.com/vdemeester/docker-events)
+[![Build Status](https://travis-ci.org/vdemeester/docker-events.svg?branch=master)](https://travis-ci.org/vdemeester/docker-events)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vdemeester/docker-events)](https://goreportcard.com/report/github.com/vdemeester/docker-events)
+[![License](https://img.shields.io/github/license/vdemeester/docker-events.svg)]()
+
+A really small library with the intent to ease the use of `Events`
+method of `engine-api`.
+
+## Usage
+
+It should be pretty straighforward to use :
+
+```go
+import "events"
+
+// […]
+
+cli, err := client.NewEnvClient()
+if err != nil {
+    // Do something..
+}
+
+cxt, cancel := context.WithCancel(context.Background())
+// Call cancel() to get out of the monitor
+
+errChan := events.Monitor(ctx, cli, types.EventsOptions{}, func(event eventtypes.Message) {
+    fmt.Printf("%v\n", event)
+})
+
+if err := <-errChan; err != nil {
+    // Do something
+}
+```
+
+It's also possible to do a little more advanced stuff using
+`EventHandler` :
+
+```go
+import "events"
+
+// […]
+
+cli, err := client.NewEnvClient()
+if err != nil {
+    // Do something..
+}
+
+// Setup the event handler
+eventHandler := events.NewHandler(events.ByAction)
+eventHandler.Handle("create", func(m eventtypes.Message) {
+    // Do something in case of create message
+})
+
+stoppedOrDead := func(m eventtypes.Message) {
+    // Do something in case of stop or die message as it might be the
+    // same way to react.
+}
+
+eventHandler.Handle("die", stoppedOrDead)
+eventHandler.Handle("stop", stoppedOrDead)
+
+// The other type of message will be discard.
+
+// Filter the events we wams so receive
+filters := filters.NewArgs()
+filters.Add("type", "container")
+options := types.EventsOptions{
+    Filters: filters,
+}
+
+cxt, cancel := context.WithCancel(context.Background())
+// Call cancel() to get out of the monitor
+
+errChan := events.MonitorWithHandler(ctx, cli, options, eventHandler)
+
+if err := <-errChan; err != nil {
+    // Do something
+}
+```

--- a/vendor/github.com/vdemeester/docker-events/events.go
+++ b/vendor/github.com/vdemeester/docker-events/events.go
@@ -1,0 +1,91 @@
+package events
+
+import (
+	"encoding/json"
+	"io"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	eventtypes "github.com/docker/engine-api/types/events"
+)
+
+// Monitor subscribes to the docker events api using engine api and will execute the
+// specified function on each message.
+// It will pass the specified options to the underline method (i.e Events).
+func Monitor(ctx context.Context, cli client.APIClient, options types.EventsOptions, fun func(m eventtypes.Message)) chan error {
+	handler := NewHandler(func(_ eventtypes.Message) string {
+		// Let's return always the same thing to not filter at all
+		return ""
+	})
+	handler.Handle("", fun)
+
+	return MonitorWithHandler(ctx, cli, options, handler)
+}
+
+// MonitorWithHandler subscribes to the docker events api using engine api and will pass the message
+// to the specified Handler, that will take care of it.
+// It will pass the specified options to the underline method (i.e Events).
+func MonitorWithHandler(ctx context.Context, cli client.APIClient, options types.EventsOptions, handler *Handler) chan error {
+	eventChan := make(chan eventtypes.Message)
+	errChan := make(chan error)
+	started := make(chan struct{})
+
+	go handler.Watch(eventChan)
+	go monitorEvents(ctx, cli, options, started, eventChan, errChan)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				// close(eventChan)
+				errChan <- nil
+			}
+		}
+	}()
+
+	<-started
+	return errChan
+}
+
+func monitorEvents(ctx context.Context, cli client.APIClient, options types.EventsOptions, started chan struct{}, eventChan chan eventtypes.Message, errChan chan error) {
+	body, err := cli.Events(ctx, options)
+	// Whether we successfully subscribed to events or not, we can now
+	// unblock the main goroutine.
+	close(started)
+	if err != nil {
+		errChan <- err
+		return
+	}
+	defer body.Close()
+
+	if err := decodeEvents(body, func(event eventtypes.Message, err error) error {
+		if err != nil {
+			return err
+		}
+		eventChan <- event
+		return nil
+	}); err != nil {
+		errChan <- err
+		return
+	}
+}
+
+type eventProcessor func(event eventtypes.Message, err error) error
+
+func decodeEvents(input io.Reader, ep eventProcessor) error {
+	dec := json.NewDecoder(input)
+	for {
+		var event eventtypes.Message
+		err := dec.Decode(&event)
+		if err != nil && err == io.EOF {
+			break
+		}
+
+		if procErr := ep(event, err); procErr != nil {
+			return procErr
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/vdemeester/docker-events/handlers.go
+++ b/vendor/github.com/vdemeester/docker-events/handlers.go
@@ -1,0 +1,56 @@
+package events
+
+import (
+	"sync"
+
+	eventtypes "github.com/docker/engine-api/types/events"
+)
+
+// NewHandler creates an event handler using the specified function to qualify the message
+// and to route it to the correct handler.
+func NewHandler(fun func(eventtypes.Message) string) *Handler {
+	return &Handler{
+		keyFunc:  fun,
+		handlers: make(map[string]func(eventtypes.Message)),
+	}
+}
+
+// ByType is a qualify function based on message type.
+func ByType(e eventtypes.Message) string {
+	return e.Type
+}
+
+// ByAction is a qualify function based on message action.
+func ByAction(e eventtypes.Message) string {
+	return e.Action
+}
+
+// Handler is a struct holding the handlers by keys, and the function to get the
+// key from the message.
+type Handler struct {
+	keyFunc  func(eventtypes.Message) string
+	handlers map[string]func(eventtypes.Message)
+	mu       sync.Mutex
+}
+
+// Handle registers a function has handler for the specified key.
+func (w *Handler) Handle(key string, h func(eventtypes.Message)) {
+	w.mu.Lock()
+	w.handlers[key] = h
+	w.mu.Unlock()
+}
+
+// Watch ranges over the passed in event chan and processes the events based on the
+// handlers created for a given action.
+// To stop watching, close the event chan.
+func (w *Handler) Watch(c <-chan eventtypes.Message) {
+	for e := range c {
+		w.mu.Lock()
+		h, exists := w.handlers[w.keyFunc(e)]
+		w.mu.Unlock()
+		if !exists {
+			continue
+		}
+		go h(e)
+	}
+}


### PR DESCRIPTION
Add a `events` command and related method in `Project` 🐯.

Events command listen to real-time events from docker (filtering for the project). It's implemented using [vdemeester/docker-events](https://github.com/vdemeester/docker-events) library.

On the API side, `Events` returns a channel of Message (for engine-api) to be consumed by the client.

To do still:
- [x] Some tests (integration/unit)
- [x] Implement the `json` flag
- [x] Format date like `docker-compose` ?
- [ ] Handle error better

<del>*Note*: test should be easier to implement once `context.Context` PR is merged (#241)</del>

Closes #215.

/cc @joshwget @ibuildthecloud @dnephin 

🐸