### PR TITLE
Fix named volumes

### DIFF
--- a/docker/convert.go
+++ b/docker/convert.go
@@ -55,10 +55,14 @@ func ConvertToAPI(s *Service) (*ConfigWrapper, error) {
 	return &result, nil
 }
 
+func isNamedVolume(volume string) bool {
+	return !strings.HasPrefix(volume, ".") && !strings.HasPrefix(volume, "/") && !strings.HasPrefix(volume, "~")
+}
+
 func volumes(c *config.ServiceConfig, ctx project.Context) map[string]struct{} {
 	volumes := make(map[string]struct{}, len(c.Volumes))
 	for k, v := range c.Volumes {
-		if len(ctx.ComposeFiles) > 0 {
+		if len(ctx.ComposeFiles) > 0 && !isNamedVolume(v) {
 			v = ctx.ResourceLookup.ResolvePath(v, ctx.ComposeFiles[0])
 		}
 

--- a/integration/volume_test.go
+++ b/integration/volume_test.go
@@ -56,4 +56,22 @@ func (s *CliSuite) TestRelativeVolume(c *C) {
 	c.Assert(cn, NotNil)
 	c.Assert(len(cn.Mounts), DeepEquals, 1)
 	c.Assert(cn.Mounts[0].Source, DeepEquals, absPath)
+	c.Assert(cn.Mounts[0].Destination, DeepEquals, "/path")
+}
+
+func (s *CliSuite) TestNamedVolume(c *C) {
+	p := s.ProjectFromText(c, "up", `
+	server:
+	  image: busybox
+	  volumes:
+	    - vol:/path
+	`)
+
+	serverName := fmt.Sprintf("%s_%s_1", p, "server")
+	cn := s.GetContainerByName(c, serverName)
+
+	c.Assert(cn, NotNil)
+	c.Assert(len(cn.Mounts), DeepEquals, 1)
+	c.Assert(cn.Mounts[0].Name, DeepEquals, "vol")
+	c.Assert(cn.Mounts[0].Destination, DeepEquals, "/path")
 }

--- a/lookup/file.go
+++ b/lookup/file.go
@@ -61,14 +61,6 @@ func (f *FileConfigLookup) ResolvePath(path, inFile string) string {
 	if len(vs) != 2 || filepath.IsAbs(vs[0]) {
 		return path
 	}
-
-	if !strings.HasPrefix(vs[0], "./") && !strings.HasPrefix(vs[0], "~/") &&
-		!strings.HasPrefix(vs[0], "/") {
-
-		logrus.Warnf("The mapping \"%s\" is ambiguous. In a future version of Docker, it will "+
-			"designate a \"named\" volume (see https://github.com/docker/docker/pull/14242). "+
-			"To prevent unexpected behaviour, change it to \"./%s\".", vs[0], vs[0])
-	}
 	vs[0] = relativePath(vs[0], inFile)
 	return strings.Join(vs, ":")
 }


### PR DESCRIPTION
Named volumes are being incorrectly resolved as relative volumes. This fixes the issue and removes the related warning, which doesn't seem to be present in Docker Compose anymore.

Signed-off-by: Josh Curl <josh@curl.me>