### PR TITLE
Add Josh Curl as maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -15,6 +15,7 @@
 			"aduermael",
 			"dnephin",
 			"ibuildthecloud",
+			"joshwget",
 			"gdevillele",
 			"vdemeester",
 		]
@@ -51,6 +52,11 @@
 	Name = "Gaetan de Villele"
 	Email = "gaetan@docker.com"
 	GitHub = "gdevillele"
+
+	[people.joshwget]
+	Name = "Josh Curl"
+	Email = "josh@rancher.com"
+	GitHub = "joshwget"
 
 	[people.vdemeester]
 	Name = "Vincent Demeester"


### PR DESCRIPTION
I'd like to nominate @joshwget as a maintainer for libcompose.  He has been active in the development of libcompose for more than 6 months and is additionally the number two contributor to libcompose.