### PR TITLE
docker.NewProject returns project struct instead of interface

### DIFF
--- a/docker/project.go
+++ b/docker/project.go
@@ -15,7 +15,7 @@ import (
 const ComposeVersion = "1.5.0"
 
 // NewProject creates a Project with the specified context.
-func NewProject(context *Context) (project.APIProject, error) {
+func NewProject(context *Context) (*project.Project, error) {
 	if context.ResourceLookup == nil {
 		context.ResourceLookup = &lookup.FileConfigLookup{}
 	}


### PR DESCRIPTION
The project struct defines some functions not available in the interface. If the interface is returned, we lose access to these when using `docker.NewProject`.

Signed-off-by: Josh Curl <josh@curl.me>