### PR TITLE
Refactoring of events command

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -1,21 +1,17 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
-	eventtypes "github.com/docker/engine-api/types/events"
-	"github.com/docker/libcompose/labels"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/project/options"
 )
@@ -277,72 +273,6 @@ func ProjectUnpause(p project.APIProject, c *cli.Context) error {
 		return cli.NewExitError(err.Error(), 1)
 	}
 	return nil
-}
-
-// ProjectEvents listen for real-time events of containers.
-func ProjectEvents(p project.APIProject, c *cli.Context) error {
-	events, err := p.Events(context.Background(), c.Args()...)
-	if err != nil {
-		return err
-	}
-	var printfn func(eventtypes.Message)
-
-	if c.Bool("json") {
-		printfn = printJSON
-	} else {
-		printfn = printStd
-	}
-	for event := range events {
-		printfn(event)
-	}
-	return nil
-}
-
-var eventAttributes = []string{"image", "name"}
-
-func printStd(event eventtypes.Message) {
-	output := os.Stdout
-	fmt.Fprintf(output, "%s ", time.Unix(event.Time, 0).Format("2006-01-02 15:04:05.999999999"))
-	fmt.Fprintf(output, "%s %s %s", event.Type, event.Action, event.Actor.ID)
-	attrs := []string{}
-	for _, attr := range eventAttributes {
-		v := event.Actor.Attributes[attr]
-		attrs = append(attrs, fmt.Sprintf("%s=%s", attr, v))
-	}
-	fmt.Fprintf(output, " (%s)", strings.Join(attrs, ", "))
-	fmt.Fprint(output, "\n")
-}
-
-// JSONEvent holds in attributes to print as JSON in the event command.
-type JSONEvent struct {
-	Service    string            `json:"service"`
-	Event      string            `json:"event"`
-	ID         string            `json:"id"`
-	Time       time.Time         `json:"time"`
-	Attributes map[string]string `json:"attributes"`
-	Type       string            `json:"type"`
-}
-
-func printJSON(event eventtypes.Message) {
-	service := event.Actor.Attributes[labels.SERVICE.Str()]
-	attributes := map[string]string{}
-	for _, attr := range eventAttributes {
-		attributes[attr] = event.Actor.Attributes[attr]
-	}
-	jsonEvent := JSONEvent{
-		Service:    service,
-		Event:      event.Action,
-		Type:       event.Type,
-		ID:         event.Actor.ID,
-		Time:       time.Unix(event.Time, 0),
-		Attributes: attributes,
-	}
-	json, err := json.Marshal(jsonEvent)
-	if err != nil {
-		logrus.Warn(err)
-	}
-	output := os.Stdout
-	fmt.Fprintf(output, "%s", json)
 }
 
 // ProjectScale scales services.

--- a/cli/app/events.go
+++ b/cli/app/events.go
@@ -1,0 +1,56 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/codegangsta/cli"
+	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/project/events"
+)
+
+// ProjectEvents listen for real-time events of containers.
+func ProjectEvents(p project.APIProject, c *cli.Context) error {
+	evts, err := p.Events(context.Background(), c.Args()...)
+	if err != nil {
+		return err
+	}
+	var printfn func(events.ContainerEvent)
+
+	if c.Bool("json") {
+		printfn = printJSON
+	} else {
+		printfn = printStd
+	}
+	for event := range evts {
+		printfn(event)
+	}
+	return nil
+}
+
+func printStd(event events.ContainerEvent) {
+	output := os.Stdout
+	fmt.Fprintf(output, "%s ", event.Time.Format("2006-01-02 15:04:05.999999999"))
+	fmt.Fprintf(output, "%s %s %s", event.Type, event.Event, event.ID)
+	attrs := []string{}
+	for attr, value := range event.Attributes {
+		attrs = append(attrs, fmt.Sprintf("%s=%s", attr, value))
+	}
+
+	fmt.Fprintf(output, " (%s)", strings.Join(attrs, ", "))
+	fmt.Fprint(output, "\n")
+}
+
+func printJSON(event events.ContainerEvent) {
+	json, err := json.Marshal(event)
+	if err != nil {
+		logrus.Warn(err)
+	}
+	output := os.Stdout
+	fmt.Fprintf(output, "%s", json)
+}

--- a/integration/api_event_test.go
+++ b/integration/api_event_test.go
@@ -6,9 +6,9 @@ import (
 	"golang.org/x/net/context"
 	check "gopkg.in/check.v1"
 
-	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
 )
 
@@ -32,7 +32,7 @@ another:
 
 	ctx, cancelFun := context.WithCancel(context.Background())
 
-	messages, err := project.Events(ctx)
+	evts, err := project.Events(ctx)
 	c.Assert(err, check.IsNil)
 
 	go func() {
@@ -40,14 +40,14 @@ another:
 		// Close after everything is done
 		time.Sleep(250 * time.Millisecond)
 		cancelFun()
-		close(messages)
+		close(evts)
 	}()
 
-	events := []eventtypes.Message{}
-	for message := range messages {
-		events = append(events, message)
+	actual := []events.ContainerEvent{}
+	for event := range evts {
+		actual = append(actual, event)
 	}
 
 	// Should be 4 events (2 create, 2 start)
-	c.Assert(len(events), check.Equals, 4, check.Commentf("%v", events))
+	c.Assert(len(actual), check.Equals, 4, check.Commentf("%v", actual))
 }

--- a/project/empty.go
+++ b/project/empty.go
@@ -3,8 +3,8 @@ package project
 import (
 	"golang.org/x/net/context"
 
-	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
 )
 
@@ -102,7 +102,7 @@ func (e *EmptyService) RemoveImage(ctx context.Context, imageType options.ImageT
 }
 
 // Events implements Service.Events but does nothing.
-func (e *EmptyService) Events(ctx context.Context, events chan eventtypes.Message) error {
+func (e *EmptyService) Events(ctx context.Context, events chan events.ContainerEvent) error {
 	return nil
 }
 

--- a/project/events/events.go
+++ b/project/events/events.go
@@ -3,6 +3,7 @@ package events
 
 import (
 	"fmt"
+	"time"
 )
 
 // Notifier defines the methods an event notifier should have.
@@ -20,6 +21,16 @@ type Event struct {
 	EventType   EventType
 	ServiceName string
 	Data        map[string]string
+}
+
+// ContainerEvent holds attributes of container events.
+type ContainerEvent struct {
+	Service    string            `json:"service"`
+	Event      string            `json:"event"`
+	ID         string            `json:"id"`
+	Time       time.Time         `json:"time"`
+	Attributes map[string]string `json:"attributes"`
+	Type       string            `json:"type"`
 }
 
 // EventType defines a type of libcompose event.

--- a/project/interface.go
+++ b/project/interface.go
@@ -3,7 +3,6 @@ package project
 import (
 	"golang.org/x/net/context"
 
-	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
@@ -18,7 +17,7 @@ type APIProject interface {
 	Create(ctx context.Context, options options.Create, services ...string) error
 	Delete(ctx context.Context, options options.Delete, services ...string) error
 	Down(ctx context.Context, options options.Down, services ...string) error
-	Events(ctx context.Context, services ...string) (chan eventtypes.Message, error)
+	Events(ctx context.Context, services ...string) (chan events.ContainerEvent, error)
 	Kill(ctx context.Context, signal string, services ...string) error
 	Log(ctx context.Context, follow bool, services ...string) error
 	Pause(ctx context.Context, services ...string) error

--- a/project/project_events.go
+++ b/project/project_events.go
@@ -3,12 +3,12 @@ package project
 import (
 	"golang.org/x/net/context"
 
-	eventtypes "github.com/docker/engine-api/types/events"
+	"github.com/docker/libcompose/project/events"
 )
 
 // Events listen for real time events from containers (of the project).
-func (p *Project) Events(ctx context.Context, services ...string) (chan eventtypes.Message, error) {
-	events := make(chan eventtypes.Message)
+func (p *Project) Events(ctx context.Context, services ...string) (chan events.ContainerEvent, error) {
+	events := make(chan events.ContainerEvent)
 	if len(services) == 0 {
 		services = p.ServiceConfigs.Keys()
 	}

--- a/project/service.go
+++ b/project/service.go
@@ -5,8 +5,8 @@ import (
 
 	"golang.org/x/net/context"
 
-	eventtypes "github.com/docker/engine-api/types/events"
 	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
 )
 
@@ -15,7 +15,7 @@ type Service interface {
 	Build(ctx context.Context, buildOptions options.Build) error
 	Create(ctx context.Context, options options.Create) error
 	Delete(ctx context.Context, options options.Delete) error
-	Events(ctx context.Context, messages chan eventtypes.Message) error
+	Events(ctx context.Context, messages chan events.ContainerEvent) error
 	Info(ctx context.Context, qFlag bool) (InfoSet, error)
 	Log(ctx context.Context, follow bool) error
 	Kill(ctx context.Context, signal string) error


### PR DESCRIPTION
Quick refactoring of the events command/method to not tie `project` to `engine-api` types or `docker` package or `engine-api` types 🐹.

- Do not depend on engine-api event types on `project` package, and thus define a new ContainerEvent` struct in `project/events` package.
- Do not pop engine-api event types to the user of libcompose api.

/cc @joshwget :angel: 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>