### PR TITLE
Add options to make parsing more customizable

### DIFF
--- a/cli/docker/app/factory.go
+++ b/cli/docker/app/factory.go
@@ -30,5 +30,5 @@ func (p *ProjectFactory) Create(c *cli.Context) (project.APIProject, error) {
 
 	context.ProjectName = c.GlobalString("project-name")
 
-	return docker.NewProject(context)
+	return docker.NewProject(context, nil)
 }

--- a/config/types.go
+++ b/config/types.go
@@ -221,3 +221,11 @@ type RawService map[string]interface{}
 
 // RawServiceMap is a collection of RawServices
 type RawServiceMap map[string]RawService
+
+// ParseOptions are a set of options to customize the parsing process
+type ParseOptions struct {
+	Interpolate bool
+	Validate    bool
+	Preprocess  func(RawServiceMap) (RawServiceMap, error)
+	Postprocess func(map[string]*ServiceConfig) (map[string]*ServiceConfig, error)
+}

--- a/docker/project.go
+++ b/docker/project.go
@@ -15,7 +15,7 @@ import (
 const ComposeVersion = "1.5.0"
 
 // NewProject creates a Project with the specified context.
-func NewProject(context *Context) (project.APIProject, error) {
+func NewProject(context *Context, parseOptions *config.ParseOptions) (project.APIProject, error) {
 	if context.ResourceLookup == nil {
 		context.ResourceLookup = &lookup.FileConfigLookup{}
 	}
@@ -54,7 +54,7 @@ func NewProject(context *Context) (project.APIProject, error) {
 	}
 
 	// FIXME(vdemeester) Remove the context duplication ?
-	p := project.NewProject(context.ClientFactory, &context.Context)
+	p := project.NewProject(context.ClientFactory, &context.Context, parseOptions)
 
 	err := p.Parse()
 	if err != nil {

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -27,7 +27,7 @@ service:
 			ComposeBytes: [][]byte{[]byte(service)},
 			ProjectName:  "test-volume-without-compose-file",
 		},
-	})
+	}, nil)
 
 	c.Assert(err, IsNil)
 

--- a/project/project.go
+++ b/project/project.go
@@ -29,6 +29,7 @@ type Project struct {
 	NetworkConfigs map[string]*config.NetworkConfig
 	Files          []string
 	ReloadCallback func() error
+	ParseOptions   *config.ParseOptions
 
 	context       *Context
 	clientFactory ClientFactory
@@ -39,10 +40,11 @@ type Project struct {
 }
 
 // NewProject creates a new project with the specified context.
-func NewProject(clientFactory ClientFactory, context *Context) *Project {
+func NewProject(clientFactory ClientFactory, context *Context, parseOptions *config.ParseOptions) *Project {
 	p := &Project{
 		context:        context,
 		clientFactory:  clientFactory,
+		ParseOptions:   parseOptions,
 		ServiceConfigs: config.NewServiceConfigs(),
 		VolumeConfigs:  make(map[string]*config.VolumeConfig),
 		NetworkConfigs: make(map[string]*config.NetworkConfig),
@@ -156,7 +158,7 @@ func (p *Project) Load(bytes []byte) error {
 }
 
 func (p *Project) load(file string, bytes []byte) error {
-	serviceConfigs, volumeConfigs, networkConfigs, err := config.Merge(p.ServiceConfigs, p.context.EnvironmentLookup, p.context.ResourceLookup, file, bytes)
+	serviceConfigs, volumeConfigs, networkConfigs, err := config.Merge(p.ServiceConfigs, p.context.EnvironmentLookup, p.context.ResourceLookup, file, bytes, p.ParseOptions)
 	if err != nil {
 		log.Errorf("Could not parse config for project %s : %v", p.Name, err)
 		return err

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -61,7 +61,7 @@ func TestTwoCall(t *testing.T) {
 
 	p := NewProject(nil, &Context{
 		ServiceFactory: factory,
-	})
+	}, nil)
 	p.ServiceConfigs = config.NewServiceConfigs()
 	p.ServiceConfigs.Add("foo", &config.ServiceConfig{})
 
@@ -83,7 +83,7 @@ func TestParseWithBadContent(t *testing.T) {
 		ComposeBytes: [][]byte{
 			[]byte("garbage"),
 		},
-	})
+	}, nil)
 
 	err := p.Parse()
 	if err == nil {
@@ -100,7 +100,7 @@ func TestParseWithGoodContent(t *testing.T) {
 		ComposeBytes: [][]byte{
 			[]byte("not-garbage:\n  image: foo"),
 		},
-	})
+	}, nil)
 
 	err := p.Parse()
 	if err != nil {
@@ -123,7 +123,7 @@ func TestEnvironmentResolve(t *testing.T) {
 	p := NewProject(nil, &Context{
 		ServiceFactory:    factory,
 		EnvironmentLookup: &TestEnvironmentLookup{},
-	})
+	}, nil)
 	p.ServiceConfigs = config.NewServiceConfigs()
 	p.ServiceConfigs.Add("foo", &config.ServiceConfig{
 		Environment: yaml.MaporEqualSlice([]string{
@@ -166,7 +166,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	p := NewProject(nil, &Context{
 		ComposeBytes: [][]byte{configOne, configTwo},
-	})
+	}, nil)
 
 	err := p.Parse()
 
@@ -179,7 +179,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	p = NewProject(nil, &Context{
 		ComposeBytes: [][]byte{configTwo, configOne},
-	})
+	}, nil)
 
 	err = p.Parse()
 
@@ -192,7 +192,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 
 	p = NewProject(nil, &Context{
 		ComposeBytes: [][]byte{configOne, configTwo, configThree},
-	})
+	}, nil)
 
 	err = p.Parse()
 


### PR DESCRIPTION
Adds a framework to specify a set of parsing-related options. Currently it allows disabling interpolation/validation and adds hooks for preprocessing and postprocessing configs. Being able to specify a custom schema is something I'm hoping to add to this soon.

Signed-off-by: Josh Curl <josh@curl.me>