### PR TITLE
Add support for build args in composefiles

### DIFF
--- a/docker/builder/builder.go
+++ b/docker/builder/builder.go
@@ -41,6 +41,7 @@ type DaemonBuilder struct {
 	NoCache          bool
 	ForceRemove      bool
 	Pull             bool
+	BuildArgs        map[string]string
 }
 
 // Build implements Builder. It consumes the docker build API endpoint and sends
@@ -72,6 +73,7 @@ func (d *DaemonBuilder) Build(ctx context.Context, imageName string) error {
 		PullParent:  d.Pull,
 		Dockerfile:  d.Dockerfile,
 		AuthConfigs: d.AuthConfigs,
+		BuildArgs:   d.BuildArgs,
 	})
 	if err != nil {
 		return err

--- a/docker/service.go
+++ b/docker/service.go
@@ -156,6 +156,7 @@ func (s *Service) build(ctx context.Context, buildOptions options.Build) error {
 		Client:           s.context.ClientFactory.Create(s),
 		ContextDirectory: s.Config().Build.Context,
 		Dockerfile:       s.Config().Build.Dockerfile,
+		BuildArgs:        s.Config().Build.Args.ToMap(),
 		AuthConfigs:      s.context.AuthLookup.All(),
 		NoCache:          buildOptions.NoCache,
 		ForceRemove:      buildOptions.ForceRemove,

--- a/integration/assets/v2-build-args/Dockerfile
+++ b/integration/assets/v2-build-args/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox:latest
+ARG buildno=0
+RUN  echo buildno is ${buildno}

--- a/integration/assets/v2-build-args/docker-compose.yml
+++ b/integration/assets/v2-build-args/docker-compose.yml
@@ -1,0 +1,9 @@
+
+version: "2"
+
+services:
+  simple:
+    build:
+      context: .
+      args:
+        buildno: 1

--- a/integration/build_test.go
+++ b/integration/build_test.go
@@ -81,3 +81,14 @@ func (s *CliSuite) TestBuildWithNoCache3(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert([]string(two.Config.Cmd), DeepEquals, []string{"echo", "two"})
 }
+
+func (s *CliSuite) TestBuildWithArgs(c *C) {
+	p := s.RandomProject()
+	cmd := exec.Command(s.command, "-f", "./assets/v2-build-args/docker-compose.yml", "-p", p, "build")
+
+	output, err := cmd.Output()
+	c.Assert(err, IsNil)
+
+	c.Assert(strings.Contains(string(output), "buildno is 1"), Equals, true, Commentf("Expected 'buildno is 1' in output, got \n%s", string(output)))
+	c.Assert(strings.Contains(string(output), "buildno is 0"), Equals, false, Commentf("Expected to not find 'buildno is 0' in output, got \n%s", string(output)))
+}

--- a/script/.integration-daemon-start
+++ b/script/.integration-daemon-start
@@ -11,7 +11,7 @@ fi
 # intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
 exec 41>&1 42>&2
 
-export DOCKER_GRAPH=${DOCKER_GRAPH:-/var/lib/docker/${DOCKER_DAEMON_VERSION}}
+export DOCKER_GRAPH=/var/lib/docker/${DOCKER_DAEMON_VERSION}
 export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
 export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
 

--- a/yaml/types_yaml.go
+++ b/yaml/types_yaml.go
@@ -212,6 +212,11 @@ func (s *MaporEqualSlice) UnmarshalYAML(tag string, value interface{}) error {
 	return nil
 }
 
+// ToMap returns the list of string as a map splitting using = the key=value
+func (s *MaporEqualSlice) ToMap() map[string]string {
+	return toMap(*s, "=")
+}
+
 // MaporColonSlice represents a slice of strings that gets unmarshal from a
 // YAML map into 'key:value' string.
 type MaporColonSlice []string
@@ -226,6 +231,11 @@ func (s *MaporColonSlice) UnmarshalYAML(tag string, value interface{}) error {
 	return nil
 }
 
+// ToMap returns the list of string as a map splitting using = the key=value
+func (s *MaporColonSlice) ToMap() map[string]string {
+	return toMap(*s, ":")
+}
+
 // MaporSpaceSlice represents a slice of strings that gets unmarshal from a
 // YAML map into 'key value' string.
 type MaporSpaceSlice []string
@@ -238,6 +248,11 @@ func (s *MaporSpaceSlice) UnmarshalYAML(tag string, value interface{}) error {
 	}
 	*s = parts
 	return nil
+}
+
+// ToMap returns the list of string as a map splitting using = the key=value
+func (s *MaporSpaceSlice) ToMap() map[string]string {
+	return toMap(*s, " ")
 }
 
 func unmarshalToStringOrSepMapParts(value interface{}, key string) ([]string, error) {
@@ -285,4 +300,13 @@ func toStrings(s []interface{}) ([]string, error) {
 		}
 	}
 	return r, nil
+}
+
+func toMap(s []string, sep string) map[string]string {
+	m := map[string]string{}
+	for _, v := range s {
+		values := strings.Split(v, sep)
+		m[values[0]] = values[1]
+	}
+	return m
 }


### PR DESCRIPTION
This connect the dots to support build args from composefiles 🐳.

     build:
       context: .
       args:
         buildno: 1

The composefile part above will behave the same as `docker build --build-arg buildno=1`.

/cc @dnephin @joshwget @ibuildthecloud 

Closes #214 

🐸
Signed-off-by: Vincent Demeester <vincent@sbr.pm>