### PR TITLE
Remove --lines flag for logs command

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -161,11 +161,6 @@ func LogsCommand(factory app.ProjectFactory) cli.Command {
 		Usage:  "Get service logs",
 		Action: app.WithProject(factory, app.ProjectLog),
 		Flags: []cli.Flag{
-			cli.IntFlag{
-				Name:  "lines",
-				Usage: "number of lines to tail",
-				Value: 100,
-			},
 			cli.BoolFlag{
 				Name:  "follow",
 				Usage: "Follow log output.",


### PR DESCRIPTION
This flag isn't actually implemented, so it's probably confusing to users when it's shown in help. The name is wrong as well, since Docker Compose uses `--tail` for this.

Signed-off-by: Josh Curl <josh@curl.me>