### PR TITLE
Implement 'depends_on'

### DIFF
--- a/project/service.go
+++ b/project/service.go
@@ -68,6 +68,9 @@ const RelTypeIpcNamespace = ServiceRelationshipType("ipc")
 // RelTypeVolumesFrom means the services share some volumes.
 const RelTypeVolumesFrom = ServiceRelationshipType("volumesFrom")
 
+// RelTypeDependsOn means the dependency was explicitly set using 'depends_on'.
+const RelTypeDependsOn = ServiceRelationshipType("dependsOn")
+
 // ServiceRelationship holds the relationship information between two services.
 type ServiceRelationship struct {
 	Target, Alias string

--- a/project/utils.go
+++ b/project/utils.go
@@ -23,6 +23,10 @@ func DefaultDependentServices(p *Project, s Service) []ServiceRelationship {
 		result = append(result, NewServiceRelationship(volumesFrom, RelTypeVolumesFrom))
 	}
 
+	for _, dependsOn := range config.DependsOn {
+		result = append(result, NewServiceRelationship(dependsOn, RelTypeDependsOn))
+	}
+
 	result = appendNs(p, result, s.Config().NetworkMode, RelTypeNetNamespace)
 	result = appendNs(p, result, s.Config().Ipc, RelTypeIpcNamespace)
 


### PR DESCRIPTION
Implementation of the `depends_on` key that builds on how dependencies are already handled. Adding tests for this is a bit difficult without a framework for testing dependencies in general, so I figure better testing can be handled separately.

#216 