### PR TITLE
Add a config command

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -275,6 +275,16 @@ func ProjectKill(p project.APIProject, c *cli.Context) error {
 	return nil
 }
 
+// ProjectConfig validates and print the compose file.
+func ProjectConfig(p project.APIProject, c *cli.Context) error {
+	yaml, err := p.Config()
+	if err != nil {
+		return cli.NewExitError(err.Error(), 1)
+	}
+	fmt.Println(yaml)
+	return nil
+}
+
 // ProjectPause pauses service containers.
 func ProjectPause(p project.APIProject, c *cli.Context) error {
 	err := p.Pause(context.Background(), c.Args()...)

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -45,6 +45,15 @@ func CreateCommand(factory app.ProjectFactory) cli.Command {
 	}
 }
 
+// ConfigCommand defines the libcompose config subcommand
+func ConfigCommand(factory app.ProjectFactory) cli.Command {
+	return cli.Command{
+		Name:   "config",
+		Usage:  "Validate and view the compose file.",
+		Action: app.WithProject(factory, app.ProjectConfig),
+	}
+}
+
 // BuildCommand defines the libcompose build subcommand.
 func BuildCommand(factory app.ProjectFactory) cli.Command {
 	return cli.Command{

--- a/cli/main/main.go
+++ b/cli/main/main.go
@@ -23,6 +23,7 @@ func main() {
 	app.Flags = append(command.CommonFlags(), dockerApp.DockerClientFlags()...)
 	app.Commands = []cli.Command{
 		command.BuildCommand(factory),
+		command.ConfigCommand(factory),
 		command.CreateCommand(factory),
 		command.EventsCommand(factory),
 		command.DownCommand(factory),

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -58,15 +58,16 @@ services:
 		child := config["child"]
 
 		if parent.Image != "foo" {
-			t.Fatal("Invalid image", parent.Image)
+			t.Fatal("Invalid parent image", parent.Image)
 		}
 
+		t.Logf("%#v", config["child"])
 		if child.Build.Context != "" {
-			t.Fatal("Invalid build", child.Build)
+			t.Fatalf("Invalid build %#v", child.Build)
 		}
 
 		if child.Image != "foo" {
-			t.Fatal("Invalid image", child.Image)
+			t.Fatal("Invalid child image", child.Image)
 		}
 	}
 }

--- a/config/types.go
+++ b/config/types.go
@@ -226,6 +226,13 @@ func (c *ServiceConfigs) Keys() []string {
 	return keys
 }
 
+// All returns all the config at once
+func (c *ServiceConfigs) All() map[string]*ServiceConfig {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.m
+}
+
 // RawService is represent a Service in map form unparsed
 type RawService map[string]interface{}
 

--- a/integration/assets/v2-dependencies/docker-compose.yml
+++ b/integration/assets/v2-dependencies/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "2.0"
+services:
+    db:
+      image: busybox:latest
+      command: top
+    web:
+      image: busybox:latest
+      command: top
+      depends_on:
+        - db
+    console:
+      image: busybox:latest
+      command: top

--- a/integration/assets/v2-full/Dockerfile
+++ b/integration/assets/v2-full/Dockerfile
@@ -1,0 +1,4 @@
+
+FROM busybox:latest
+RUN  echo something
+CMD  top

--- a/integration/assets/v2-full/docker-compose.yml
+++ b/integration/assets/v2-full/docker-compose.yml
@@ -1,0 +1,25 @@
+
+version: "2"
+
+volumes:
+  data:
+    driver: local
+
+networks:
+  front: {}
+
+services:
+  web:
+    build:
+      context: .
+    networks:
+      - front
+      - default
+    volumes_from:
+      - other
+
+  other:
+    image: busybox:latest
+    command: top
+    volumes:
+      - /data

--- a/integration/assets/v2-simple/docker-compose.yml
+++ b/integration/assets/v2-simple/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "2"
+services:
+  simple:
+    image: busybox:latest
+    command: top
+  another:
+    image: busybox:latest
+    command: top

--- a/integration/assets/v2-simple/links-invalid.yml
+++ b/integration/assets/v2-simple/links-invalid.yml
@@ -1,0 +1,10 @@
+version: "2"
+services:
+  simple:
+    image: busybox:latest
+    command: top
+    links:
+      - another
+  another:
+    image: busybox:latest
+    command: top

--- a/project/interface.go
+++ b/project/interface.go
@@ -14,6 +14,7 @@ type APIProject interface {
 	events.Emitter
 
 	Build(ctx context.Context, options options.Build, sevice ...string) error
+	Config() (string, error)
 	Create(ctx context.Context, options options.Create, services ...string) error
 	Delete(ctx context.Context, options options.Delete, services ...string) error
 	Down(ctx context.Context, options options.Down, services ...string) error

--- a/project/project_config.go
+++ b/project/project_config.go
@@ -1,0 +1,27 @@
+package project
+
+import (
+	"github.com/docker/libcompose/config"
+	"gopkg.in/yaml.v2"
+)
+
+// ExportedConfig holds config attribute that will be exported
+type ExportedConfig struct {
+	Version  string                           `yaml:"version,omitempty"`
+	Services map[string]*config.ServiceConfig `yaml:"services"`
+	Volumes  map[string]*config.VolumeConfig  `yaml:"volumes"`
+	Networks map[string]*config.NetworkConfig `yaml:"networks"`
+}
+
+// Config validates and print the compose file.
+func (p *Project) Config() (string, error) {
+	cfg := ExportedConfig{
+		Version:  "2.0",
+		Services: p.ServiceConfigs.All(),
+		Volumes:  p.VolumeConfigs,
+		Networks: p.NetworkConfigs,
+	}
+
+	bytes, err := yaml.Marshal(cfg)
+	return string(bytes), err
+}


### PR DESCRIPTION
Add a simple config command (without any options for now) that does the same as `docker-compose config` 🐼.

It's pretty early on and the output will need tweaking. Even with tweaking it is going to be difficult to get the exact same output as docker-compose. The main point is to produce valid yaml that can be reused by both of them.

- [x] Need to add some test
- [x] Need to get rid of some empty key too (I'm not sure how, @joshwget help :sweat_smile: )
- [x] keep default value too
- [x] Need to add more flags :smile: (in this PR or not)

```
$ cat integration/assets/v2-full/docker-compose.yml 

version: "2"

volumes:
  data:
    driver: local

networks:
  front: {}

services:
  web:
    build:
      context: .
    networks:
      - front
      - default
    volumes_from:
      - other

  other:
    image: busybox:latest
    command: top
    volumes:
      - /data

$ ./bundles/libcompose-cli -p toto -f integration/assets/v2-full/docker-compose.yml config
WARN[0000] Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose) 
version: "2.0"
services:
  other:
    build: {}
    command: [top]
    image: busybox:latest
    logging: {}
    volumes:
    - /data
    ulimits: {}
  web:
    build:
      context: integration/assets/v2-full
    logging: {}
    networks:
    - front
    - default
    volumes_from:
    - other
    ulimits: {}
volumes:
  data:
    driver: local
networks:
  front:
    ipam: {}
```

*Notes* : 
- it slighly differ from `docker-compose config` output, mainly on the order of the keys and the empty struct.
- some flags of the `config` command are for validating only. At the point we arrive in `project.Config` the validation is already done, so it might end up as a no-op :stuck_out_tongue_closed_eyes:.
- `command` are not printed the same way as with `docker-compose` : `command: [top]` vs `command: "top"`
- `build: .` is still possible to use with `v2` compose file, but fails miserably with libcompose.. 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>