### PR TITLE
Add support to network v2 🐡

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ WORKDIR /go/src/github.com/docker/libcompose
 
 # Compose COMMIT for acceptance test version, update that commit when
 # you want to update the acceptance test version to support.
-ENV COMPOSE_COMMIT f1603a3ee2b074df4cce61842bfc3dff2af8915e
+ENV COMPOSE_COMMIT 1.8.0-rc1
 RUN virtualenv venv && \
     git clone https://github.com/docker/compose.git venv/compose && \
     cd venv/compose && \

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ LIBCOMPOSE_ENVS := \
 	-e DOCKER_TEST_HOST \
 	-e TESTDIRS \
 	-e TESTFLAGS \
-        -e SHOWWARNING \
+	-e SHOWWARNING \
 	-e TESTVERBOSE
 
 # (default to no bind mount if DOCKER_HOST is set)

--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -181,7 +181,11 @@ func ProjectRun(p project.APIProject, c *cli.Context) error {
 	serviceName := c.Args()[0]
 	commandParts := c.Args()[1:]
 
-	exitCode, err := p.Run(context.Background(), serviceName, commandParts)
+	options := options.Run{
+		Detached: c.Bool("d"),
+	}
+
+	exitCode, err := p.Run(context.Background(), serviceName, commandParts, options)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}

--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -135,7 +135,12 @@ func RunCommand(factory app.ProjectFactory) cli.Command {
 		Name:   "run",
 		Usage:  "Run a one-off command",
 		Action: app.WithProject(factory, app.ProjectRun),
-		Flags:  []cli.Flag{},
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  "d",
+				Usage: "Detached mode: Run container in the background, print new container name.",
+			},
+		},
 	}
 }
 

--- a/docker/convert.go
+++ b/docker/convert.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"golang.org/x/net/context"
+
 	"github.com/docker/docker/runconfig/opts"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
@@ -11,6 +13,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 	"github.com/docker/libcompose/config"
+	composeclient "github.com/docker/libcompose/docker/client"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/utils"
 )
@@ -43,7 +46,7 @@ func isVolume(s string) bool {
 
 // ConvertToAPI converts a service configuration to a docker API container configuration.
 func ConvertToAPI(s *Service) (*ConfigWrapper, error) {
-	config, hostConfig, err := Convert(s.serviceConfig, s.context.Context)
+	config, hostConfig, err := Convert(s.serviceConfig, s.context.Context, s.clientFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +117,7 @@ func ports(c *config.ServiceConfig) (map[nat.Port]struct{}, nat.PortMap, error) 
 }
 
 // Convert converts a service configuration to an docker API structures (Config and HostConfig)
-func Convert(c *config.ServiceConfig, ctx project.Context) (*container.Config, *container.HostConfig, error) {
+func Convert(c *config.ServiceConfig, ctx project.Context, clientFactory composeclient.Factory) (*container.Config, *container.HostConfig, error) {
 	restartPolicy, err := restartPolicy(c)
 	if err != nil {
 		return nil, nil, err
@@ -177,6 +180,48 @@ func Convert(c *config.ServiceConfig, ctx project.Context) (*container.Config, *
 		Devices:      deviceMappings,
 	}
 
+	networkMode := c.NetworkMode
+	if c.NetworkMode == "" {
+		if c.Networks != nil && len(c.Networks.Networks) > 0 {
+			networkMode = c.Networks.Networks[0].RealName
+		}
+	} else {
+		switch {
+		case strings.HasPrefix(c.NetworkMode, "service:"):
+			serviceName := c.NetworkMode[8:]
+			if serviceConfig, ok := ctx.Project.ServiceConfigs.Get(serviceName); ok {
+				// FIXME(vdemeester) this is actually not right, should be fixed but not there
+				service, err := ctx.ServiceFactory.Create(ctx.Project, serviceName, serviceConfig)
+				if err != nil {
+					return nil, nil, err
+				}
+				containers, err := service.Containers(context.Background())
+				if err != nil {
+					return nil, nil, err
+				}
+				if len(containers) != 0 {
+					container := containers[0]
+					containerID, err := container.ID()
+					if err != nil {
+						return nil, nil, err
+					}
+					networkMode = "container:" + containerID
+				}
+				// FIXME(vdemeester) log/warn in case of len(containers) == 0
+			}
+		case strings.HasPrefix(c.NetworkMode, "container:"):
+			containerName := c.NetworkMode[10:]
+			client := clientFactory.Create(nil)
+			container, err := GetContainer(context.Background(), client, containerName)
+			if err != nil {
+				return nil, nil, err
+			}
+			networkMode = "container:" + container.ID
+		default:
+			// do nothing :)
+		}
+	}
+
 	hostConfig := &container.HostConfig{
 		VolumesFrom: volumesFrom,
 		CapAdd:      strslice.StrSlice(utils.CopySlice(c.CapAdd)),
@@ -190,7 +235,7 @@ func Convert(c *config.ServiceConfig, ctx project.Context) (*container.Config, *
 			Type:   c.Logging.Driver,
 			Config: utils.CopyMap(c.Logging.Options),
 		},
-		NetworkMode:    container.NetworkMode(c.NetworkMode),
+		NetworkMode:    container.NetworkMode(networkMode),
 		ReadonlyRootfs: c.ReadOnly,
 		PidMode:        container.PidMode(c.Pid),
 		UTSMode:        container.UTSMode(c.Uts),

--- a/docker/convert_test.go
+++ b/docker/convert_test.go
@@ -27,7 +27,7 @@ func TestParseBindsAndVolumes(t *testing.T) {
 	assert.Nil(t, err)
 	cfg, hostCfg, err := Convert(&config.ServiceConfig{
 		Volumes: []string{"/foo", "/home:/home", "/bar/baz", ".:/home", "/usr/lib:/usr/lib:ro"},
-	}, ctx.Context)
+	}, ctx.Context, nil)
 	assert.Nil(t, err)
 	assert.Equal(t, map[string]struct{}{"/foo": {}, "/bar/baz": {}}, cfg.Volumes)
 	assert.Equal(t, []string{"/home:/home", abs + "/foo:/home", "/usr/lib:/usr/lib:ro"}, hostCfg.Binds)
@@ -44,7 +44,7 @@ func TestParseLabels(t *testing.T) {
 		Entrypoint: yaml.Command([]string{bashCmd}),
 		Labels:     yaml.SliceorMap{fooLabel: "service.config.value"},
 	}
-	cfg, _, err := Convert(sc, ctx.Context)
+	cfg, _, err := Convert(sc, ctx.Context, nil)
 	assert.Nil(t, err)
 
 	cfg.Labels[fooLabel] = "FUN"

--- a/docker/network/factory.go
+++ b/docker/network/factory.go
@@ -1,0 +1,19 @@
+package network
+
+import (
+	"github.com/docker/libcompose/config"
+	composeclient "github.com/docker/libcompose/docker/client"
+	"github.com/docker/libcompose/project"
+)
+
+// DockerFactory implements project.NetworksFactory
+type DockerFactory struct {
+	ClientFactory composeclient.Factory
+}
+
+// Create implements project.NetworksFactory Create method.
+// It creates a Networks (that implements project.Networks) from specified configurations.
+func (f *DockerFactory) Create(projectName string, networkConfigs map[string]*config.NetworkConfig, serviceConfigs *config.ServiceConfigs, networkEnabled bool) (project.Networks, error) {
+	cli := f.ClientFactory.Create(nil)
+	return NetworksFromServices(cli, projectName, networkConfigs, serviceConfigs, networkEnabled)
+}

--- a/docker/network/network.go
+++ b/docker/network/network.go
@@ -1,0 +1,194 @@
+package network
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/client"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/network"
+	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/yaml"
+)
+
+// Network holds attributes and method for a network definition in compose
+type Network struct {
+	client        client.APIClient
+	name          string
+	projectName   string
+	driver        string
+	driverOptions map[string]string
+	ipam          config.Ipam
+	external      bool
+}
+
+func (n *Network) fullName() string {
+	name := n.projectName + "_" + n.name
+	if n.external {
+		name = n.name
+	}
+	return name
+}
+
+// Inspect inspect the current network
+func (n *Network) Inspect(ctx context.Context) (types.NetworkResource, error) {
+	return n.client.NetworkInspect(ctx, n.fullName())
+}
+
+// Remove removes the current network (from docker engine)
+func (n *Network) Remove(ctx context.Context) error {
+	if n.external {
+		fmt.Printf("Network %s is external, skipping", n.fullName())
+		return nil
+	}
+	fmt.Printf("Removing network %q\n", n.fullName())
+	return n.client.NetworkRemove(ctx, n.fullName())
+}
+
+// EnsureItExists make sure the network exists and return an error if it does not exists
+// and cannot be created.
+func (n *Network) EnsureItExists(ctx context.Context) error {
+	networkResource, err := n.Inspect(ctx)
+	if n.external {
+		if client.IsErrNetworkNotFound(err) {
+			// FIXME(vdemeester) introduce some libcompose error type
+			return fmt.Errorf("Network %s declared as external, but could not be found. Please create the network manually using docker network create %s and try again", n.fullName(), n.fullName())
+		}
+		return err
+	}
+	if err != nil && client.IsErrNetworkNotFound(err) {
+		return n.create(ctx)
+	}
+	if n.driver != "" && networkResource.Driver != n.driver {
+		return fmt.Errorf("Network %q needs to be recreated - driver has changed", n.fullName())
+	}
+	if len(n.driverOptions) != 0 && !reflect.DeepEqual(networkResource.Options, n.driverOptions) {
+		return fmt.Errorf("Network %q needs to be recreated - options have changed", n.fullName())
+	}
+	return err
+}
+
+func (n *Network) create(ctx context.Context) error {
+	fmt.Printf("Creating network %q with driver %q\n", n.fullName(), n.driver)
+	_, err := n.client.NetworkCreate(ctx, n.fullName(), types.NetworkCreate{
+		Driver:  n.driver,
+		Options: n.driverOptions,
+		IPAM:    convertToAPIIpam(n.ipam),
+	})
+	return err
+}
+
+func convertToAPIIpam(ipam config.Ipam) network.IPAM {
+	ipamConfigs := []network.IPAMConfig{}
+	for _, config := range ipam.Config {
+		ipamConfigs = append(ipamConfigs, network.IPAMConfig{
+			Subnet:     config.Subnet,
+			IPRange:    config.IPRange,
+			Gateway:    config.Gateway,
+			AuxAddress: config.AuxAddress,
+		})
+	}
+	return network.IPAM{
+		Driver: ipam.Driver,
+		Config: ipamConfigs,
+	}
+}
+
+// NewNetwork creates a new network from the specified name and config.
+func NewNetwork(projectName, name string, config *config.NetworkConfig, client client.APIClient) *Network {
+	networkName := name
+	if config.External.External {
+		networkName = config.External.Name
+	}
+	return &Network{
+		client:        client,
+		name:          networkName,
+		projectName:   projectName,
+		driver:        config.Driver,
+		driverOptions: config.DriverOpts,
+		external:      config.External.External,
+		ipam:          config.Ipam,
+	}
+}
+
+// Networks holds a list of network
+type Networks struct {
+	networks       []*Network
+	networkEnabled bool
+}
+
+// Initialize make sure network exists if network is enabled
+func (n *Networks) Initialize(ctx context.Context) error {
+	if !n.networkEnabled {
+		return nil
+	}
+	for _, network := range n.networks {
+		err := network.EnsureItExists(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Remove removes networks (clean-up)
+func (n *Networks) Remove(ctx context.Context) error {
+	if !n.networkEnabled {
+		return nil
+	}
+	for _, network := range n.networks {
+		err := network.Remove(ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// NetworksFromServices creates a new Networks struct based on networks configurations and
+// services configuration. If a network is defined but not used by any service, it will return
+// an error along the Networks.
+func NetworksFromServices(cli client.APIClient, projectName string, networkConfigs map[string]*config.NetworkConfig, services *config.ServiceConfigs, networkEnabled bool) (*Networks, error) {
+	var err error
+	networks := make([]*Network, 0, len(networkConfigs))
+	networkNames := map[string]*yaml.Network{}
+	for _, serviceName := range services.Keys() {
+		serviceConfig, _ := services.Get(serviceName)
+		if serviceConfig.NetworkMode != "" || serviceConfig.Networks == nil || len(serviceConfig.Networks.Networks) == 0 {
+			continue
+		}
+		for _, network := range serviceConfig.Networks.Networks {
+			if network.Name != "default" {
+				if _, ok := networkConfigs[network.Name]; !ok {
+					return nil, fmt.Errorf(`Service "%s" uses an undefined network "%s"`, serviceName, network.Name)
+				}
+			}
+			networkNames[network.Name] = network
+		}
+	}
+	for name, config := range networkConfigs {
+		network := NewNetwork(projectName, name, config, cli)
+		networks = append(networks, network)
+	}
+	if len(networkNames) != len(networks) {
+		unused := []string{}
+		for name := range networkConfigs {
+			if name == "default" {
+				continue
+			}
+			if _, ok := networkNames[name]; !ok {
+				unused = append(unused, name)
+			}
+		}
+		if len(unused) != 0 {
+			err = fmt.Errorf("Some networks were defined but are not used by any service: %v", strings.Join(unused, " "))
+		}
+	}
+	return &Networks{
+		networks:       networks,
+		networkEnabled: networkEnabled,
+	}, err
+}

--- a/docker/network/network_test.go
+++ b/docker/network/network_test.go
@@ -1,0 +1,538 @@
+package network
+
+import (
+	"fmt"
+	"testing"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/network"
+	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/test"
+	"github.com/docker/libcompose/yaml"
+)
+
+type networkNotFound struct {
+	network string
+}
+
+func (e networkNotFound) Error() string {
+	return fmt.Sprintf("network %s not found", e.network)
+}
+
+func (e networkNotFound) NotFound() bool {
+	return true
+}
+
+func TestNetworksFromServices(t *testing.T) {
+	cases := []struct {
+		networkConfigs   map[string]*config.NetworkConfig
+		services         map[string]*config.ServiceConfig
+		networkEnabled   bool
+		expectedNetworks []*Network
+		expectedError    bool
+	}{
+		{
+			expectedNetworks: []*Network{},
+		},
+		{
+			networkConfigs: map[string]*config.NetworkConfig{
+				"net1": {},
+			},
+			services: map[string]*config.ServiceConfig{},
+			expectedNetworks: []*Network{
+				{
+					name:        "net1",
+					projectName: "prj",
+				},
+			},
+			expectedError: true,
+		},
+		{
+			networkConfigs: map[string]*config.NetworkConfig{
+				"net1": {},
+				"net2": {},
+			},
+			services: map[string]*config.ServiceConfig{
+				"svc1": {
+					Networks: &yaml.Networks{
+						Networks: []*yaml.Network{
+							{
+								Name: "net1",
+							},
+						},
+					},
+				},
+			},
+			expectedNetworks: []*Network{
+				{
+					name:        "default",
+					projectName: "prj",
+				},
+				{
+					name:        "net1",
+					projectName: "prj",
+				},
+				{
+					name:        "net2",
+					projectName: "prj",
+				},
+			},
+			expectedError: true,
+		},
+		{
+			networkConfigs: map[string]*config.NetworkConfig{
+				"net1": {},
+				"net2": {},
+			},
+			services: map[string]*config.ServiceConfig{
+				"svc1": {
+					Networks: &yaml.Networks{
+						Networks: []*yaml.Network{
+							{
+								Name: "net1",
+							},
+						},
+					},
+				},
+				"svc2": {
+					Networks: &yaml.Networks{
+						Networks: []*yaml.Network{
+							{
+								Name: "net1",
+							},
+							{
+								Name: "net2",
+							},
+						},
+					},
+				},
+			},
+			expectedNetworks: []*Network{
+				{
+					name:        "net1",
+					projectName: "prj",
+				},
+				{
+					name:        "net2",
+					projectName: "prj",
+				},
+			},
+			expectedError: false,
+		},
+		{
+			networkConfigs: map[string]*config.NetworkConfig{
+				"net1": {},
+				"net2": {},
+			},
+			services: map[string]*config.ServiceConfig{
+				"svc1": {
+					Networks: &yaml.Networks{
+						Networks: []*yaml.Network{
+							{
+								Name: "net1",
+							},
+						},
+					},
+				},
+				"svc2": {
+					Networks: &yaml.Networks{
+						Networks: []*yaml.Network{
+							{
+								Name: "net1",
+							},
+							{
+								Name: "net2",
+							},
+						},
+					},
+				},
+				"svc3": {
+					NetworkMode: "host",
+					Networks: &yaml.Networks{
+						Networks: []*yaml.Network{
+							{
+								Name: "net3",
+							},
+						},
+					},
+				},
+			},
+			expectedNetworks: []*Network{
+				{
+					name:        "net1",
+					projectName: "prj",
+				},
+				{
+					name:        "net2",
+					projectName: "prj",
+				},
+			},
+			expectedError: false,
+		},
+	}
+	for index, c := range cases {
+		services := config.NewServiceConfigs()
+		for name, service := range c.services {
+			services.Add(name, service)
+		}
+		networks, err := NetworksFromServices(&networkClient{}, "prj", c.networkConfigs, services, c.networkEnabled)
+		if c.expectedError {
+			if err == nil {
+				t.Fatalf("%d: expected an error, got nothing", index)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("%d: didn't expect an error, got one %s", index, err.Error())
+			}
+			if networks.networkEnabled != c.networkEnabled {
+				t.Fatalf("%d: expected network enabled %v, got %v", index, c.networkEnabled, networks.networkEnabled)
+			}
+			if len(networks.networks) != len(c.expectedNetworks) {
+				t.Fatalf("%d: expected %v, got %v", index, c.expectedNetworks, networks.networks)
+			}
+			for _, network := range networks.networks {
+				testExpectedContainsNetwork(t, index, c.expectedNetworks, network)
+			}
+		}
+	}
+}
+
+func testExpectedContainsNetwork(t *testing.T, index int, expected []*Network, network *Network) {
+	found := false
+	for _, e := range expected {
+		if e.name == network.name && e.projectName == network.projectName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("%d: network %v not found in %v", index, network, expected)
+	}
+}
+
+type networkClient struct {
+	test.NopClient
+	expectedNetworkCreate   types.NetworkCreate
+	expectedRemoveNetworkID string
+	expectedName            string
+	inspectError            error
+	inspectNetworkDriver    string
+	inspectNetworkOptions   map[string]string
+	removeError             error
+}
+
+func (c *networkClient) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
+	if c.inspectError != nil {
+		return types.NetworkResource{}, c.inspectError
+	}
+	return types.NetworkResource{
+		ID:      "network_id",
+		Driver:  c.inspectNetworkDriver,
+		Options: c.inspectNetworkOptions,
+	}, nil
+}
+
+func (c *networkClient) NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error) {
+	if c.expectedName != "" {
+		if options.Driver != c.expectedNetworkCreate.Driver {
+			return types.NetworkCreateResponse{}, fmt.Errorf("Invalid network create, expected driver %q, got %q", c.expectedNetworkCreate.Driver, options.Driver)
+		}
+		if options.IPAM.Driver != c.expectedNetworkCreate.IPAM.Driver {
+			return types.NetworkCreateResponse{}, fmt.Errorf("Invalid network create, expected ipam %q, got %q", c.expectedNetworkCreate.IPAM, options.IPAM)
+		}
+		if len(options.IPAM.Config) != len(c.expectedNetworkCreate.IPAM.Config) {
+			return types.NetworkCreateResponse{}, fmt.Errorf("Invalid network create, expected ipam %q, got %q", c.expectedNetworkCreate.Driver, options.Driver)
+		}
+		return types.NetworkCreateResponse{
+			ID: c.expectedName,
+		}, nil
+	}
+	return c.NopClient.NetworkCreate(ctx, name, options)
+}
+
+func (c *networkClient) NetworkRemove(ctx context.Context, networkID string) error {
+	if c.expectedRemoveNetworkID != "" {
+		if networkID != c.expectedRemoveNetworkID {
+			return fmt.Errorf("Invalid network id for removing, expected %q, got %q", c.expectedRemoveNetworkID, networkID)
+		}
+		return nil
+	}
+	return c.NopClient.NetworkRemove(ctx, networkID)
+}
+
+func TestNetworksInitialize(t *testing.T) {
+	errorCases := []struct {
+		networkEnabled        bool
+		network               *Network
+		inspectError          error
+		inspectNetworkDriver  string
+		inspectNetworkOptions map[string]string
+		expectedNetworkCreate types.NetworkCreate
+		expectedName          string
+	}{
+		// NetworkNotEnabled, never an error
+		{
+			networkEnabled: false,
+			network: &Network{
+				name:   "net1",
+				driver: "driver1",
+			},
+			inspectError: networkNotFound{
+				network: "net1",
+			},
+		},
+		// External
+		{
+			networkEnabled: true,
+			network: &Network{
+				name:     "net1",
+				external: true,
+			},
+		},
+		// NotFound, will create a new one
+		{
+			networkEnabled: true,
+			network: &Network{
+				name:   "net1",
+				driver: "driver1",
+			},
+			inspectError: networkNotFound{
+				network: "net1",
+			},
+			expectedName: "net1",
+			expectedNetworkCreate: types.NetworkCreate{
+				Driver: "driver1",
+			},
+		},
+		// NotFound, will create a new one
+		// with IPAM
+		{
+			networkEnabled: true,
+			network: &Network{
+				name:   "net1",
+				driver: "driver1",
+				ipam: config.Ipam{
+					Driver: "ipamDriver",
+					Config: []config.IpamConfig{
+						{
+							Subnet:  "subnet",
+							IPRange: "iprange",
+						},
+					},
+				},
+			},
+			inspectError: networkNotFound{
+				network: "net1",
+			},
+			expectedName: "net1",
+			expectedNetworkCreate: types.NetworkCreate{
+				Driver: "driver1",
+				IPAM: network.IPAM{
+					Driver: "ipamDriver",
+					Config: []network.IPAMConfig{
+						{
+							Subnet:  "subnet",
+							IPRange: "iprange",
+						},
+					},
+				},
+			},
+		},
+		{
+			networkEnabled: true,
+			network: &Network{
+				name:   "net1",
+				driver: "driver1",
+			},
+			inspectNetworkDriver: "driver1",
+		},
+		{
+			networkEnabled: true,
+			network: &Network{
+				name:   "net1",
+				driver: "driver1",
+				driverOptions: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			inspectNetworkDriver: "driver1",
+			inspectNetworkOptions: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+		},
+	}
+	for _, e := range errorCases {
+		cli := &networkClient{
+			expectedName:          e.expectedName,
+			expectedNetworkCreate: e.expectedNetworkCreate,
+			inspectError:          e.inspectError,
+			inspectNetworkDriver:  e.inspectNetworkDriver,
+			inspectNetworkOptions: e.inspectNetworkOptions,
+		}
+		e.network.client = cli
+		networks := &Networks{
+			networkEnabled: e.networkEnabled,
+			networks: []*Network{
+				e.network,
+			},
+		}
+		err := networks.Initialize(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestNetworksInitializeErrors(t *testing.T) {
+	errorCases := []struct {
+		network               *Network
+		inspectError          error
+		inspectNetworkDriver  string
+		inspectNetworkOptions map[string]string
+		expectedNetworkCreate types.NetworkCreate
+		expectedName          string
+		expectedError         string
+	}{
+		{
+			network: &Network{
+				projectName: "prj",
+				name:        "net1",
+			},
+			inspectError:  fmt.Errorf("any error"),
+			expectedError: "any error",
+		},
+		{
+			network: &Network{
+				projectName: "prj",
+				name:        "net1",
+				external:    true,
+			},
+			inspectError: networkNotFound{
+				network: "net1",
+			},
+			expectedError: "Network net1 declared as external, but could not be found. Please create the network manually using docker network create net1 and try again",
+		},
+		{
+			network: &Network{
+				projectName: "prj",
+				name:        "net1",
+			},
+			inspectError: networkNotFound{
+				network: "net1",
+			},
+			expectedError: "Engine no longer exists", // default error
+		},
+		{
+			network: &Network{
+				projectName: "prj",
+				name:        "net1",
+				driver:      "driver1",
+			},
+			inspectNetworkDriver: "driver2",
+			expectedError:        `Network "prj_net1" needs to be recreated - driver has changed`,
+		},
+		{
+			network: &Network{
+				projectName: "prj",
+				name:        "net1",
+				driver:      "driver1",
+				driverOptions: map[string]string{
+					"key1": "value1",
+					"key2": "value2",
+				},
+			},
+			inspectNetworkDriver: "driver1",
+			inspectNetworkOptions: map[string]string{
+				"key1": "value1",
+				"key2": "anothervalue",
+			},
+			expectedError: `Network "prj_net1" needs to be recreated - options have changed`,
+		},
+	}
+	for index, e := range errorCases {
+		cli := &networkClient{
+			expectedName:          e.expectedName,
+			expectedNetworkCreate: e.expectedNetworkCreate,
+			inspectError:          e.inspectError,
+			inspectNetworkDriver:  e.inspectNetworkDriver,
+			inspectNetworkOptions: e.inspectNetworkOptions,
+		}
+		e.network.client = cli
+		networks := &Networks{
+			networkEnabled: true,
+			networks: []*Network{
+				e.network,
+			},
+		}
+		err := networks.Initialize(context.Background())
+		if err == nil || err.Error() != e.expectedError {
+			t.Errorf("%d: expected an error %v, got %v", index, e.expectedError, err)
+		}
+	}
+}
+
+func TestNetworksRemove(t *testing.T) {
+	removeCases := []struct {
+		networkEnabled          bool
+		expectedRemoveNetworkID string
+		network                 *Network
+	}{
+		// Network not enabled, always no error
+		{
+			networkEnabled: false,
+			network: &Network{
+				projectName: "prj",
+				name:        "net1",
+				driver:      "driver1",
+			},
+		},
+		// Network enabled
+		{
+			networkEnabled:          true,
+			expectedRemoveNetworkID: "prj_net1",
+			network: &Network{
+				projectName: "prj",
+				name:        "net1",
+				driver:      "driver1",
+			},
+		},
+	}
+	for _, c := range removeCases {
+		cli := &networkClient{
+			expectedRemoveNetworkID: c.expectedRemoveNetworkID,
+		}
+		c.network.client = cli
+		networks := &Networks{
+			networkEnabled: c.networkEnabled,
+			networks: []*Network{
+				c.network,
+			},
+		}
+		err := networks.Remove(context.Background())
+		if err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func TestNetworksRemoveErrors(t *testing.T) {
+	cli := &networkClient{}
+	networks := &Networks{
+		networkEnabled: true,
+		networks: []*Network{
+			{
+				client:      cli,
+				projectName: "prj",
+				name:        "net1",
+			},
+		},
+	}
+	err := networks.Remove(context.Background())
+	if err == nil {
+		t.Errorf("Expected a error, got nothing.")
+	}
+}

--- a/docker/project.go
+++ b/docker/project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/engine-api/types/filters"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/docker/client"
+	"github.com/docker/libcompose/docker/network"
 	"github.com/docker/libcompose/labels"
 	"github.com/docker/libcompose/lookup"
 	"github.com/docker/libcompose/project"
@@ -56,6 +57,13 @@ func NewProject(context *Context, parseOptions *config.ParseOptions) (project.AP
 			return nil, err
 		}
 		context.ClientFactory = factory
+	}
+
+	if context.NetworksFactory == nil {
+		networksFactory := &network.DockerFactory{
+			ClientFactory: context.ClientFactory,
+		}
+		context.NetworksFactory = networksFactory
 	}
 
 	// FIXME(vdemeester) Remove the context duplication ?

--- a/integration/assets/networks/bridge.yml
+++ b/integration/assets/networks/bridge.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks:
+      - bridge
+      - default

--- a/integration/assets/networks/default-network-config.yml
+++ b/integration/assets/networks/default-network-config.yml
@@ -1,0 +1,13 @@
+version: "2"
+services:
+  simple:
+    image: busybox:latest
+    command: top
+  another:
+    image: busybox:latest
+    command: top
+networks:
+  default:
+    driver: bridge
+    driver_opts:
+      "com.docker.network.bridge.enable_icc": "false"

--- a/integration/assets/networks/docker-compose.yml
+++ b/integration/assets/networks/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "2"
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks: ["front"]
+  app:
+    image: busybox
+    command: top
+    networks: ["front", "back"]
+    links:
+      - "db:database"
+  db:
+    image: busybox
+    command: top
+    networks: ["back"]
+
+networks:
+  front: {}
+  back: {}

--- a/integration/assets/networks/external-default.yml
+++ b/integration/assets/networks/external-default.yml
@@ -1,0 +1,12 @@
+version: "2"
+services:
+  simple:
+    image: busybox:latest
+    command: top
+  another:
+    image: busybox:latest
+    command: top
+networks:
+  default:
+    external:
+      name: composetest_external_network

--- a/integration/assets/networks/external-networks.yml
+++ b/integration/assets/networks/external-networks.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks:
+      - networks_foo
+      - bar
+
+networks:
+  networks_foo:
+    external: true
+  bar:
+    external:
+      name: networks_bar

--- a/integration/assets/networks/missing-network.yml
+++ b/integration/assets/networks/missing-network.yml
@@ -1,0 +1,10 @@
+version: "2"
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks: ["foo"]
+
+networks:
+  bar: {}

--- a/integration/assets/networks/network-aliases.yml
+++ b/integration/assets/networks/network-aliases.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks:
+      front:
+        aliases:
+          - forward_facing
+          - ahead
+      back:
+
+networks:
+  front: {}
+  back: {}

--- a/integration/assets/networks/network-mode.yml
+++ b/integration/assets/networks/network-mode.yml
@@ -1,0 +1,27 @@
+version: "2"
+
+services:
+  bridge:
+    image: busybox
+    command: top
+    network_mode: bridge
+
+  service:
+    image: busybox
+    command: top
+    network_mode: "service:bridge"
+
+  container:
+    image: busybox
+    command: top
+    network_mode: "container:composetest_network_mode_container"
+
+  host:
+    image: busybox
+    command: top
+    network_mode: host
+
+  none:
+    image: busybox
+    command: top
+    network_mode: none

--- a/integration/assets/networks/network-static-addresses.yml
+++ b/integration/assets/networks/network-static-addresses.yml
@@ -1,0 +1,23 @@
+version: "2"
+
+services:
+  web:
+    image: busybox
+    command: top
+    networks:
+     static_test:
+        ipv4_address: 172.16.100.100
+        ipv6_address: fe80::1001:100
+
+networks:
+  static_test:
+    driver: bridge
+    driver_opts:
+      com.docker.network.enable_ipv6: "true"
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.16.100.0/24
+        gateway: 172.16.100.1
+      - subnet: fe80::/64
+        gateway: fe80::1001:1

--- a/project/context.go
+++ b/project/context.go
@@ -24,6 +24,7 @@ type Context struct {
 	ProjectName         string
 	isOpen              bool
 	ServiceFactory      ServiceFactory
+	NetworksFactory     NetworksFactory
 	EnvironmentLookup   config.EnvironmentLookup
 	ResourceLookup      config.ResourceLookup
 	LoggerFactory       logger.Factory

--- a/project/empty.go
+++ b/project/empty.go
@@ -92,7 +92,7 @@ func (e *EmptyService) Unpause(ctx context.Context) error {
 }
 
 // Run implements Service.Run but does nothing.
-func (e *EmptyService) Run(ctx context.Context, commandParts []string) (int, error) {
+func (e *EmptyService) Run(ctx context.Context, commandParts []string, options options.Run) (int, error) {
 	return 0, nil
 }
 

--- a/project/interface.go
+++ b/project/interface.go
@@ -26,7 +26,7 @@ type APIProject interface {
 	Port(ctx context.Context, index int, protocol, serviceName, privatePort string) (string, error)
 	Pull(ctx context.Context, services ...string) error
 	Restart(ctx context.Context, timeout int, services ...string) error
-	Run(ctx context.Context, serviceName string, commandParts []string) (int, error)
+	Run(ctx context.Context, serviceName string, commandParts []string, options options.Run) (int, error)
 	Scale(ctx context.Context, timeout int, servicesScale map[string]int) error
 	Start(ctx context.Context, services ...string) error
 	Stop(ctx context.Context, timeout int, services ...string) error

--- a/project/network.go
+++ b/project/network.go
@@ -1,0 +1,19 @@
+package project
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/docker/libcompose/config"
+)
+
+// Networks defines the methods a libcompose network aggregate should define.
+type Networks interface {
+	Initialize(ctx context.Context) error
+	Remove(ctx context.Context) error
+}
+
+// NetworksFactory is an interface factory to create Networks object for the specified
+// configurations (service, networks, …)
+type NetworksFactory interface {
+	Create(projectName string, networkConfigs map[string]*config.NetworkConfig, serviceConfigs *config.ServiceConfigs, networkEnabled bool) (Networks, error)
+}

--- a/project/options/types.go
+++ b/project/options/types.go
@@ -28,6 +28,11 @@ type Create struct {
 	// ForceBuild bool
 }
 
+// Run holds options of compose run.
+type Run struct {
+	Detached bool
+}
+
 // Up holds options of compose up.
 type Up struct {
 	Create

--- a/project/project.go
+++ b/project/project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
 	"github.com/docker/libcompose/utils"
+	"github.com/docker/libcompose/yaml"
 )
 
 type wrapperAction func(*serviceWrapper, map[string]*serviceWrapper)
@@ -29,6 +30,7 @@ type Project struct {
 	ParseOptions   *config.ParseOptions
 
 	runtime       RuntimeProject
+	networks      Networks
 	configVersion string
 	context       *Context
 	reload        []string
@@ -164,13 +166,6 @@ func (p *Project) load(file string, bytes []byte) error {
 
 	p.configVersion = version
 
-	for name, config := range serviceConfigs {
-		err := p.AddConfig(name, config)
-		if err != nil {
-			return err
-		}
-	}
-
 	for name, config := range volumeConfigs {
 		err := p.AddVolumeConfig(name, config)
 		if err != nil {
@@ -185,6 +180,72 @@ func (p *Project) load(file string, bytes []byte) error {
 		}
 	}
 
+	for name, config := range serviceConfigs {
+		err := p.AddConfig(name, config)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Update network configuration a little bit
+	if p.isNetworkEnabled() {
+		for _, serviceName := range p.ServiceConfigs.Keys() {
+			serviceConfig, _ := p.ServiceConfigs.Get(serviceName)
+			if serviceConfig.NetworkMode != "" {
+				continue
+			}
+			if serviceConfig.Networks == nil || len(serviceConfig.Networks.Networks) == 0 {
+				// Add default as network
+				serviceConfig.Networks = &yaml.Networks{
+					Networks: []*yaml.Network{
+						{
+							Name: "default",
+						},
+					},
+				}
+			}
+			// Consolidate the name of the network
+			// FIXME(vdemeester) probably shouldn't be there, maybe move that to interface/factory
+			for _, network := range serviceConfig.Networks.Networks {
+				if net, ok := p.NetworkConfigs[network.Name]; ok {
+					if net.External.External {
+						network.RealName = network.Name
+						if net.External.Name != "" {
+							network.RealName = net.External.Name
+						}
+					} else {
+						network.RealName = p.Name + "_" + network.Name
+					}
+				}
+				// Ignoring if we don't find the network, it will be catched later
+			}
+		}
+	}
+
+	// FIXME(vdemeester) Not sure about this..
+	if p.context.NetworksFactory != nil {
+		networks, err := p.context.NetworksFactory.Create(p.Name, p.NetworkConfigs, p.ServiceConfigs, p.isNetworkEnabled())
+		if err != nil {
+			return err
+		}
+
+		p.networks = networks
+	}
+
+	return nil
+}
+
+func (p *Project) isNetworkEnabled() bool {
+	return p.configVersion == "2"
+}
+
+// initialize sets up required element for project before any action (on project and service).
+// This means it's not needed to be called on Config for example.
+func (p *Project) initialize(ctx context.Context) error {
+	if err := p.networks.Initialize(ctx); err != nil {
+		return err
+	}
+	// TODO Initialize volumes
 	return nil
 }
 
@@ -246,6 +307,14 @@ func (p *Project) Down(ctx context.Context, opts options.Down, services ...strin
 	if err := p.Delete(ctx, options.Delete{
 		RemoveVolume: opts.RemoveVolume,
 	}, services...); err != nil {
+		return err
+	}
+
+	networks, err := p.context.NetworksFactory.Create(p.Name, p.NetworkConfigs, p.ServiceConfigs, p.isNetworkEnabled())
+	if err != nil {
+		return err
+	}
+	if err := networks.Remove(ctx); err != nil {
 		return err
 	}
 
@@ -321,16 +390,19 @@ func (p *Project) Start(ctx context.Context, services ...string) error {
 }
 
 // Run executes a one off command (like `docker run image command`).
-func (p *Project) Run(ctx context.Context, serviceName string, commandParts []string) (int, error) {
+func (p *Project) Run(ctx context.Context, serviceName string, commandParts []string, opts options.Run) (int, error) {
 	if !p.ServiceConfigs.Has(serviceName) {
 		return 1, fmt.Errorf("%s is not defined in the template", serviceName)
 	}
 
+	if err := p.initialize(ctx); err != nil {
+		return 1, err
+	}
 	var exitCode int
 	err := p.forEach([]string{}, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
 		wrapper.Do(wrappers, events.ServiceRunStart, events.ServiceRun, func(service Service) error {
 			if service.Name() == serviceName {
-				code, err := service.Run(ctx, commandParts)
+				code, err := service.Run(ctx, commandParts, opts)
 				exitCode = code
 				return err
 			}
@@ -344,6 +416,9 @@ func (p *Project) Run(ctx context.Context, serviceName string, commandParts []st
 
 // Up creates and starts the specified services (kinda like docker run).
 func (p *Project) Up(ctx context.Context, options options.Up, services ...string) error {
+	if err := p.initialize(ctx); err != nil {
+		return err
+	}
 	return p.perform(events.ProjectUpStart, events.ProjectUpDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
 		wrapper.Do(wrappers, events.ServiceUpStart, events.ServiceUp, func(service Service) error {
 			return service.Up(ctx, options)

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -34,7 +34,7 @@ func (t *TestService) Name() string {
 	return t.name
 }
 
-func (t *TestService) Run(ctx context.Context, commandParts []string) (int, error) {
+func (t *TestService) Run(ctx context.Context, commandParts []string, opts options.Run) (int, error) {
 	return 0, nil
 }
 

--- a/project/service.go
+++ b/project/service.go
@@ -22,7 +22,7 @@ type Service interface {
 	Pause(ctx context.Context) error
 	Pull(ctx context.Context) error
 	Restart(ctx context.Context, timeout int) error
-	Run(ctx context.Context, commandParts []string) (int, error)
+	Run(ctx context.Context, commandParts []string, options options.Run) (int, error)
 	Scale(ctx context.Context, count int, timeout int) error
 	Start(ctx context.Context) error
 	Stop(ctx context.Context, timeout int) error
@@ -74,6 +74,9 @@ const RelTypeVolumesFrom = ServiceRelationshipType("volumesFrom")
 
 // RelTypeDependsOn means the dependency was explicitly set using 'depends_on'.
 const RelTypeDependsOn = ServiceRelationshipType("dependsOn")
+
+// RelTypeNetworkMode means the services depends on another service on networkMode
+const RelTypeNetworkMode = ServiceRelationshipType("networkMode")
 
 // ServiceRelationship holds the relationship information between two services.
 type ServiceRelationship struct {

--- a/project/utils.go
+++ b/project/utils.go
@@ -25,6 +25,13 @@ func DefaultDependentServices(p *Project, s Service) []ServiceRelationship {
 		result = append(result, NewServiceRelationship(dependsOn, RelTypeDependsOn))
 	}
 
+	if config.NetworkMode != "" {
+		if strings.HasPrefix(config.NetworkMode, "service:") {
+			serviceName := config.NetworkMode[8:]
+			result = append(result, NewServiceRelationship(serviceName, RelTypeNetworkMode))
+		}
+	}
+
 	return result
 }
 

--- a/script/test-acceptance
+++ b/script/test-acceptance
@@ -18,7 +18,7 @@ cd venv/compose
 # if the tests fail, we still want to execute a few cleanup commands
 # so we save the result for the exit command at the end.
 # the "or" ensures that return code isn't trapped by the parent script.
-timeout 15m py.test -vs --tb=short tests/acceptance || result=$?
+timeout --foreground 15m py.test -vs --tb=short $ACCEPTANCE_TEST_ARGS tests/acceptance || result=$?
 
 cd -
 bundle .integration-daemon-stop

--- a/yaml/network_test.go
+++ b/yaml/network_test.go
@@ -20,7 +20,7 @@ func TestMarshalNetworks(t *testing.T) {
 		},
 		{
 			networks: Networks{
-				Networks: []Network{
+				Networks: []*Network{
 					{
 						Name: "network1",
 					},
@@ -35,7 +35,7 @@ network2: {}
 		},
 		{
 			networks: Networks{
-				Networks: []Network{
+				Networks: []*Network{
 					{
 						Name:    "network1",
 						Aliases: []string{"alias1", "alias2"},
@@ -54,7 +54,7 @@ network2: {}
 		},
 		{
 			networks: Networks{
-				Networks: []Network{
+				Networks: []*Network{
 					{
 						Name:    "network1",
 						Aliases: []string{"alias1", "alias2"},
@@ -92,7 +92,7 @@ func TestUnmarshalNetworks(t *testing.T) {
 			yaml: `- network1
 - network2`,
 			expected: &Networks{
-				Networks: []Network{
+				Networks: []*Network{
 					{
 						Name: "network1",
 					},
@@ -105,7 +105,7 @@ func TestUnmarshalNetworks(t *testing.T) {
 		{
 			yaml: `network1: {}`,
 			expected: &Networks{
-				Networks: []Network{
+				Networks: []*Network{
 					{
 						Name: "network1",
 					},
@@ -118,7 +118,7 @@ func TestUnmarshalNetworks(t *testing.T) {
     - alias1
     - alias2`,
 			expected: &Networks{
-				Networks: []Network{
+				Networks: []*Network{
 					{
 						Name:    "network1",
 						Aliases: []string{"alias1", "alias2"},
@@ -134,7 +134,7 @@ func TestUnmarshalNetworks(t *testing.T) {
   ipv4_address: 172.16.238.10
   ipv6_address: 2001:3984:3989::10`,
 			expected: &Networks{
-				Networks: []Network{
+				Networks: []*Network{
 					{
 						Name:        "network1",
 						Aliases:     []string{"alias1", "alias2"},


### PR DESCRIPTION
This PR brings the first and main step to add support for networking for v2 compose files 🐹.

- Create a `docker/network` package, with testing
- Add some yml to try it out
- Update some stuff in container and service. Note though there is a lot of FIXME(s)/TODO(s) because some of the things added will be refactored/moved with service.go and container.go refactoring.

There is probably still some weird edge cases where it does not works correctly but it does the job for the main use cases. What is still to do :

- [x] Complete unit tests, depending on docker/engine-api#238 to *mock* `NotFound` network errors and thus test the call to `NetworkCreate`.
- [x] Add some integration tests
- [x] Support `service:…` and `container:…` network mode :wink: 

As said before, I made some changes *against my will* because of the way `Container` and `Service` interact with the current code base ; they will be taken care of when refactoring them to make `Container` a little bit less intelligent (and way less *talkative* with the API) and `Service` a little bit more :angel:. 

/cc @joshwget @ibuildthecloud @shouze

Closes #278 

🐸

*Note: this builds on top of #309 and #310 to make integration test pass :angel:*

Signed-off-by: Vincent Demeester <vincent@sbr.pm>