### PR TITLE
Introduce watchContainers in service…

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -28,6 +28,7 @@ import (
 
 // Container holds information about a docker container and the service it is tied on.
 type Container struct {
+	id              string
 	name            string
 	serviceName     string
 	projectName     string

--- a/docker/service.go
+++ b/docker/service.go
@@ -86,28 +86,6 @@ func (s *Service) Create(ctx context.Context, options options.Create) error {
 	return err
 }
 
-func (s *Service) collectContainers(ctx context.Context) ([]*Container, error) {
-	client := s.clientFactory.Create(s)
-	containers, err := GetContainersByFilter(ctx, client, labels.SERVICE.Eq(s.name), labels.PROJECT.Eq(s.project.Name))
-	if err != nil {
-		return nil, err
-	}
-
-	result := []*Container{}
-
-	for _, container := range containers {
-		containerNumber, err := strconv.Atoi(container.Labels[labels.NUMBER.Str()])
-		if err != nil {
-			return nil, err
-		}
-		// Compose add "/" before name, so Name[1] will store actaul name.
-		name := strings.SplitAfter(container.Names[0], "/")
-		result = append(result, NewContainer(client, name[1], containerNumber, s))
-	}
-
-	return result, nil
-}
-
 func (s *Service) createOne(ctx context.Context, imageName string) (*Container, error) {
 	containers, err := s.constructContainers(ctx, imageName, 1)
 	if err != nil {
@@ -300,15 +278,35 @@ func (s *Service) up(ctx context.Context, imageName string, create bool, options
 		containers = []*Container{c}
 	}
 
-	return s.eachContainer(ctx, containers, func(c *Container) error {
-		if create {
-			if err := s.recreateIfNeeded(ctx, imageName, c, options.NoRecreate, options.ForceRecreate); err != nil {
+	hasBeenCreate := false
+
+	createAction := func(c *Container) error {
+		if !hasBeenCreate {
+			hasBeenCreate = true
+			if create {
+				if err := s.recreateIfNeeded(ctx, imageName, c, options.NoRecreate, options.ForceRecreate); err != nil {
+					return err
+				}
+			}
+			if err := c.Up(ctx, imageName); err != nil {
 				return err
 			}
 		}
+		if options.Log {
+			return c.Log(ctx, true)
+		}
+		return nil
+	}
+	actions := actionMap{
+		"create": createAction,
+		"die": func(c *Container) error {
+			// FIXME(vdemeester) add status code & co
+			logrus.Infof("Container %s exited.", c.Name())
+			return nil
+		},
+	}
 
-		return c.Up(ctx, imageName)
-	})
+	return s.watchContainers(ctx, containers, createAction, actions)
 }
 
 func (s *Service) recreateIfNeeded(ctx context.Context, imageName string, c *Container, noRecreate, forceRecreate bool) error {
@@ -335,6 +333,28 @@ func (s *Service) recreateIfNeeded(ctx context.Context, imageName string, c *Con
 	return nil
 }
 
+func (s *Service) collectContainers(ctx context.Context) ([]*Container, error) {
+	client := s.clientFactory.Create(s)
+	containers, err := GetContainersByFilter(ctx, client, labels.SERVICE.Eq(s.name), labels.PROJECT.Eq(s.project.Name))
+	if err != nil {
+		return nil, err
+	}
+
+	result := []*Container{}
+
+	for _, container := range containers {
+		containerNumber, err := strconv.Atoi(container.Labels[labels.NUMBER.Str()])
+		if err != nil {
+			return nil, err
+		}
+		// Compose add "/" before name, so Name[1] will store actaul name.
+		name := strings.SplitAfter(container.Names[0], "/")
+		result = append(result, NewContainer(client, name[1], containerNumber, s))
+	}
+
+	return result, nil
+}
+
 func (s *Service) collectContainersAndDo(ctx context.Context, action func(*Container) error) error {
 	containers, err := s.collectContainers(ctx)
 	if err != nil {
@@ -344,19 +364,60 @@ func (s *Service) collectContainersAndDo(ctx context.Context, action func(*Conta
 }
 
 func (s *Service) eachContainer(ctx context.Context, containers []*Container, action func(*Container) error) error {
-
 	tasks := utils.InParallel{}
 	for _, container := range containers {
-		task := func(container *Container) func() error {
-			return func() error {
-				return action(container)
-			}
-		}(container)
+		task := taskFunc(container, action)
+		tasks.Add(task)
+	}
+	return tasks.Wait()
+}
 
+func (s *Service) getFilters() filters.Args {
+	filter := filters.NewArgs()
+	filter.Add("label", fmt.Sprintf("%s=%s", labels.PROJECT, s.project.Name))
+	filter.Add("label", fmt.Sprintf("%s=%s", labels.SERVICE, s.name))
+	return filter
+}
+
+type actionMap map[string]func(*Container) error
+
+func (s *Service) watchContainers(ctx context.Context, initialContainers []*Container, action func(*Container) error, actions actionMap) error {
+	ctx, cancelFun := context.WithCancel(ctx)
+
+	tasks := utils.InParallel{}
+	for _, container := range initialContainers {
+		task := taskFunc(container, action)
 		tasks.Add(task)
 	}
 
-	return tasks.Wait()
+	filter := s.getFilters()
+	cli := s.clientFactory.Create(s)
+
+	handler := dockerevents.NewHandler(dockerevents.ByAction)
+	for key, action := range actions {
+		handler.Handle(key, func(m eventtypes.Message) {
+			container, _ := ExistingContainer(ctx, cli, m.ID, s)
+			if container != nil {
+				tasks.Add(taskFunc(container, action))
+			}
+		})
+	}
+
+	dockerevents.MonitorWithHandler(ctx, cli, types.EventsOptions{
+		Filters: filter,
+	}, handler)
+
+	err := tasks.Wait()
+	// Get out of the events monitor :)
+	cancelFun()
+
+	return err
+}
+
+func taskFunc(container *Container, action func(*Container) error) func() error {
+	return func() error {
+		return action(container)
+	}
 }
 
 // Stop implements Service.Stop. It stops any containers related to the service.
@@ -389,9 +450,24 @@ func (s *Service) Delete(ctx context.Context, options options.Delete) error {
 
 // Log implements Service.Log. It returns the docker logs for each container related to the service.
 func (s *Service) Log(ctx context.Context, follow bool) error {
-	return s.collectContainersAndDo(ctx, func(c *Container) error {
+	containers, err := s.collectContainers(ctx)
+	if err != nil {
+		return err
+	}
+
+	logAction := func(c *Container) error {
 		return c.Log(ctx, follow)
-	})
+	}
+	actions := actionMap{
+		"create": logAction,
+		"die": func(c *Container) error {
+			// FIXME(vdemeester) add status code & co
+			logrus.Infof("Container %s exited.", c.Name())
+			return nil
+		},
+	}
+
+	return s.watchContainers(ctx, containers, logAction, actions)
 }
 
 // Scale implements Service.Scale. It creates or removes containers to have the specified number
@@ -481,9 +557,7 @@ var eventAttributes = []string{"image", "name"}
 // Events implements Service.Events. It listen to all real-time events happening
 // for the service, and put them into the specified chan.
 func (s *Service) Events(ctx context.Context, evts chan events.ContainerEvent) error {
-	filter := filters.NewArgs()
-	filter.Add("label", fmt.Sprintf("%s=%s", labels.PROJECT, s.project.Name))
-	filter.Add("label", fmt.Sprintf("%s=%s", labels.SERVICE, s.name))
+	filter := s.getFilters()
 	client := s.clientFactory.Create(s)
 	return <-dockerevents.Monitor(ctx, client, types.EventsOptions{
 		Filters: filter,

--- a/project/options/types.go
+++ b/project/options/types.go
@@ -31,6 +31,7 @@ type Create struct {
 // Up holds options of compose up.
 type Up struct {
 	Create
+	Log bool
 }
 
 // ImageType defines the type of image (local, all)

--- a/project/project.go
+++ b/project/project.go
@@ -368,6 +368,8 @@ func (p *Project) Run(ctx context.Context, serviceName string, commandParts []st
 
 // Up creates and starts the specified services (kinda like docker run).
 func (p *Project) Up(ctx context.Context, options options.Up, services ...string) error {
+	ctx, cancelFun := context.WithCancel(ctx)
+	defer cancelFun()
 	return p.perform(events.ProjectUpStart, events.ProjectUpDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
 		wrapper.Do(wrappers, events.ServiceUpStart, events.ServiceUp, func(service Service) error {
 			return service.Up(ctx, options)


### PR DESCRIPTION
… that are used for `Up()` and `Log()` methods for now, to be able to detect new container for the current service and dying events 🐯.

This makes the behavior of `up` and `logs` command almost the same as docker-compose and should help implementing some `up` flags like `--abort-on-container-exit`.

/cc @joshwget @kunalkushwaha 

Having a simple way to listen to `docker` events helps a lot :angel:.

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>