### PR TITLE
Bump engine-api to d06b85b29e37346a050f335042e16e6e8a9f49da

### DIFF
--- a/docker/container.go
+++ b/docker/container.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"os"
 	"strings"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -196,7 +197,7 @@ func (c *Container) CreateWithOverride(ctx context.Context, imageName string, co
 // Stop stops the container.
 func (c *Container) Stop(ctx context.Context, timeout int) error {
 	return c.withContainer(ctx, func(container *types.ContainerJSON) error {
-		return c.client.ContainerStop(ctx, container.ID, timeout)
+		return c.client.ContainerStop(ctx, container.ID, time.Duration(timeout)*time.Second)
 	})
 }
 
@@ -315,7 +316,7 @@ func (c *Container) Run(ctx context.Context, imageName string, configOverride *c
 		return holdHijackedConnection(configOverride.Tty, in, out, stderr, resp)
 	})
 
-	if err := c.client.ContainerStart(ctx, container.ID); err != nil {
+	if err := c.client.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
 		return -1, err
 	}
 
@@ -400,7 +401,7 @@ func (c *Container) Up(ctx context.Context, imageName string) error {
 // Start the specified container with the specified host config
 func (c *Container) Start(container *types.ContainerJSON) error {
 	logrus.WithFields(logrus.Fields{"container.ID": container.ID, "c.name": c.name}).Debug("Starting container")
-	if err := c.client.ContainerStart(context.Background(), container.ID); err != nil {
+	if err := c.client.ContainerStart(context.Background(), container.ID, types.ContainerStartOptions{}); err != nil {
 		logrus.WithFields(logrus.Fields{"container.ID": container.ID, "c.name": c.name}).Debug("Failed to start container")
 		return err
 	}
@@ -612,7 +613,7 @@ func (c *Container) Restart(ctx context.Context, timeout int) error {
 		return err
 	}
 
-	return c.client.ContainerRestart(ctx, container.ID, timeout)
+	return c.client.ContainerRestart(ctx, container.ID, time.Duration(timeout)*time.Second)
 }
 
 // Log forwards container logs to the project configured logger.

--- a/script/vendor.sh
+++ b/script/vendor.sh
@@ -13,7 +13,7 @@ clone git github.com/vbatts/tar-split v0.9.11
 clone git github.com/docker/docker 9837ec4da53f15f9120d53a6e1517491ba8b0261
 clone git github.com/docker/go-units 651fc226e7441360384da338d0fd37f2440ffbe3
 clone git github.com/docker/go-connections v0.2.0
-clone git github.com/docker/engine-api fd7f99d354831e7e809386087e7ec3129fdb1520
+clone git github.com/docker/engine-api d06b85b29e37346a050f335042e16e6e8a9f49da
 clone git github.com/vdemeester/docker-events b308d2e8d639d928c882913bcb4f85b3a84c7a07
 clone git github.com/flynn/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff
 clone git github.com/gorilla/context 14f550f51a

--- a/test/nop.go
+++ b/test/nop.go
@@ -3,9 +3,11 @@ package test
 import (
 	"errors"
 	"io"
+	"time"
 
 	"golang.org/x/net/context"
 
+	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/filters"
@@ -15,6 +17,9 @@ import (
 
 var (
 	errNoEngine = errors.New("Engine no longer exists")
+
+	// Make sure NopClient implements APIClient
+	_ client.APIClient = &NopClient{}
 )
 
 // NopClient is a nop API Client based on engine-api
@@ -29,6 +34,21 @@ func NewNopClient() *NopClient {
 // ClientVersion returns the version string associated with this instance of the Client
 func (client *NopClient) ClientVersion() string {
 	return ""
+}
+
+// CheckpointCreate creates a checkpoint from the given container with the given name
+func (client *NopClient) CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error {
+	return errNoEngine
+}
+
+// CheckpointDelete deletes the checkpoint with the given name from the given container
+func (client *NopClient) CheckpointDelete(ctx context.Context, container string, checkpointID string) error {
+	return errNoEngine
+}
+
+// CheckpointList returns the volumes configured in the docker host.
+func (client *NopClient) CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error) {
+	return []types.Checkpoint{}, errNoEngine
 }
 
 // ContainerAttach attaches a connection to a container in the server
@@ -127,7 +147,7 @@ func (client *NopClient) ContainerResize(ctx context.Context, container string, 
 }
 
 // ContainerRestart stops and starts a container again
-func (client *NopClient) ContainerRestart(ctx context.Context, container string, timeout int) error {
+func (client *NopClient) ContainerRestart(ctx context.Context, container string, timeout time.Duration) error {
 	return errNoEngine
 }
 
@@ -142,12 +162,12 @@ func (client *NopClient) ContainerStats(ctx context.Context, container string, s
 }
 
 // ContainerStart sends a request to the docker daemon to start a container
-func (client *NopClient) ContainerStart(ctx context.Context, container string) error {
+func (client *NopClient) ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error {
 	return errNoEngine
 }
 
 // ContainerStop stops a container without terminating the process
-func (client *NopClient) ContainerStop(ctx context.Context, container string, timeout int) error {
+func (client *NopClient) ContainerStop(ctx context.Context, container string, timeout time.Duration) error {
 	return errNoEngine
 }
 
@@ -247,7 +267,7 @@ func (client *NopClient) ImageSave(ctx context.Context, images []string) (io.Rea
 }
 
 // ImageTag tags an image in the docker host
-func (client *NopClient) ImageTag(ctx context.Context, image, ref string, options types.ImageTagOptions) error {
+func (client *NopClient) ImageTag(ctx context.Context, image, ref string) error {
 	return errNoEngine
 }
 
@@ -274,6 +294,11 @@ func (client *NopClient) NetworkDisconnect(ctx context.Context, networkID, conta
 // NetworkInspect returns the information for a specific network configured in the docker host
 func (client *NopClient) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
 	return types.NetworkResource{}, errNoEngine
+}
+
+// NetworkInspectWithRaw returns the information for a specific network configured in the docker host and it's raw representation.
+func (client *NopClient) NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error) {
+	return types.NetworkResource{}, []byte{}, errNoEngine
 }
 
 // NetworkList returns the list of networks configured in the docker host
@@ -308,6 +333,11 @@ func (client *NopClient) VolumeCreate(ctx context.Context, options types.VolumeC
 // VolumeInspect returns the information about a specific volume in the docker host
 func (client *NopClient) VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error) {
 	return types.Volume{}, errNoEngine
+}
+
+// VolumeInspectWithRaw returns the information about a specific volume in the docker host and it's raw representation
+func (client *NopClient) VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error) {
+	return types.Volume{}, []byte{}, errNoEngine
 }
 
 // VolumeList returns the volumes configured in the docker host

--- a/vendor/github.com/docker/engine-api/client/checkpoint_create.go
+++ b/vendor/github.com/docker/engine-api/client/checkpoint_create.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// CheckpointCreate creates a checkpoint from the given container with the given name
+func (cli *Client) CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error {
+	resp, err := cli.post(ctx, "/containers/"+container+"/checkpoints", nil, options, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/checkpoint_delete.go
+++ b/vendor/github.com/docker/engine-api/client/checkpoint_delete.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"golang.org/x/net/context"
+)
+
+// CheckpointDelete deletes the checkpoint with the given name from the given container
+func (cli *Client) CheckpointDelete(ctx context.Context, containerID string, checkpointID string) error {
+	resp, err := cli.delete(ctx, "/containers/"+containerID+"/checkpoints/"+checkpointID, nil, nil)
+	ensureReaderClosed(resp)
+	return err
+}

--- a/vendor/github.com/docker/engine-api/client/checkpoint_list.go
+++ b/vendor/github.com/docker/engine-api/client/checkpoint_list.go
@@ -1,0 +1,22 @@
+package client
+
+import (
+	"encoding/json"
+
+	"github.com/docker/engine-api/types"
+	"golang.org/x/net/context"
+)
+
+// CheckpointList returns the volumes configured in the docker host.
+func (cli *Client) CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error) {
+	var checkpoints []types.Checkpoint
+
+	resp, err := cli.get(ctx, "/containers/"+container+"/checkpoints", nil, nil)
+	if err != nil {
+		return checkpoints, err
+	}
+
+	err = json.NewDecoder(resp.body).Decode(&checkpoints)
+	ensureReaderClosed(resp)
+	return checkpoints, err
+}

--- a/vendor/github.com/docker/engine-api/client/client.go
+++ b/vendor/github.com/docker/engine-api/client/client.go
@@ -12,6 +12,9 @@ import (
 	"github.com/docker/go-connections/tlsconfig"
 )
 
+// DefaultVersion is the version of the current stable API
+const DefaultVersion string = "1.23"
+
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
@@ -59,13 +62,22 @@ func NewEnvClient() (*Client, error) {
 	if host == "" {
 		host = DefaultDockerHost
 	}
-	return NewClient(host, os.Getenv("DOCKER_API_VERSION"), client, nil)
+
+	version := os.Getenv("DOCKER_API_VERSION")
+	if version == "" {
+		version = DefaultVersion
+	}
+
+	return NewClient(host, version, client, nil)
 }
 
 // NewClient initializes a new API client for the given host and API version.
-// It won't send any version information if the version number is empty.
 // It uses the given http client as transport.
 // It also initializes the custom http headers to add to each request.
+//
+// It won't send any version information if the version number is empty. It is
+// highly recommended that you set a version or your client may break if the
+// server is upgraded.
 func NewClient(host string, version string, client *http.Client, httpHeaders map[string]string) (*Client, error) {
 	proto, addr, basePath, err := ParseHost(host)
 	if err != nil {

--- a/vendor/github.com/docker/engine-api/client/container_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/container_inspect.go
@@ -52,14 +52,3 @@ func (cli *Client) ContainerInspectWithRaw(ctx context.Context, containerID stri
 	err = json.NewDecoder(rdr).Decode(&response)
 	return response, body, err
 }
-
-func (cli *Client) containerInspectWithResponse(ctx context.Context, containerID string, query url.Values) (types.ContainerJSON, *serverResponse, error) {
-	serverResp, err := cli.get(ctx, "/containers/"+containerID+"/json", nil, nil)
-	if err != nil {
-		return types.ContainerJSON{}, serverResp, err
-	}
-
-	var response types.ContainerJSON
-	err = json.NewDecoder(serverResp.body).Decode(&response)
-	return response, serverResp, err
-}

--- a/vendor/github.com/docker/engine-api/client/container_restart.go
+++ b/vendor/github.com/docker/engine-api/client/container_restart.go
@@ -2,17 +2,18 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerRestart stops and starts a container again.
 // It makes the daemon to wait for the container to be up again for
 // a specific amount of time, given the timeout.
-func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerRestart(ctx context.Context, containerID string, timeout time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	query.Set("t", timetypes.DurationToSecondsString(timeout))
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/restart", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/github.com/docker/engine-api/client/container_start.go
+++ b/vendor/github.com/docker/engine-api/client/container_start.go
@@ -1,10 +1,21 @@
 package client
 
-import "golang.org/x/net/context"
+import (
+	"net/url"
+
+	"golang.org/x/net/context"
+
+	"github.com/docker/engine-api/types"
+)
 
 // ContainerStart sends a request to the docker daemon to start a container.
-func (cli *Client) ContainerStart(ctx context.Context, containerID string) error {
-	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", nil, nil, nil)
+func (cli *Client) ContainerStart(ctx context.Context, containerID string, options types.ContainerStartOptions) error {
+	query := url.Values{}
+	if len(options.CheckpointID) != 0 {
+		query.Set("checkpoint", options.CheckpointID)
+	}
+
+	resp, err := cli.post(ctx, "/containers/"+containerID+"/start", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err
 }

--- a/vendor/github.com/docker/engine-api/client/container_stop.go
+++ b/vendor/github.com/docker/engine-api/client/container_stop.go
@@ -2,16 +2,17 @@ package client
 
 import (
 	"net/url"
-	"strconv"
+	"time"
 
+	timetypes "github.com/docker/engine-api/types/time"
 	"golang.org/x/net/context"
 )
 
 // ContainerStop stops a container without terminating the process.
 // The process is blocked until the container stops or the timeout expires.
-func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout int) error {
+func (cli *Client) ContainerStop(ctx context.Context, containerID string, timeout time.Duration) error {
 	query := url.Values{}
-	query.Set("t", strconv.Itoa(timeout))
+	query.Set("t", timetypes.DurationToSecondsString(timeout))
 	resp, err := cli.post(ctx, "/containers/"+containerID+"/stop", query, nil, nil)
 	ensureReaderClosed(resp)
 	return err

--- a/vendor/github.com/docker/engine-api/client/errors.go
+++ b/vendor/github.com/docker/engine-api/client/errors.go
@@ -8,26 +8,47 @@ import (
 // ErrConnectionFailed is an error raised when the connection between the client and the server failed.
 var ErrConnectionFailed = errors.New("Cannot connect to the Docker daemon. Is the docker daemon running on this host?")
 
+type notFound interface {
+	error
+	NotFound() bool // Is the error a NotFound error
+}
+
+// IsErrNotFound returns true if the error is caused with an
+// object (image, container, network, volume, …) is not found in the docker host.
+func IsErrNotFound(err error) bool {
+	te, ok := err.(notFound)
+	return ok && te.NotFound()
+}
+
 // imageNotFoundError implements an error returned when an image is not in the docker host.
 type imageNotFoundError struct {
 	imageID string
 }
 
+// NoFound indicates that this error type is of NotFound
+func (e imageNotFoundError) NotFound() bool {
+	return true
+}
+
 // Error returns a string representation of an imageNotFoundError
-func (i imageNotFoundError) Error() string {
-	return fmt.Sprintf("Error: No such image: %s", i.imageID)
+func (e imageNotFoundError) Error() string {
+	return fmt.Sprintf("Error: No such image: %s", e.imageID)
 }
 
 // IsErrImageNotFound returns true if the error is caused
 // when an image is not found in the docker host.
 func IsErrImageNotFound(err error) bool {
-	_, ok := err.(imageNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // containerNotFoundError implements an error returned when a container is not in the docker host.
 type containerNotFoundError struct {
 	containerID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e containerNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a containerNotFoundError
@@ -38,13 +59,17 @@ func (e containerNotFoundError) Error() string {
 // IsErrContainerNotFound returns true if the error is caused
 // when a container is not found in the docker host.
 func IsErrContainerNotFound(err error) bool {
-	_, ok := err.(containerNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // networkNotFoundError implements an error returned when a network is not in the docker host.
 type networkNotFoundError struct {
 	networkID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e networkNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -55,13 +80,17 @@ func (e networkNotFoundError) Error() string {
 // IsErrNetworkNotFound returns true if the error is caused
 // when a network is not found in the docker host.
 func IsErrNetworkNotFound(err error) bool {
-	_, ok := err.(networkNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // volumeNotFoundError implements an error returned when a volume is not in the docker host.
 type volumeNotFoundError struct {
 	volumeID string
+}
+
+// NoFound indicates that this error type is of NotFound
+func (e volumeNotFoundError) NotFound() bool {
+	return true
 }
 
 // Error returns a string representation of a networkNotFoundError
@@ -72,8 +101,7 @@ func (e volumeNotFoundError) Error() string {
 // IsErrVolumeNotFound returns true if the error is caused
 // when a volume is not found in the docker host.
 func IsErrVolumeNotFound(err error) bool {
-	_, ok := err.(volumeNotFoundError)
-	return ok
+	return IsErrNotFound(err)
 }
 
 // unauthorizedError represents an authorization error in a remote registry.

--- a/vendor/github.com/docker/engine-api/client/events.go
+++ b/vendor/github.com/docker/engine-api/client/events.go
@@ -33,7 +33,7 @@ func (cli *Client) Events(ctx context.Context, options types.EventsOptions) (io.
 		query.Set("until", ts)
 	}
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/docker/engine-api/client/image_build.go
+++ b/vendor/github.com/docker/engine-api/client/image_build.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"golang.org/x/net/context"
 
@@ -117,19 +116,4 @@ func getDockerOS(serverHeader string) string {
 		osType = matches[1]
 	}
 	return osType
-}
-
-// convertKVStringsToMap converts ["key=value"] to {"key":"value"}
-func convertKVStringsToMap(values []string) map[string]string {
-	result := make(map[string]string, len(values))
-	for _, value := range values {
-		kv := strings.SplitN(value, "=", 2)
-		if len(kv) == 1 {
-			result[kv[0]] = ""
-		} else {
-			result[kv[0]] = kv[1]
-		}
-	}
-
-	return result
 }

--- a/vendor/github.com/docker/engine-api/client/image_list.go
+++ b/vendor/github.com/docker/engine-api/client/image_list.go
@@ -15,7 +15,7 @@ func (cli *Client) ImageList(ctx context.Context, options types.ImageListOptions
 	query := url.Values{}
 
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return images, err
 		}

--- a/vendor/github.com/docker/engine-api/client/image_pull.go
+++ b/vendor/github.com/docker/engine-api/client/image_pull.go
@@ -32,7 +32,7 @@ func (cli *Client) ImagePull(ctx context.Context, ref string, options types.Imag
 	}
 
 	resp, err := cli.tryImageCreate(ctx, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/vendor/github.com/docker/engine-api/client/image_push.go
+++ b/vendor/github.com/docker/engine-api/client/image_push.go
@@ -35,7 +35,7 @@ func (cli *Client) ImagePush(ctx context.Context, ref string, options types.Imag
 	query.Set("tag", tag)
 
 	resp, err := cli.tryImagePush(ctx, distributionRef.Name(), query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return nil, privilegeErr

--- a/vendor/github.com/docker/engine-api/client/image_search.go
+++ b/vendor/github.com/docker/engine-api/client/image_search.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -17,6 +18,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	var results []registry.SearchResult
 	query := url.Values{}
 	query.Set("term", term)
+	query.Set("limit", fmt.Sprintf("%d", options.Limit))
 
 	if options.Filters.Len() > 0 {
 		filterJSON, err := filters.ToParam(options.Filters)
@@ -27,7 +29,7 @@ func (cli *Client) ImageSearch(ctx context.Context, term string, options types.I
 	}
 
 	resp, err := cli.tryImageSearch(ctx, query, options.RegistryAuth)
-	if resp.statusCode == http.StatusUnauthorized {
+	if resp.statusCode == http.StatusUnauthorized && options.PrivilegeFunc != nil {
 		newAuthHeader, privilegeErr := options.PrivilegeFunc()
 		if privilegeErr != nil {
 			return results, privilegeErr

--- a/vendor/github.com/docker/engine-api/client/image_tag.go
+++ b/vendor/github.com/docker/engine-api/client/image_tag.go
@@ -8,12 +8,11 @@ import (
 	"golang.org/x/net/context"
 
 	distreference "github.com/docker/distribution/reference"
-	"github.com/docker/engine-api/types"
 	"github.com/docker/engine-api/types/reference"
 )
 
 // ImageTag tags an image in the docker host
-func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options types.ImageTagOptions) error {
+func (cli *Client) ImageTag(ctx context.Context, imageID, ref string) error {
 	distributionRef, err := distreference.ParseNamed(ref)
 	if err != nil {
 		return fmt.Errorf("Error parsing reference: %q is not a valid repository/tag", ref)
@@ -28,9 +27,6 @@ func (cli *Client) ImageTag(ctx context.Context, imageID, ref string, options ty
 	query := url.Values{}
 	query.Set("repo", distributionRef.Name())
 	query.Set("tag", tag)
-	if options.Force {
-		query.Set("force", "1")
-	}
 
 	resp, err := cli.post(ctx, "/images/"+imageID+"/tag", query, nil, nil)
 	ensureReaderClosed(resp)

--- a/vendor/github.com/docker/engine-api/client/interface.go
+++ b/vendor/github.com/docker/engine-api/client/interface.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"io"
+	"time"
 
 	"golang.org/x/net/context"
 
@@ -15,6 +16,9 @@ import (
 // APIClient is an interface that clients that talk with a docker server must implement.
 type APIClient interface {
 	ClientVersion() string
+	CheckpointCreate(ctx context.Context, container string, options types.CheckpointCreateOptions) error
+	CheckpointDelete(ctx context.Context, container string, checkpointID string) error
+	CheckpointList(ctx context.Context, container string) ([]types.Checkpoint, error)
 	ContainerAttach(ctx context.Context, container string, options types.ContainerAttachOptions) (types.HijackedResponse, error)
 	ContainerCommit(ctx context.Context, container string, options types.ContainerCommitOptions) (types.ContainerCommitResponse, error)
 	ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, containerName string) (types.ContainerCreateResponse, error)
@@ -34,11 +38,11 @@ type APIClient interface {
 	ContainerRemove(ctx context.Context, container string, options types.ContainerRemoveOptions) error
 	ContainerRename(ctx context.Context, container, newContainerName string) error
 	ContainerResize(ctx context.Context, container string, options types.ResizeOptions) error
-	ContainerRestart(ctx context.Context, container string, timeout int) error
+	ContainerRestart(ctx context.Context, container string, timeout time.Duration) error
 	ContainerStatPath(ctx context.Context, container, path string) (types.ContainerPathStat, error)
 	ContainerStats(ctx context.Context, container string, stream bool) (io.ReadCloser, error)
-	ContainerStart(ctx context.Context, container string) error
-	ContainerStop(ctx context.Context, container string, timeout int) error
+	ContainerStart(ctx context.Context, container string, options types.ContainerStartOptions) error
+	ContainerStop(ctx context.Context, container string, timeout time.Duration) error
 	ContainerTop(ctx context.Context, container string, arguments []string) (types.ContainerProcessList, error)
 	ContainerUnpause(ctx context.Context, container string) error
 	ContainerUpdate(ctx context.Context, container string, updateConfig container.UpdateConfig) error
@@ -58,12 +62,13 @@ type APIClient interface {
 	ImageRemove(ctx context.Context, image string, options types.ImageRemoveOptions) ([]types.ImageDelete, error)
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
-	ImageTag(ctx context.Context, image, ref string, options types.ImageTagOptions) error
+	ImageTag(ctx context.Context, image, ref string) error
 	Info(ctx context.Context) (types.Info, error)
 	NetworkConnect(ctx context.Context, networkID, container string, config *network.EndpointSettings) error
 	NetworkCreate(ctx context.Context, name string, options types.NetworkCreate) (types.NetworkCreateResponse, error)
 	NetworkDisconnect(ctx context.Context, networkID, container string, force bool) error
 	NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error)
+	NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error)
 	NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error)
 	NetworkRemove(ctx context.Context, networkID string) error
 	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
@@ -71,6 +76,7 @@ type APIClient interface {
 	UpdateClientVersion(v string)
 	VolumeCreate(ctx context.Context, options types.VolumeCreateRequest) (types.Volume, error)
 	VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error)
+	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string) error
 }

--- a/vendor/github.com/docker/engine-api/client/network_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/network_inspect.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/docker/engine-api/types"
@@ -10,15 +12,27 @@ import (
 
 // NetworkInspect returns the information for a specific network configured in the docker host.
 func (cli *Client) NetworkInspect(ctx context.Context, networkID string) (types.NetworkResource, error) {
+	networkResource, _, err := cli.NetworkInspectWithRaw(ctx, networkID)
+	return networkResource, err
+}
+
+// NetworkInspectWithRaw returns the information for a specific network configured in the docker host and it's raw representation.
+func (cli *Client) NetworkInspectWithRaw(ctx context.Context, networkID string) (types.NetworkResource, []byte, error) {
 	var networkResource types.NetworkResource
 	resp, err := cli.get(ctx, "/networks/"+networkID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
-			return networkResource, networkNotFoundError{networkID}
+			return networkResource, nil, networkNotFoundError{networkID}
 		}
-		return networkResource, err
+		return networkResource, nil, err
 	}
-	err = json.NewDecoder(resp.body).Decode(&networkResource)
-	ensureReaderClosed(resp)
-	return networkResource, err
+	defer ensureReaderClosed(resp)
+
+	body, err := ioutil.ReadAll(resp.body)
+	if err != nil {
+		return networkResource, nil, err
+	}
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&networkResource)
+	return networkResource, body, err
 }

--- a/vendor/github.com/docker/engine-api/client/network_list.go
+++ b/vendor/github.com/docker/engine-api/client/network_list.go
@@ -13,7 +13,7 @@ import (
 func (cli *Client) NetworkList(ctx context.Context, options types.NetworkListOptions) ([]types.NetworkResource, error) {
 	query := url.Values{}
 	if options.Filters.Len() > 0 {
-		filterJSON, err := filters.ToParam(options.Filters)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, options.Filters)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/docker/engine-api/client/request.go
+++ b/vendor/github.com/docker/engine-api/client/request.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/docker/engine-api/client/transport/cancellable"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/versions"
 	"golang.org/x/net/context"
 )
 
@@ -85,6 +87,10 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 	}
 
 	req, err := cli.newRequest(method, path, query, body, headers)
+	if err != nil {
+		return serverResp, err
+	}
+
 	if cli.proto == "unix" || cli.proto == "npipe" {
 		// For local communications, it doesn't matter what the host is. We just
 		// need a valid and meaningful host name. (See #189)
@@ -98,10 +104,6 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 	}
 
 	resp, err := cancellable.Do(ctx, cli.transport, req)
-	if resp != nil {
-		serverResp.statusCode = resp.StatusCode
-	}
-
 	if err != nil {
 		if isTimeout(err) || strings.Contains(err.Error(), "connection refused") || strings.Contains(err.Error(), "dial unix") {
 			return serverResp, ErrConnectionFailed
@@ -110,11 +112,16 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 		if !cli.transport.Secure() && strings.Contains(err.Error(), "malformed HTTP response") {
 			return serverResp, fmt.Errorf("%v.\n* Are you trying to connect to a TLS-enabled daemon without TLS?", err)
 		}
-		if cli.transport.Secure() && strings.Contains(err.Error(), "remote error: bad certificate") {
+
+		if cli.transport.Secure() && strings.Contains(err.Error(), "bad certificate") {
 			return serverResp, fmt.Errorf("The server probably has client authentication (--tlsverify) enabled. Please check your TLS client certification settings: %v", err)
 		}
 
 		return serverResp, fmt.Errorf("An error occurred trying to connect: %v", err)
+	}
+
+	if resp != nil {
+		serverResp.statusCode = resp.StatusCode
 	}
 
 	if serverResp.statusCode < 200 || serverResp.statusCode >= 400 {
@@ -125,7 +132,20 @@ func (cli *Client) sendClientRequest(ctx context.Context, method, path string, q
 		if len(body) == 0 {
 			return serverResp, fmt.Errorf("Error: request returned %s for API route and version %s, check if the server supports the requested API version", http.StatusText(serverResp.statusCode), req.URL)
 		}
-		return serverResp, fmt.Errorf("Error response from daemon: %s", bytes.TrimSpace(body))
+
+		var errorMessage string
+		if (cli.version == "" || versions.GreaterThan(cli.version, "1.23")) &&
+			resp.Header.Get("Content-Type") == "application/json" {
+			var errorResponse types.ErrorResponse
+			if err := json.Unmarshal(body, &errorResponse); err != nil {
+				return serverResp, fmt.Errorf("Error reading JSON: %v", err)
+			}
+			errorMessage = errorResponse.Message
+		} else {
+			errorMessage = string(body)
+		}
+
+		return serverResp, fmt.Errorf("Error response from daemon: %s", strings.TrimSpace(errorMessage))
 	}
 
 	serverResp.body = resp.Body
@@ -167,6 +187,8 @@ func encodeData(data interface{}) (*bytes.Buffer, error) {
 
 func ensureReaderClosed(response *serverResponse) {
 	if response != nil && response.body != nil {
+		// Drain up to 512 bytes and close the body to let the Transport reuse the connection
+		io.CopyN(ioutil.Discard, response.body, 512)
 		response.body.Close()
 	}
 }

--- a/vendor/github.com/docker/engine-api/client/volume_inspect.go
+++ b/vendor/github.com/docker/engine-api/client/volume_inspect.go
@@ -1,7 +1,9 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/docker/engine-api/types"
@@ -10,15 +12,27 @@ import (
 
 // VolumeInspect returns the information about a specific volume in the docker host.
 func (cli *Client) VolumeInspect(ctx context.Context, volumeID string) (types.Volume, error) {
+	volume, _, err := cli.VolumeInspectWithRaw(ctx, volumeID)
+	return volume, err
+}
+
+// VolumeInspectWithRaw returns the information about a specific volume in the docker host and it's raw representation
+func (cli *Client) VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error) {
 	var volume types.Volume
 	resp, err := cli.get(ctx, "/volumes/"+volumeID, nil, nil)
 	if err != nil {
 		if resp.statusCode == http.StatusNotFound {
-			return volume, volumeNotFoundError{volumeID}
+			return volume, nil, volumeNotFoundError{volumeID}
 		}
-		return volume, err
+		return volume, nil, err
 	}
-	err = json.NewDecoder(resp.body).Decode(&volume)
-	ensureReaderClosed(resp)
-	return volume, err
+	defer ensureReaderClosed(resp)
+
+	body, err := ioutil.ReadAll(resp.body)
+	if err != nil {
+		return volume, nil, err
+	}
+	rdr := bytes.NewReader(body)
+	err = json.NewDecoder(rdr).Decode(&volume)
+	return volume, body, err
 }

--- a/vendor/github.com/docker/engine-api/client/volume_list.go
+++ b/vendor/github.com/docker/engine-api/client/volume_list.go
@@ -15,7 +15,7 @@ func (cli *Client) VolumeList(ctx context.Context, filter filters.Args) (types.V
 	query := url.Values{}
 
 	if filter.Len() > 0 {
-		filterJSON, err := filters.ToParam(filter)
+		filterJSON, err := filters.ToParamWithVersion(cli.version, filter)
 		if err != nil {
 			return volumes, err
 		}

--- a/vendor/github.com/docker/engine-api/types/client.go
+++ b/vendor/github.com/docker/engine-api/types/client.go
@@ -10,6 +10,12 @@ import (
 	"github.com/docker/go-units"
 )
 
+// CheckpointCreateOptions holds parameters to create a checkpoint from a container
+type CheckpointCreateOptions struct {
+	CheckpointID string
+	Exit         bool
+}
+
 // ContainerAttachOptions holds parameters to attach to a container.
 type ContainerAttachOptions struct {
 	Stream     bool
@@ -65,6 +71,11 @@ type ContainerRemoveOptions struct {
 	RemoveVolumes bool
 	RemoveLinks   bool
 	Force         bool
+}
+
+// ContainerStartOptions holds parameters to start containers.
+type ContainerStartOptions struct {
+	CheckpointID string
 }
 
 // CopyToContainerOptions holds information
@@ -207,11 +218,7 @@ type ImageSearchOptions struct {
 	RegistryAuth  string
 	PrivilegeFunc RequestPrivilegeFunc
 	Filters       filters.Args
-}
-
-// ImageTagOptions holds parameters to tag an image
-type ImageTagOptions struct {
-	Force bool
+	Limit         int
 }
 
 // ResizeOptions holds parameters to resize a tty.

--- a/vendor/github.com/docker/engine-api/types/container/config.go
+++ b/vendor/github.com/docker/engine-api/types/container/config.go
@@ -1,9 +1,31 @@
 package container
 
 import (
+	"time"
+
 	"github.com/docker/engine-api/types/strslice"
 	"github.com/docker/go-connections/nat"
 )
+
+// HealthConfig holds configuration settings for the HEALTHCHECK feature.
+type HealthConfig struct {
+	// Test is the test to perform to check that the container is healthy.
+	// An empty slice means to inherit the default.
+	// The options are:
+	// {} : inherit healthcheck
+	// {"NONE"} : disable healthcheck
+	// {"CMD", args...} : exec arguments directly
+	// {"CMD-SHELL", command} : run command with system's default shell
+	Test []string `json:",omitempty"`
+
+	// Zero means to inherit. Durations are expressed as integer nanoseconds.
+	Interval time.Duration `json:",omitempty"` // Interval is the time to wait between checks.
+	Timeout  time.Duration `json:",omitempty"` // Timeout is the time to wait before considering the check to have hung.
+
+	// Retries is the number of consecutive failures needed to consider a container as unhealthy.
+	// Zero means inherit.
+	Retries int `json:",omitempty"`
+}
 
 // Config contains the configuration data about a container.
 // It should hold only portable information about the container.
@@ -24,6 +46,7 @@ type Config struct {
 	StdinOnce       bool                  // If true, close stdin after the 1 attached client disconnects.
 	Env             []string              // List of environment variable to set in the container
 	Cmd             strslice.StrSlice     // Command to run when starting the container
+	Healthcheck     *HealthConfig         `json:",omitempty"` // Healthcheck describes how to check the container is healthy
 	ArgsEscaped     bool                  `json:",omitempty"` // True if command is already escaped (Windows specific)
 	Image           string                // Name of the image as it was passed by the operator (eg. could be symbolic)
 	Volumes         map[string]struct{}   // List of volumes (mounts) used for the container
@@ -34,4 +57,6 @@ type Config struct {
 	OnBuild         []string              // ONBUILD metadata that were defined on the image Dockerfile
 	Labels          map[string]string     // List of labels set to this container
 	StopSignal      string                `json:",omitempty"` // Signal to stop a container
+	StopTimeout     *int                  `json:",omitempty"` // Timeout (in seconds) to stop a container
+	Shell           strslice.StrSlice     `json:",omitempty"` // Shell for shell-form of RUN, CMD, ENTRYPOINT
 }

--- a/vendor/github.com/docker/engine-api/types/container/host_config.go
+++ b/vendor/github.com/docker/engine-api/types/container/host_config.go
@@ -136,28 +136,47 @@ func (n UTSMode) Valid() bool {
 	return true
 }
 
-// PidMode represents the pid stack of the container.
+// PidMode represents the pid namespace of the container.
 type PidMode string
 
-// IsPrivate indicates whether the container uses its private pid stack.
+// IsPrivate indicates whether the container uses its own new pid namespace.
 func (n PidMode) IsPrivate() bool {
-	return !(n.IsHost())
+	return !(n.IsHost() || n.IsContainer())
 }
 
-// IsHost indicates whether the container uses the host's pid stack.
+// IsHost indicates whether the container uses the host's pid namespace.
 func (n PidMode) IsHost() bool {
 	return n == "host"
 }
 
-// Valid indicates whether the pid stack is valid.
+// IsContainer indicates whether the container uses a container's pid namespace.
+func (n PidMode) IsContainer() bool {
+	parts := strings.SplitN(string(n), ":", 2)
+	return len(parts) > 1 && parts[0] == "container"
+}
+
+// Valid indicates whether the pid namespace is valid.
 func (n PidMode) Valid() bool {
 	parts := strings.Split(string(n), ":")
 	switch mode := parts[0]; mode {
 	case "", "host":
+	case "container":
+		if len(parts) != 2 || parts[1] == "" {
+			return false
+		}
 	default:
 		return false
 	}
 	return true
+}
+
+// Container returns the name of the container whose pid namespace is going to be used.
+func (n PidMode) Container() string {
+	parts := strings.SplitN(string(n), ":", 2)
+	if len(parts) > 1 {
+		return parts[1]
+	}
+	return ""
 }
 
 // DeviceMapping represents the device mapping between the host and the container.
@@ -176,7 +195,7 @@ type RestartPolicy struct {
 // IsNone indicates whether the container has the "no" restart policy.
 // This means the container will not automatically restart when exiting.
 func (rp *RestartPolicy) IsNone() bool {
-	return rp.Name == "no"
+	return rp.Name == "no" || rp.Name == ""
 }
 
 // IsAlways indicates whether the container has the "always" restart policy.
@@ -238,11 +257,10 @@ type Resources struct {
 	Ulimits              []*units.Ulimit // List of ulimits to be set in the container
 
 	// Applicable to Windows
-	CPUCount                int64  `json:"CpuCount"`   // CPU count
-	CPUPercent              int64  `json:"CpuPercent"` // CPU percent
-	IOMaximumIOps           uint64 // Maximum IOps for the container system drive
-	IOMaximumBandwidth      uint64 // Maximum IO in bytes per second for the container system drive
-	NetworkMaximumBandwidth uint64 // Maximum bandwidth of the network endpoint in bytes per second
+	CPUCount           int64  `json:"CpuCount"`   // CPU count
+	CPUPercent         int64  `json:"CpuPercent"` // CPU percent
+	IOMaximumIOps      uint64 // Maximum IOps for the container system drive
+	IOMaximumBandwidth uint64 // Maximum IO in bytes per second for the container system drive
 }
 
 // UpdateConfig holds the mutable attributes of a Container.
@@ -290,7 +308,8 @@ type HostConfig struct {
 	UTSMode         UTSMode           // UTS namespace to use for the container
 	UsernsMode      UsernsMode        // The user namespace to use for the container
 	ShmSize         int64             // Total shm memory usage
-	Sysctls         map[string]string `json:",omitempty"` // List of Namespaced sysctls used for the container
+	Sysctls         map[string]string `json:",omitempty"`        // List of Namespaced sysctls used for the container
+	Runtime         string            `json:"runtime,omitempty"` // Runtime to use with this container
 
 	// Applicable to Windows
 	ConsoleSize [2]int    // Initial console size

--- a/vendor/github.com/docker/engine-api/types/errors.go
+++ b/vendor/github.com/docker/engine-api/types/errors.go
@@ -1,0 +1,6 @@
+package types
+
+// ErrorResponse is the response body of API errors.
+type ErrorResponse struct {
+	Message string `json:"message"`
+}

--- a/vendor/github.com/docker/engine-api/types/events/events.go
+++ b/vendor/github.com/docker/engine-api/types/events/events.go
@@ -9,6 +9,8 @@ const (
 	VolumeEventType = "volume"
 	// NetworkEventType is the event type that networks generate
 	NetworkEventType = "network"
+	// DaemonEventType is the event type that daemon generate
+	DaemonEventType = "daemon"
 )
 
 // Actor describes something that generates events,

--- a/vendor/github.com/docker/engine-api/types/filters/parse.go
+++ b/vendor/github.com/docker/engine-api/types/filters/parse.go
@@ -215,10 +215,22 @@ func (filters Args) ExactMatch(field, source string) bool {
 	}
 
 	// try to match full name value to avoid O(N) regular expression matching
-	if fieldValues[source] {
+	return fieldValues[source]
+}
+
+// UniqueExactMatch returns true if there is only one filter and the source matches exactly this one.
+func (filters Args) UniqueExactMatch(field, source string) bool {
+	fieldValues := filters.fields[field]
+	//do not filter if there is no filter set or cannot determine filter
+	if len(fieldValues) == 0 {
 		return true
 	}
-	return false
+	if len(filters.fields[field]) != 1 {
+		return false
+	}
+
+	// try to match full name value to avoid O(N) regular expression matching
+	return fieldValues[source]
 }
 
 // FuzzyMatch returns true if the source matches exactly one of the filters,

--- a/vendor/github.com/docker/engine-api/types/seccomp.go
+++ b/vendor/github.com/docker/engine-api/types/seccomp.go
@@ -24,6 +24,11 @@ const (
 	ArchMIPSEL      Arch = "SCMP_ARCH_MIPSEL"
 	ArchMIPSEL64    Arch = "SCMP_ARCH_MIPSEL64"
 	ArchMIPSEL64N32 Arch = "SCMP_ARCH_MIPSEL64N32"
+	ArchPPC         Arch = "SCMP_ARCH_PPC"
+	ArchPPC64       Arch = "SCMP_ARCH_PPC64"
+	ArchPPC64LE     Arch = "SCMP_ARCH_PPC64LE"
+	ArchS390        Arch = "SCMP_ARCH_S390"
+	ArchS390X       Arch = "SCMP_ARCH_S390X"
 )
 
 // Action taken upon Seccomp rule match

--- a/vendor/github.com/docker/engine-api/types/time/duration_convert.go
+++ b/vendor/github.com/docker/engine-api/types/time/duration_convert.go
@@ -1,0 +1,12 @@
+package time
+
+import (
+	"strconv"
+	"time"
+)
+
+// DurationToSecondsString converts the specified duration to the number
+// seconds it represents, formatted as a string.
+func DurationToSecondsString(duration time.Duration) string {
+	return strconv.FormatFloat(duration.Seconds(), 'f', 0, 64)
+}

--- a/vendor/github.com/docker/engine-api/types/types.go
+++ b/vendor/github.com/docker/engine-api/types/types.go
@@ -28,7 +28,7 @@ type ContainerExecCreateResponse struct {
 }
 
 // ContainerUpdateResponse contains response of Remote API:
-// POST /containers/{name:.*}/update
+// POST "/containers/{name:.*}/update"
 type ContainerUpdateResponse struct {
 	// Warnings are any warnings encountered during the updating of the container.
 	Warnings []string `json:"Warnings"`
@@ -142,7 +142,7 @@ type Port struct {
 }
 
 // Container contains response of Remote API:
-// GET  "/containers/json"
+// GET "/containers/json"
 type Container struct {
 	ID         string `json:"Id"`
 	Names      []string
@@ -252,6 +252,8 @@ type Info struct {
 	ClusterStore       string
 	ClusterAdvertise   string
 	SecurityOptions    []string
+	Runtimes           map[string]Runtime
+	DefaultRuntime     string
 }
 
 // PluginsInfo is a temp struct holding Plugins name
@@ -274,6 +276,28 @@ type ExecStartCheck struct {
 	Tty bool
 }
 
+// HealthcheckResult stores information about a single run of a healthcheck probe
+type HealthcheckResult struct {
+	Start    time.Time // Start is the time this check started
+	End      time.Time // End is the time this check ended
+	ExitCode int       // ExitCode meanings: 0=healthy, 1=unhealthy, 2=starting, else=error running probe
+	Output   string    // Output from last check
+}
+
+// Health states
+const (
+	Starting  = "starting"  // Starting indicates that the container is not yet ready
+	Healthy   = "healthy"   // Healthy indicates that the container is running correctly
+	Unhealthy = "unhealthy" // Unhealthy indicates that the container has a problem
+)
+
+// Health stores information about the container's healthcheck results
+type Health struct {
+	Status        string               // Status is one of Starting, Healthy or Unhealthy
+	FailingStreak int                  // FailingStreak is the number of consecutive failures
+	Log           []*HealthcheckResult // Log contains the last few results (oldest first)
+}
+
 // ContainerState stores container's running state
 // it's part of ContainerJSONBase and will return by "inspect" command
 type ContainerState struct {
@@ -288,6 +312,7 @@ type ContainerState struct {
 	Error      string
 	StartedAt  string
 	FinishedAt string
+	Health     *Health `json:",omitempty"`
 }
 
 // ContainerNode stores information about the node that a container
@@ -298,7 +323,7 @@ type ContainerNode struct {
 	Addr      string
 	Name      string
 	Cpus      int
-	Memory    int
+	Memory    int64
 	Labels    map[string]string
 }
 
@@ -352,13 +377,13 @@ type SummaryNetworkSettings struct {
 
 // NetworkSettingsBase holds basic information about networks
 type NetworkSettingsBase struct {
-	Bridge                 string
-	SandboxID              string
-	HairpinMode            bool
-	LinkLocalIPv6Address   string
-	LinkLocalIPv6PrefixLen int
-	Ports                  nat.PortMap
-	SandboxKey             string
+	Bridge                 string      // Bridge is the Bridge name the network uses(e.g. `docker0`)
+	SandboxID              string      // SandboxID uniquely represents a container's network stack
+	HairpinMode            bool        // HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
+	LinkLocalIPv6Address   string      // LinkLocalIPv6Address is an IPv6 unicast address using the link-local prefix
+	LinkLocalIPv6PrefixLen int         // LinkLocalIPv6PrefixLen is the prefix length of an IPv6 unicast address
+	Ports                  nat.PortMap // Ports is a collection of PortBinding indexed by Port
+	SandboxKey             string      // SandboxKey identifies the sandbox
 	SecondaryIPAddresses   []network.Address
 	SecondaryIPv6Addresses []network.Address
 }
@@ -367,14 +392,14 @@ type NetworkSettingsBase struct {
 // during the 2 release deprecation period.
 // It will be removed in Docker 1.11.
 type DefaultNetworkSettings struct {
-	EndpointID          string
-	Gateway             string
-	GlobalIPv6Address   string
-	GlobalIPv6PrefixLen int
-	IPAddress           string
-	IPPrefixLen         int
-	IPv6Gateway         string
-	MacAddress          string
+	EndpointID          string // EndpointID uniquely represents a service endpoint in a Sandbox
+	Gateway             string // Gateway holds the gateway address for the network
+	GlobalIPv6Address   string // GlobalIPv6Address holds network's global IPv6 address
+	GlobalIPv6PrefixLen int    // GlobalIPv6PrefixLen represents mask length of network's global IPv6 address
+	IPAddress           string // IPAddress holds the IPv4 address for the network
+	IPPrefixLen         int    // IPPrefixLen represents mask length of network's IPv4 address
+	IPv6Gateway         string // IPv6Gateway holds gateway address specific for IPv6
+	MacAddress          string // MacAddress holds the MAC address for the network
 }
 
 // MountPoint represents a mount point configuration inside the container.
@@ -416,16 +441,16 @@ type VolumeCreateRequest struct {
 
 // NetworkResource is the body of the "get network" http response message
 type NetworkResource struct {
-	Name       string
-	ID         string `json:"Id"`
-	Scope      string
-	Driver     string
-	EnableIPv6 bool
-	IPAM       network.IPAM
-	Internal   bool
-	Containers map[string]EndpointResource
-	Options    map[string]string
-	Labels     map[string]string
+	Name       string                      // Name is the requested name of the network
+	ID         string                      `json:"Id"` // ID uniquely indentifies a network on a single machine
+	Scope      string                      // Scope describes the level at which the network exists (e.g. `global` for cluster-wide or `local` for machine level)
+	Driver     string                      // Driver is the Driver name used to create the network (e.g. `bridge`, `overlay`)
+	EnableIPv6 bool                        // EnableIPv6 represents whether to enable IPv6
+	IPAM       network.IPAM                // IPAM is the network's IP Address Management
+	Internal   bool                        // Internal respresents if the network is used internal only
+	Containers map[string]EndpointResource // Containers contains endpoints belonging to the network
+	Options    map[string]string           // Options holds the network specific options to use for when creating the network
+	Labels     map[string]string           // Labels holds metadata specific to the network being created
 }
 
 // EndpointResource contains network resources allocated and used for a container in a network
@@ -470,4 +495,19 @@ type NetworkConnect struct {
 type NetworkDisconnect struct {
 	Container string
 	Force     bool
+}
+
+// Checkpoint represents the details of a checkpoint
+type Checkpoint struct {
+	Name string // Name is the name of the checkpoint
+}
+
+// DefaultRuntimeName is the reserved name/alias used to represent the
+// OCI runtime being shipped with the docker daemon package.
+var DefaultRuntimeName = "default"
+
+// Runtime describes an OCI runtime
+type Runtime struct {
+	Path string   `json:"path"`
+	Args []string `json:"runtimeArgs,omitempty"`
 }

--- a/vendor/github.com/docker/engine-api/types/versions/README.md
+++ b/vendor/github.com/docker/engine-api/types/versions/README.md
@@ -9,6 +9,6 @@ Consider moving a type here when you need to keep backwards compatibility in the
 The package name convention is to use `v` as a prefix for the version number and `p`(patch) as a separator. We use this nomenclature due to a few restrictions in the Go package name convention:
 
 1. We cannot use `.` because it's interpreted by the language, think of `v1.20.CallFunction`.
-2. We cannot use `_` because golint complains abount it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
+2. We cannot use `_` because golint complains about it. The code is actually valid, but it looks probably more weird: `v1_20.CallFunction`.
 
 For instance, if you want to modify a type that was available in the version `1.21` of the API but it will have different fields in the version `1.22`, you want to create a new package under `api/types/versions/v1p21`.


### PR DESCRIPTION
This brings engine-api vendor to d06b85b29e37346a050f335042e16e6e8a9f49da… 🐮

Mainly needed for #294 :angel: 

🐸