### PR TITLE
Add a SHOWNOWARNING constant to hide warning message

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ wrappedNode(label: 'linux && x86_64') {
     makeTask(image, "validate")
 
     stage "test"
-    makeTask(image, "test", ["DAEMON_VERSION=all"])
+    makeTask(image, "test", ["DAEMON_VERSION=all", "SHOWWARNING=false"])
 
     stage "build"
     makeTask(image, "cross-binary")

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ LIBCOMPOSE_ENVS := \
 	-e DOCKER_TEST_HOST \
 	-e TESTDIRS \
 	-e TESTFLAGS \
+        -e SHOWWARNING \
 	-e TESTVERBOSE
 
 # (default to no bind mount if DOCKER_HOST is set)

--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -14,6 +14,7 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/project/options"
+	"github.com/docker/libcompose/version"
 )
 
 // ProjectAction is an adapter to allow the use of ordinary functions as libcompose actions.
@@ -31,7 +32,9 @@ func BeforeApp(c *cli.Context) error {
 	if c.GlobalBool("verbose") {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	logrus.Warning("Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose)")
+	if version.ShowWarning() {
+		logrus.Warning("Note: This is an experimental alternate implementation of the Compose CLI (https://github.com/docker/compose)")
+	}
 	return nil
 }
 

--- a/script/binary
+++ b/script/binary
@@ -11,6 +11,6 @@ GITCOMMIT=$(git rev-parse --short HEAD)
 
 # Build binaries
 go build \
-   -ldflags="-w -X github.com/docker/libcompose/version.GITCOMMIT=${GITCOMMIT} -X github.com/docker/libcompose/version.BUILDTIME=${BUILDTIME}" \
+   -ldflags="-w -X github.com/docker/libcompose/version.GITCOMMIT=${GITCOMMIT} -X github.com/docker/libcompose/version.BUILDTIME=${BUILDTIME} -X github.com/docker/libcompose/version.SHOWWARNING=${SHOWWARNING}" \
    -o bundles/libcompose-cli \
    ./cli/main

--- a/version/version.go
+++ b/version/version.go
@@ -9,4 +9,12 @@ var (
 
 	// BUILDTIME will be overwritten automatically by the build system
 	BUILDTIME = ""
+
+	// SHOWWARNING might be overwritten by the build system to not show the warning
+	SHOWWARNING = "true"
 )
+
+// ShowWarning returns wether the warning should be printed or not
+func ShowWarning() bool {
+	return SHOWWARNING != "false"
+}


### PR DESCRIPTION
This allows to run acceptance tests without the warning that makes some
tests to fails 👼

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>