### PR TITLE
Remove project event logging

### DIFF
--- a/project/listener.go
+++ b/project/listener.go
@@ -29,27 +29,6 @@ var (
 		events.ServicePause:        true,
 		events.ServiceUnpauseStart: true,
 		events.ServiceUnpause:      true,
-
-		events.ProjectDeleteDone:   true,
-		events.ProjectDeleteStart:  true,
-		events.ProjectDownDone:     true,
-		events.ProjectDownStart:    true,
-		events.ProjectStopDone:     true,
-		events.ProjectStopStart:    true,
-		events.ProjectKillDone:     true,
-		events.ProjectKillStart:    true,
-		events.ProjectCreateDone:   true,
-		events.ProjectCreateStart:  true,
-		events.ProjectStartDone:    true,
-		events.ProjectStartStart:   true,
-		events.ProjectRestartDone:  true,
-		events.ProjectRestartStart: true,
-		events.ProjectUpDone:       true,
-		events.ProjectUpStart:      true,
-		events.ProjectPauseDone:    true,
-		events.ProjectPauseStart:   true,
-		events.ProjectUnpauseDone:  true,
-		events.ProjectUnpauseStart: true,
 	}
 )
 


### PR DESCRIPTION
Switch to only showing service events, which makes the output closer to Docker Compose. There are also scenarios when showing project logs results in some confusing behavior. For example, calling start on a subset of all services for a project will result in a log "Project started", which doesn't seem quite right in this case.

Signed-off-by: Josh Curl <josh@curl.me>