### PR TITLE
Load multiple type of env_file and environments

### DIFF
--- a/config/merge.go
+++ b/config/merge.go
@@ -8,6 +8,8 @@ import (
 
 	yaml "github.com/cloudfoundry-incubator/candiedyaml"
 	"github.com/docker/docker/pkg/urlutil"
+	"github.com/docker/libcompose/utils"
+	composeYaml "github.com/docker/libcompose/yaml"
 )
 
 var (
@@ -86,7 +88,13 @@ func readEnvFile(resourceLookup ResourceLookup, inFile string, serviceData RawSe
 	if _, ok := serviceData["env_file"]; !ok {
 		return serviceData, nil
 	}
-	envFiles := serviceData["env_file"].([]interface{})
+
+	var envFiles composeYaml.Stringorslice
+
+	if err := utils.Convert(serviceData["env_file"], &envFiles); err != nil {
+		return nil, err
+	}
+
 	if len(envFiles) == 0 {
 		return serviceData, nil
 	}
@@ -95,13 +103,16 @@ func readEnvFile(resourceLookup ResourceLookup, inFile string, serviceData RawSe
 		return nil, fmt.Errorf("Can not use env_file in file %s no mechanism provided to load files", inFile)
 	}
 
-	var vars []interface{}
+	var vars composeYaml.MaporEqualSlice
+
 	if _, ok := serviceData["environment"]; ok {
-		vars = serviceData["environment"].([]interface{})
+		if err := utils.Convert(serviceData["environment"], &vars); err != nil {
+			return nil, err
+		}
 	}
 
 	for i := len(envFiles) - 1; i >= 0; i-- {
-		envFile := envFiles[i].(string)
+		envFile := envFiles[i]
 		content, _, err := resourceLookup.Lookup(envFile, inFile)
 		if err != nil {
 			return nil, err
@@ -118,7 +129,7 @@ func readEnvFile(resourceLookup ResourceLookup, inFile string, serviceData RawSe
 
 			found := false
 			for _, v := range vars {
-				if strings.HasPrefix(v.(string), key) {
+				if strings.HasPrefix(v, key) {
 					found = true
 					break
 				}


### PR DESCRIPTION
## WHAT
Accept multiple types of `env_files` and `environments` in `docker-compose.yml` using type assertion and switch-statement.

## WHY
Original docker-compose.yml supports the multiple type of some configurations:

- [`env_file`](https://docs.docker.com/compose/compose-file/#env-file): __string__ or __array[string]__

```yaml
env_file: .env
# or
env_file:
  - .env
```

- [`environment`](https://docs.docker.com/compose/compose-file/#environment): __array[string]__ or __map[string]string__ or __map[string]int__

```yaml
environment:
  - FOO=bar
# or
environment:
  FOO: bar
```

However, current libcompose accepts _single_ type only. `env_file` accepts __array[string]__, `environment` accepts __array[string]__.
If unsupported type is given, `config.readEnvFile` fails with panic.

with array[string] `env_file`:

```
remote: panic: interface conversion: interface is string, not []interface {}
remote:
remote: goroutine 1 [running]:
remote: panic(0xbe0c20, 0xc820017f40)
remote:         /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.readEnvFile(0x7f84e76565e8, 0x11acc38, 0xc820016240, 0x37, 0xc8201275c0, 0x5, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge.go:89 +0x161
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.parseV2(0x7f84e76565e8, 0x11acc38, 0x7f84e7656668, 0xc820014280, 0xc820016240, 0x37, 0xc8201275c0, 0xc820127560, 0x117f820, 0xc820016100, ...)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge_v2.go:95 +0x83
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.MergeServicesV2(0xc8200142c0, 0x7f84e7656668, 0xc820014280, 0x7f84e76565e8, 0x11acc38, 0xc820016240, 0x37, 0xc8202d0000, 0x3eb, 0x5eb, ...)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge_v2.go:36 +0x2e3
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.Merge(0xc8200142c0, 0x7f84e7656668, 0xc820014280, 0x7f84e76565e8, 0x11acc38, 0xc820016240, 0x37, 0xc8202d0000, 0x3eb, 0x5eb, ...)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge.go:40 +0x24c
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project.(*Project).load(0xc8201440c0, 0xc820016240, 0x37, 0xc8202d0000, 0x3eb, 0x5eb, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project/project.go:159 +0xdf
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project.(*Project).Parse(0xc8201440c0, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project/project.go:84 +0x323
remote: github.com/dtan4/paus-gitreceive/receiver/model.NewCompose(0xc82019664b, 0x14, 0xc820016240, 0x37, 0xc820196720, 0x17, 0x7f84e767e270, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/model/compose.go:65 +0x466
remote: main.main()
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/main.go:168 +0xc07
```

with map[string]string `environments`:

```
remote: panic: interface conversion: interface is map[interface {}]interface {}, not []interface {}
remote:
remote: goroutine 1 [running]:
remote: panic(0xbe0c20, 0xc820121600)
remote:         /usr/local/Cellar/go/1.6.2/libexec/src/runtime/panic.go:481 +0x3e6
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.readEnvFile(0x7f574fd91fb0, 0x11acc38, 0xc820120a80, 0x37, 0xc82038c150, 0x7, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge.go:109 +0x4c2
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.parseV2(0x7f574fd91fb0, 0x11acc38, 0x7f574fd92030, 0xc820126e80, 0xc820120a80, 0x37, 0xc82038c150, 0xc82038c0f0, 0x117f820, 0xc820016100, ...)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge_v2.go:95 +0x83
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.MergeServicesV2(0xc820126ec0, 0x7f574fd92030, 0xc820126e80, 0x7f574fd91fb0, 0x11acc38, 0xc820120a80, 0x37, 0xc820352c00, 0x3e6, 0x5e6, ...)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge_v2.go:36 +0x2e3
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config.Merge(0xc820126ec0, 0x7f574fd92030, 0xc820126e80, 0x7f574fd91fb0, 0x11acc38, 0xc820120a80, 0x37, 0xc820352c00, 0x3e6, 0x5e6, ...)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/config/merge.go:40 +0x24c
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project.(*Project).load(0xc82013a0c0, 0xc820120a80, 0x37, 0xc820352c00, 0x3e6, 0x5e6, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project/project.go:159 +0xdf
remote: github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project.(*Project).Parse(0xc82013a0c0, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/vendor/github.com/docker/libcompose/project/project.go:84 +0x323
remote: github.com/dtan4/paus-gitreceive/receiver/model.NewCompose(0xc82018c6ab, 0x14, 0xc820120a80, 0x37, 0xc82018c780, 0x17, 0x7f574fdc0270, 0x0, 0x0)
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/model/compose.go:65 +0x466
remote: main.main()
remote:         /Users/dtan4/src/github.com/dtan4/paus-gitreceive/receiver/main.go:168 +0xc07
```
