### PR TITLE
Allow integers in map values, except in 'labels' key

### DIFF
--- a/yaml/types_yaml.go
+++ b/yaml/types_yaml.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/docker/engine-api/types/strslice"
@@ -259,6 +260,8 @@ func toSepMapParts(value map[interface{}]interface{}, sep string) ([]string, err
 		if sk, ok := k.(string); ok {
 			if sv, ok := v.(string); ok {
 				parts = append(parts, sk+sep+sv)
+			} else if sv, ok := v.(int64); ok {
+				parts = append(parts, sk+sep+strconv.FormatInt(sv, 10))
 			} else {
 				return nil, fmt.Errorf("Cannot unmarshal '%v' of type %T into a string value", v, v)
 			}

--- a/yaml/types_yaml_test.go
+++ b/yaml/types_yaml_test.go
@@ -99,14 +99,14 @@ func contains(list []string, item string) bool {
 }
 
 func TestMaporsliceYaml(t *testing.T) {
-	str := `{foo: {bar: baz, far: faz}}`
+	str := `{foo: {bar: baz, far: 1}}`
 
 	s := StructMaporslice{}
 	yaml.Unmarshal([]byte(str), &s)
 
 	assert.Equal(t, 2, len(s.Foo))
 	assert.True(t, contains(s.Foo, "bar=baz"))
-	assert.True(t, contains(s.Foo, "far=faz"))
+	assert.True(t, contains(s.Foo, "far=1"))
 
 	d, err := yaml.Marshal(&s)
 	assert.Nil(t, err)
@@ -116,7 +116,7 @@ func TestMaporsliceYaml(t *testing.T) {
 
 	assert.Equal(t, 2, len(s2.Foo))
 	assert.True(t, contains(s2.Foo, "bar=baz"))
-	assert.True(t, contains(s2.Foo, "far=faz"))
+	assert.True(t, contains(s2.Foo, "far=1"))
 }
 
 var sampleStructCommand = `command: bash`


### PR DESCRIPTION
Allows integers as values in all maps except the `labels` key, which gives an error in Docker Compose.

#266 

Signed-off-by: Josh Curl <josh@curl.me>