### PR TITLE
Make sure daemon graph folder is not shared…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ wrappedNode(label: 'linux && x86_64') {
     makeTask(image, "validate")
 
     stage "test"
-    makeTask(image, "test", ["TESTVERBOSE=1", "DAEMON_VERSION=all"])
+    makeTask(image, "test", ["DAEMON_VERSION=all"])
 
     stage "build"
     makeTask(image, "cross-binary")

--- a/script/.integration-daemon-start
+++ b/script/.integration-daemon-start
@@ -11,6 +11,7 @@ fi
 # intentionally open a couple bogus file descriptors to help test that they get scrubbed in containers
 exec 41>&1 42>&2
 
+export DOCKER_GRAPH=${DOCKER_GRAPH:-/var/lib/docker/${DOCKER_DAEMON_VERSION}}
 export DOCKER_GRAPHDRIVER=${DOCKER_GRAPHDRIVER:-vfs}
 export DOCKER_USERLANDPROXY=${DOCKER_USERLANDPROXY:-true}
 
@@ -32,6 +33,7 @@ if [ -z "$DOCKER_TEST_HOST" ]; then
                   --storage-driver "$DOCKER_GRAPHDRIVER" \
                   --pidfile "$DEST/docker.pid" \
                   --userland-proxy="$DOCKER_USERLANDPROXY" \
+                  --graph="$DOCKER_GRAPH" \
                   $storage_params \
       &> "$DEST/docker.log"
     ) &


### PR DESCRIPTION
… across integration runs (when testing against multiple daemon) 🐙.
Also remove `TESTVERBOSE` in CI, it's too much output -_-''.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>