### PR TITLE
Refactoring the Container struct…

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -303,7 +303,7 @@ func ProjectScale(p project.APIProject, c *cli.Context) error {
 
 	err := p.Scale(context.Background(), c.Int("timeout"), servicesScale)
 	if err != nil {
-		return cli.NewExitError(err.Error(), 1)
+		return cli.NewExitError(err.Error(), 0)
 	}
 	return nil
 }

--- a/docker/container.go
+++ b/docker/container.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -16,71 +17,60 @@ import (
 	"github.com/docker/docker/pkg/term"
 	"github.com/docker/engine-api/client"
 	"github.com/docker/engine-api/types"
-	"github.com/docker/engine-api/types/container"
 	"github.com/docker/engine-api/types/network"
 	"github.com/docker/go-connections/nat"
 	"github.com/docker/libcompose/config"
 	"github.com/docker/libcompose/labels"
 	"github.com/docker/libcompose/logger"
 	"github.com/docker/libcompose/project"
-	"github.com/docker/libcompose/project/events"
-	util "github.com/docker/libcompose/utils"
-	"github.com/docker/libcompose/yaml"
 )
 
 // Container holds information about a docker container and the service it is tied on.
 type Container struct {
-	name            string
-	serviceName     string
-	projectName     string
-	containerNumber int
-	oneOff          bool
-	eventNotifier   events.Notifier
-	loggerFactory   logger.Factory
-	client          client.APIClient
-
-	// FIXME(vdemeester) Remove this dependency
-	service *Service
+	// FIXME(vdemeester) Replace with ContainerClient with engine-api vendor update
+	client    client.APIClient
+	name      string
+	id        string
+	container *types.ContainerJSON
 }
 
-// NewContainer creates a container struct with the specified docker client, name and service.
-func NewContainer(client client.APIClient, name string, containerNumber int, service *Service) *Container {
-	return &Container{
-		client:          client,
-		name:            name,
-		containerNumber: containerNumber,
-
-		// TODO(vdemeester) Move these to arguments
-		serviceName:   service.name,
-		projectName:   service.project.Name,
-		eventNotifier: service.project,
-		loggerFactory: service.context.LoggerFactory,
-
-		// TODO(vdemeester) Remove this dependency
-		service: service,
+// CreateContainer creates a container and return a Container struct (and an error if any)
+func CreateContainer(ctx context.Context, client client.APIClient, name string, configWrapper *ConfigWrapper) (*Container, error) {
+	container, err := client.ContainerCreate(ctx, configWrapper.Config, configWrapper.HostConfig, configWrapper.NetworkingConfig, name)
+	if err != nil {
+		return nil, err
 	}
+	return New(ctx, client, container.ID, name)
 }
 
-// NewOneOffContainer creates a "oneoff" container struct with the specified docker client, name and service.
-func NewOneOffContainer(client client.APIClient, name string, containerNumber int, service *Service) *Container {
-	c := NewContainer(client, name, containerNumber, service)
-	c.oneOff = true
-	return c
+// New creates a container struct with the specified client, id and name
+func New(ctx context.Context, client client.APIClient, id, name string) (*Container, error) {
+	container, err := GetContainer(ctx, client, id)
+	if err != nil {
+		return nil, err
+	}
+	return &Container{
+		client:    client,
+		name:      name,
+		id:        id,
+		container: container,
+	}, nil
 }
 
-func (c *Container) findExisting(ctx context.Context) (*types.ContainerJSON, error) {
-	return GetContainer(ctx, c.client, c.name)
+// NewInspected creates a container struct from an inspected container
+func NewInspected(client client.APIClient, container *types.ContainerJSON) *Container {
+	return &Container{
+		client:    client,
+		name:      container.Name,
+		id:        container.ID,
+		container: container,
+	}
 }
 
 // Info returns info about the container, like name, command, state or ports.
 func (c *Container) Info(ctx context.Context, qFlag bool) (project.Info, error) {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return nil, err
-	}
-
 	infos, err := GetContainersByFilter(ctx, c.client, map[string][]string{
-		"name": {container.Name},
+		"name": {c.container.Name},
 	})
 	if err != nil || len(infos) == 0 {
 		return nil, err
@@ -89,7 +79,7 @@ func (c *Container) Info(ctx context.Context, qFlag bool) (project.Info, error) 
 
 	result := project.Info{}
 	if qFlag {
-		result = append(result, project.InfoPart{Key: "Id", Value: container.ID})
+		result = append(result, project.InfoPart{Key: "Id", Value: c.container.ID})
 	} else {
 		result = append(result, project.InfoPart{Key: "Name", Value: name(info.Names)})
 		result = append(result, project.InfoPart{Key: "Command", Value: info.Command})
@@ -128,145 +118,65 @@ func name(names []string) string {
 	return current[1:]
 }
 
-// Recreate will not refresh the container by means of relaxation and enjoyment,
-// just delete it and create a new one with the current configuration
-func (c *Container) Recreate(ctx context.Context, imageName string) (*types.ContainerJSON, error) {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return nil, err
-	}
+// Rename rename the container.
+func (c *Container) Rename(ctx context.Context, newName string) error {
+	return c.client.ContainerRename(ctx, c.container.ID, newName)
+}
 
-	hash := container.Config.Labels[labels.HASH.Str()]
-	if hash == "" {
-		return nil, fmt.Errorf("Failed to find hash on old container: %s", container.Name)
-	}
-
-	name := container.Name[1:]
-	newName := fmt.Sprintf("%s_%s", name, container.ID[:12])
-	logrus.Debugf("Renaming %s => %s", name, newName)
-	if err := c.client.ContainerRename(ctx, container.ID, newName); err != nil {
-		logrus.Errorf("Failed to rename old container %s", c.name)
-		return nil, err
-	}
-
-	newContainer, err := c.createContainer(ctx, imageName, container.ID, nil)
-	if err != nil {
-		return nil, err
-	}
-	logrus.Debugf("Created replacement container %s", newContainer.ID)
-
-	if err := c.client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{
+// Remove removes the container.
+func (c *Container) Remove(ctx context.Context, removeVolume bool) error {
+	return c.client.ContainerRemove(ctx, c.container.ID, types.ContainerRemoveOptions{
 		Force:         true,
-		RemoveVolumes: false,
-	}); err != nil {
-		logrus.Errorf("Failed to remove old container %s", c.name)
-		return nil, err
-	}
-	logrus.Debugf("Removed old container %s %s", c.name, container.ID)
-
-	return newContainer, nil
-}
-
-// Create creates the container based on the specified image name and send an event
-// to notify the container has been created. If the container already exists, does
-// nothing.
-func (c *Container) Create(ctx context.Context, imageName string) (*types.ContainerJSON, error) {
-	return c.CreateWithOverride(ctx, imageName, nil)
-}
-
-// CreateWithOverride create container and override parts of the config to
-// allow special situations to override the config generated from the compose
-// file
-func (c *Container) CreateWithOverride(ctx context.Context, imageName string, configOverride *config.ServiceConfig) (*types.ContainerJSON, error) {
-	container, err := c.findExisting(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if container == nil {
-		container, err = c.createContainer(ctx, imageName, "", configOverride)
-		if err != nil {
-			return nil, err
-		}
-		c.eventNotifier.Notify(events.ContainerCreated, c.serviceName, map[string]string{
-			"name": c.Name(),
-		})
-	}
-
-	return container, err
+		RemoveVolumes: removeVolume,
+	})
 }
 
 // Stop stops the container.
 func (c *Container) Stop(ctx context.Context, timeout int) error {
-	return c.withContainer(ctx, func(container *types.ContainerJSON) error {
-		timeoutDuration := time.Duration(timeout) * time.Second
-		return c.client.ContainerStop(ctx, container.ID, &timeoutDuration)
-	})
+	timeoutDuration := time.Duration(timeout) * time.Second
+	return c.client.ContainerStop(ctx, c.container.ID, &timeoutDuration)
 }
 
 // Pause pauses the container. If the containers are already paused, don't fail.
 func (c *Container) Pause(ctx context.Context) error {
-	return c.withContainer(ctx, func(container *types.ContainerJSON) error {
-		if !container.State.Paused {
-			return c.client.ContainerPause(ctx, container.ID)
+	if !c.container.State.Paused {
+		if err := c.client.ContainerPause(ctx, c.container.ID); err != nil {
+			return err
 		}
-		return nil
-	})
+		return c.updateInnerContainer(ctx)
+	}
+	return nil
 }
 
 // Unpause unpauses the container. If the containers are not paused, don't fail.
 func (c *Container) Unpause(ctx context.Context) error {
-	return c.withContainer(ctx, func(container *types.ContainerJSON) error {
-		if container.State.Paused {
-			return c.client.ContainerUnpause(ctx, container.ID)
+	if c.container.State.Paused {
+		if err := c.client.ContainerUnpause(ctx, c.container.ID); err != nil {
+			return err
 		}
-		return nil
-	})
+		return c.updateInnerContainer(ctx)
+	}
+	return nil
+}
+
+func (c *Container) updateInnerContainer(ctx context.Context) error {
+	container, err := GetContainer(ctx, c.client, c.container.ID)
+	if err != nil {
+		return err
+	}
+	c.container = container
+	return nil
 }
 
 // Kill kill the container.
 func (c *Container) Kill(ctx context.Context, signal string) error {
-	return c.withContainer(ctx, func(container *types.ContainerJSON) error {
-		return c.client.ContainerKill(ctx, container.ID, signal)
-	})
-}
-
-// Delete removes the container if existing. If the container is running, it tries
-// to stop it first.
-func (c *Container) Delete(ctx context.Context, removeVolume bool) error {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return err
-	}
-
-	info, err := c.client.ContainerInspect(ctx, container.ID)
-	if err != nil {
-		return err
-	}
-
-	if !info.State.Running {
-		return c.client.ContainerRemove(ctx, container.ID, types.ContainerRemoveOptions{
-			Force:         true,
-			RemoveVolumes: removeVolume,
-		})
-	}
-
-	return nil
+	return c.client.ContainerKill(ctx, c.container.ID, signal)
 }
 
 // IsRunning returns the running state of the container.
+// FIXME(vdemeester): remove the nil error here
 func (c *Container) IsRunning(ctx context.Context) (bool, error) {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return false, err
-	}
-
-	info, err := c.client.ContainerInspect(ctx, container.ID)
-	if err != nil {
-		return false, err
-	}
-
-	return info.State.Running, nil
+	return c.container.State.Running, nil
 }
 
 // Run creates, start and attach to the container based on the image name,
@@ -278,11 +188,6 @@ func (c *Container) Run(ctx context.Context, configOverride *config.ServiceConfi
 		out, stderr io.Writer
 		in          io.ReadCloser
 	)
-
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return -1, err
-	}
 
 	if configOverride.StdinOpen {
 		in = os.Stdin
@@ -301,7 +206,7 @@ func (c *Container) Run(ctx context.Context, configOverride *config.ServiceConfi
 		Stderr: configOverride.Tty,
 	}
 
-	resp, err := c.client.ContainerAttach(ctx, container.ID, options)
+	resp, err := c.client.ContainerAttach(ctx, c.container.ID, options)
 	if err != nil {
 		return -1, err
 	}
@@ -319,7 +224,7 @@ func (c *Container) Run(ctx context.Context, configOverride *config.ServiceConfi
 		return holdHijackedConnection(configOverride.Tty, in, out, stderr, resp)
 	})
 
-	if err := c.client.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
+	if err := c.client.ContainerStart(ctx, c.container.ID, types.ContainerStartOptions{}); err != nil {
 		return -1, err
 	}
 
@@ -328,7 +233,7 @@ func (c *Container) Run(ctx context.Context, configOverride *config.ServiceConfi
 		return -1, err
 	}
 
-	exitedContainer, err := c.client.ContainerInspect(ctx, container.ID)
+	exitedContainer, err := c.client.ContainerInspect(ctx, c.container.ID)
 	if err != nil {
 		return -1, err
 	}
@@ -385,240 +290,17 @@ func holdHijackedConnection(tty bool, inputStream io.ReadCloser, outputStream, e
 
 // Start the specified container with the specified host config
 func (c *Container) Start(ctx context.Context) error {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
+	logrus.WithFields(logrus.Fields{"container.ID": c.container.ID, "c.name": c.name}).Debug("Starting container")
+	if err := c.client.ContainerStart(ctx, c.container.ID, types.ContainerStartOptions{}); err != nil {
+		logrus.WithFields(logrus.Fields{"container.ID": c.container.ID, "c.name": c.name}).Debug("Failed to start container")
 		return err
 	}
-	logrus.WithFields(logrus.Fields{"container.ID": container.ID, "c.name": c.name}).Debug("Starting container")
-	if err := c.client.ContainerStart(context.Background(), container.ID, types.ContainerStartOptions{}); err != nil {
-		logrus.WithFields(logrus.Fields{"container.ID": container.ID, "c.name": c.name}).Debug("Failed to start container")
-		return err
-	}
-	c.eventNotifier.Notify(events.ContainerStarted, c.serviceName, map[string]string{
-		"name": c.Name(),
-	})
 	return nil
-}
-
-// OutOfSync checks if the container is out of sync with the service definition.
-// It looks if the the service hash container label is the same as the computed one.
-func (c *Container) OutOfSync(ctx context.Context, imageName string) (bool, error) {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return false, err
-	}
-
-	if container.Config.Image != imageName {
-		logrus.Debugf("Images for %s do not match %s!=%s", c.name, container.Config.Image, imageName)
-		return true, nil
-	}
-
-	if container.Config.Labels[labels.HASH.Str()] != c.getHash() {
-		logrus.Debugf("Hashes for %s do not match %s!=%s", c.name, container.Config.Labels[labels.HASH.Str()], c.getHash())
-		return true, nil
-	}
-
-	image, _, err := c.client.ImageInspectWithRaw(ctx, container.Config.Image, false)
-	if err != nil {
-		if client.IsErrImageNotFound(err) {
-			logrus.Debugf("Image %s do not exist, do not know if it's out of sync", container.Config.Image)
-			return false, nil
-		}
-		return false, err
-	}
-
-	logrus.Debugf("Checking existing image name vs id: %s == %s", image.ID, container.Image)
-	return image.ID != container.Image, err
-}
-
-func (c *Container) getHash() string {
-	return config.GetServiceHash(c.serviceName, c.service.Config())
-}
-
-func volumeBinds(volumes map[string]struct{}, container *types.ContainerJSON) []string {
-	result := make([]string, 0, len(container.Mounts))
-	for _, mount := range container.Mounts {
-		if _, ok := volumes[mount.Destination]; ok {
-			result = append(result, fmt.Sprint(mount.Source, ":", mount.Destination))
-		}
-	}
-	return result
-}
-
-func (c *Container) createContainer(ctx context.Context, imageName, oldContainer string, configOverride *config.ServiceConfig) (*types.ContainerJSON, error) {
-	serviceConfig := c.service.serviceConfig
-	if configOverride != nil {
-		serviceConfig.Command = configOverride.Command
-		serviceConfig.Tty = configOverride.Tty
-		serviceConfig.StdinOpen = configOverride.StdinOpen
-	}
-	configWrapper, err := ConvertToAPI(c.service)
-	if err != nil {
-		return nil, err
-	}
-
-	configWrapper.Config.Image = imageName
-
-	if configWrapper.Config.Labels == nil {
-		configWrapper.Config.Labels = map[string]string{}
-	}
-
-	oneOffString := "False"
-	if c.oneOff {
-		oneOffString = "True"
-	}
-
-	configWrapper.Config.Labels[labels.SERVICE.Str()] = c.serviceName
-	configWrapper.Config.Labels[labels.PROJECT.Str()] = c.projectName
-	configWrapper.Config.Labels[labels.HASH.Str()] = c.getHash()
-	configWrapper.Config.Labels[labels.ONEOFF.Str()] = oneOffString
-	configWrapper.Config.Labels[labels.NUMBER.Str()] = fmt.Sprint(c.containerNumber)
-	configWrapper.Config.Labels[labels.VERSION.Str()] = ComposeVersion
-
-	err = c.populateAdditionalHostConfig(configWrapper.HostConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	if oldContainer != "" {
-		info, err := c.client.ContainerInspect(ctx, oldContainer)
-		if err != nil {
-			return nil, err
-		}
-		configWrapper.HostConfig.Binds = util.Merge(configWrapper.HostConfig.Binds, volumeBinds(configWrapper.Config.Volumes, &info))
-	}
-
-	logrus.Debugf("Creating container %s %#v", c.name, configWrapper)
-
-	container, err := c.client.ContainerCreate(ctx, configWrapper.Config, configWrapper.HostConfig, configWrapper.NetworkingConfig, c.name)
-	if err != nil {
-		logrus.Debugf("Failed to create container %s: %v", c.name, err)
-		return nil, err
-	}
-
-	return GetContainer(ctx, c.client, container.ID)
-}
-
-func (c *Container) populateAdditionalHostConfig(hostConfig *container.HostConfig) error {
-	links, err := c.getLinks()
-	if err != nil {
-		return err
-	}
-
-	for _, link := range c.service.DependentServices() {
-		if !c.service.project.ServiceConfigs.Has(link.Target) {
-			continue
-		}
-
-		service, err := c.service.project.CreateService(link.Target)
-		if err != nil {
-			return err
-		}
-
-		// FIXME(vdemeester) container should not know service
-		containers, err := service.Containers(context.Background())
-		if err != nil {
-			return err
-		}
-
-		if link.Type == project.RelTypeIpcNamespace {
-			hostConfig, err = c.addIpc(hostConfig, service, containers)
-		} else if link.Type == project.RelTypeNetNamespace {
-			hostConfig, err = c.addNetNs(hostConfig, service, containers)
-		}
-
-		if err != nil {
-			return err
-		}
-	}
-
-	hostConfig.Links = []string{}
-	for k, v := range links {
-		hostConfig.Links = append(hostConfig.Links, strings.Join([]string{v, k}, ":"))
-	}
-	for _, v := range c.service.Config().ExternalLinks {
-		hostConfig.Links = append(hostConfig.Links, v)
-	}
-
-	return nil
-}
-
-// FIXME(vdemeester) this is temporary
-func (c *Container) getLinks() (map[string]string, error) {
-	links := map[string]string{}
-	for _, link := range c.service.DependentServices() {
-		if !c.service.project.ServiceConfigs.Has(link.Target) {
-			continue
-		}
-
-		service, err := c.service.project.CreateService(link.Target)
-		if err != nil {
-			return nil, err
-		}
-
-		// FIXME(vdemeester) container should not know service
-		containers, err := service.Containers(context.Background())
-		if err != nil {
-			return nil, err
-		}
-
-		if link.Type == project.RelTypeLink {
-			c.addLinks(links, service, link, containers)
-		}
-
-		if err != nil {
-			return nil, err
-		}
-	}
-	return links, nil
-}
-
-func (c *Container) addLinks(links map[string]string, service project.Service, rel project.ServiceRelationship, containers []project.Container) {
-	for _, container := range containers {
-		if _, ok := links[rel.Alias]; !ok {
-			links[rel.Alias] = container.Name()
-		}
-
-		links[container.Name()] = container.Name()
-	}
-}
-
-func (c *Container) addIpc(config *container.HostConfig, service project.Service, containers []project.Container) (*container.HostConfig, error) {
-	if len(containers) == 0 {
-		return nil, fmt.Errorf("Failed to find container for IPC %v", c.service.Config().Ipc)
-	}
-
-	id, err := containers[0].ID()
-	if err != nil {
-		return nil, err
-	}
-
-	config.IpcMode = container.IpcMode("container:" + id)
-	return config, nil
-}
-
-func (c *Container) addNetNs(config *container.HostConfig, service project.Service, containers []project.Container) (*container.HostConfig, error) {
-	if len(containers) == 0 {
-		return nil, fmt.Errorf("Failed to find container for networks ns %v", c.service.Config().NetworkMode)
-	}
-
-	id, err := containers[0].ID()
-	if err != nil {
-		return nil, err
-	}
-
-	config.NetworkMode = container.NetworkMode("container:" + id)
-	return config, nil
 }
 
 // ID returns the container Id.
 func (c *Container) ID() (string, error) {
-	// FIXME(vdemeester) container should not ask for his ID..
-	container, err := c.findExisting(context.Background())
-	if container == nil {
-		return "", err
-	}
-	return container.ID, err
+	return c.container.ID, nil
 }
 
 // Name returns the container name.
@@ -628,30 +310,16 @@ func (c *Container) Name() string {
 
 // Restart restarts the container if existing, does nothing otherwise.
 func (c *Container) Restart(ctx context.Context, timeout int) error {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return err
-	}
-
 	timeoutDuration := time.Duration(timeout) * time.Second
-	return c.client.ContainerRestart(ctx, container.ID, &timeoutDuration)
+	return c.client.ContainerRestart(ctx, c.container.ID, &timeoutDuration)
 }
 
 // Log forwards container logs to the project configured logger.
-func (c *Container) Log(ctx context.Context, follow bool) error {
-	container, err := c.findExisting(ctx)
-	if container == nil || err != nil {
-		return err
-	}
-
-	info, err := c.client.ContainerInspect(ctx, container.ID)
+func (c *Container) Log(ctx context.Context, l logger.Logger, follow bool) error {
+	info, err := c.client.ContainerInspect(ctx, c.container.ID)
 	if err != nil {
 		return err
 	}
-
-	// FIXME(vdemeester) update container struct to do less API calls
-	name := fmt.Sprintf("%s_%d", c.service.name, c.containerNumber)
-	l := c.loggerFactory.Create(name)
 
 	options := types.ContainerLogsOptions{
 		ShowStdout: true,
@@ -675,27 +343,9 @@ func (c *Container) Log(ctx context.Context, follow bool) error {
 	return err
 }
 
-func (c *Container) withContainer(ctx context.Context, action func(*types.ContainerJSON) error) error {
-	container, err := c.findExisting(ctx)
-	if err != nil {
-		return err
-	}
-
-	if container != nil {
-		return action(container)
-	}
-
-	return nil
-}
-
 // Port returns the host port the specified port is mapped on.
 func (c *Container) Port(ctx context.Context, port string) (string, error) {
-	container, err := c.findExisting(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	if bindings, ok := container.NetworkSettings.Ports[nat.Port(port)]; ok {
+	if bindings, ok := c.container.NetworkSettings.Ports[nat.Port(port)]; ok {
 		result := []string{}
 		for _, binding := range bindings {
 			result = append(result, binding.HostIP+":"+binding.HostPort)
@@ -707,60 +357,29 @@ func (c *Container) Port(ctx context.Context, port string) (string, error) {
 }
 
 // Networks returns the containers network
-// FIXME(vdemeester) should not need ctx or calling the API, will take care of it
-// when refactoring Container.
-func (c *Container) Networks(ctx context.Context) (map[string]*network.EndpointSettings, error) {
-	container, err := c.findExisting(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if container == nil {
-		return map[string]*network.EndpointSettings{}, nil
-	}
-	return container.NetworkSettings.Networks, nil
+func (c *Container) Networks() (map[string]*network.EndpointSettings, error) {
+	return c.container.NetworkSettings.Networks, nil
 }
 
-// NetworkDisconnect disconnects the container from the specified network
-// FIXME(vdemeester) will be refactor with Container refactoring
-func (c *Container) NetworkDisconnect(ctx context.Context, net *yaml.Network) error {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return err
-	}
-	return c.client.NetworkDisconnect(ctx, net.RealName, container.ID, true)
+// Image returns the container image. Depending on the engine version its either
+// the complete id or the digest reference the image.
+func (c *Container) Image() string {
+	return c.container.Image
 }
 
-// NetworkConnect connects the container to the specified network
-// FIXME(vdemeester) will be refactor with Container refactoring
-func (c *Container) NetworkConnect(ctx context.Context, net *yaml.Network) error {
-	container, err := c.findExisting(ctx)
-	if err != nil || container == nil {
-		return err
-	}
-	internalLinks, err := c.getLinks()
-	if err != nil {
-		return err
-	}
-	links := []string{}
-	// TODO(vdemeester) handle link to self (?)
-	for k, v := range internalLinks {
-		links = append(links, strings.Join([]string{v, k}, ":"))
-	}
-	for _, v := range c.service.Config().ExternalLinks {
-		links = append(links, v)
-	}
-	aliases := []string{}
-	if !c.oneOff {
-		aliases = []string{c.serviceName}
-	}
-	aliases = append(aliases, net.Aliases...)
-	return c.client.NetworkConnect(ctx, net.RealName, container.ID, &network.EndpointSettings{
-		Aliases:   aliases,
-		Links:     links,
-		IPAddress: net.IPv4Address,
-		IPAMConfig: &network.EndpointIPAMConfig{
-			IPv4Address: net.IPv4Address,
-			IPv6Address: net.IPv6Address,
-		},
-	})
+// ImageConfig returns the container image stored in the config. It's the
+// human-readable name of the image.
+func (c *Container) ImageConfig() string {
+	return c.container.Config.Image
+}
+
+// Hash returns the container hash stored as label.
+func (c *Container) Hash() string {
+	return c.container.Config.Labels[labels.HASH.Str()]
+}
+
+// Number returns the container number stored as label.
+func (c *Container) Number() (int, error) {
+	numberStr := c.container.Config.Labels[labels.NUMBER.Str()]
+	return strconv.Atoi(numberStr)
 }

--- a/docker/convert.go
+++ b/docker/convert.go
@@ -45,8 +45,8 @@ func isVolume(s string) bool {
 }
 
 // ConvertToAPI converts a service configuration to a docker API container configuration.
-func ConvertToAPI(s *Service) (*ConfigWrapper, error) {
-	config, hostConfig, err := Convert(s.serviceConfig, s.context.Context, s.clientFactory)
+func ConvertToAPI(serviceConfig *config.ServiceConfig, ctx project.Context, clientFactory composeclient.Factory) (*ConfigWrapper, error) {
+	config, hostConfig, err := Convert(serviceConfig, ctx, clientFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -246,6 +246,10 @@ func Convert(c *config.ServiceConfig, ctx project.Context, clientFactory compose
 		SecurityOpt:    utils.CopySlice(c.SecurityOpt),
 		VolumeDriver:   c.VolumeDriver,
 		Resources:      resources,
+	}
+
+	if config.Labels == nil {
+		config.Labels = map[string]string{}
 	}
 
 	return config, hostConfig, nil

--- a/docker/image.go
+++ b/docker/image.go
@@ -18,6 +18,11 @@ import (
 	"github.com/docker/engine-api/types"
 )
 
+func inspectImage(ctx context.Context, client client.APIClient, image string) (types.ImageInspect, error) {
+	imageInspect, _, err := client.ImageInspectWithRaw(ctx, image, false)
+	return imageInspect, err
+}
+
 func removeImage(ctx context.Context, client client.APIClient, image string) error {
 	_, err := client.ImageRemove(ctx, image, types.ImageRemoveOptions{})
 	return err

--- a/docker/service_create.go
+++ b/docker/service_create.go
@@ -1,0 +1,188 @@
+package docker
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/net/context"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/docker/engine-api/types"
+	"github.com/docker/engine-api/types/container"
+	"github.com/docker/libcompose/config"
+	"github.com/docker/libcompose/labels"
+	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/project/events"
+	util "github.com/docker/libcompose/utils"
+)
+
+func (s *Service) createContainer(ctx context.Context, namer Namer, oldContainer string, configOverride *config.ServiceConfig, oneOff bool) (*Container, error) {
+	serviceConfig := s.serviceConfig
+	if configOverride != nil {
+		serviceConfig.Command = configOverride.Command
+		serviceConfig.Tty = configOverride.Tty
+		serviceConfig.StdinOpen = configOverride.StdinOpen
+	}
+	configWrapper, err := ConvertToAPI(serviceConfig, s.context.Context, s.clientFactory)
+	if err != nil {
+		return nil, err
+	}
+	configWrapper.Config.Image = s.imageName()
+
+	containerName, containerNumber := namer.Next()
+
+	configWrapper.Config.Labels[labels.SERVICE.Str()] = s.name
+	configWrapper.Config.Labels[labels.PROJECT.Str()] = s.project.Name
+	configWrapper.Config.Labels[labels.HASH.Str()] = config.GetServiceHash(s.name, serviceConfig)
+	configWrapper.Config.Labels[labels.ONEOFF.Str()] = strings.Title(strconv.FormatBool(oneOff))
+	configWrapper.Config.Labels[labels.NUMBER.Str()] = fmt.Sprintf("%d", containerNumber)
+	configWrapper.Config.Labels[labels.VERSION.Str()] = ComposeVersion
+
+	err = s.populateAdditionalHostConfig(configWrapper.HostConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// FIXME(vdemeester): oldContainer should be a Container instead of a string
+	client := s.clientFactory.Create(s)
+	if oldContainer != "" {
+		info, err := client.ContainerInspect(ctx, oldContainer)
+		if err != nil {
+			return nil, err
+		}
+		configWrapper.HostConfig.Binds = util.Merge(configWrapper.HostConfig.Binds, volumeBinds(configWrapper.Config.Volumes, &info))
+	}
+
+	logrus.Debugf("Creating container %s %#v", containerName, configWrapper)
+	// FIXME(vdemeester): long-term will be container.Create(…)
+	container, err := CreateContainer(ctx, client, containerName, configWrapper)
+	if err != nil {
+		return nil, err
+	}
+	s.project.Notify(events.ContainerCreated, s.name, map[string]string{
+		"name": containerName,
+	})
+	return container, nil
+}
+
+func (s *Service) populateAdditionalHostConfig(hostConfig *container.HostConfig) error {
+	links, err := s.getLinks()
+	if err != nil {
+		return err
+	}
+
+	for _, link := range s.DependentServices() {
+		if !s.project.ServiceConfigs.Has(link.Target) {
+			continue
+		}
+
+		service, err := s.project.CreateService(link.Target)
+		if err != nil {
+			return err
+		}
+
+		containers, err := service.Containers(context.Background())
+		if err != nil {
+			return err
+		}
+
+		if link.Type == project.RelTypeIpcNamespace {
+			hostConfig, err = addIpc(hostConfig, service, containers, s.serviceConfig.Ipc)
+		} else if link.Type == project.RelTypeNetNamespace {
+			hostConfig, err = addNetNs(hostConfig, service, containers, s.serviceConfig.NetworkMode)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+
+	hostConfig.Links = []string{}
+	for k, v := range links {
+		hostConfig.Links = append(hostConfig.Links, strings.Join([]string{v, k}, ":"))
+	}
+	for _, v := range s.serviceConfig.ExternalLinks {
+		hostConfig.Links = append(hostConfig.Links, v)
+	}
+
+	return nil
+}
+
+// FIXME(vdemeester) this is temporary
+func (s *Service) getLinks() (map[string]string, error) {
+	links := map[string]string{}
+	for _, link := range s.DependentServices() {
+		if !s.project.ServiceConfigs.Has(link.Target) {
+			continue
+		}
+
+		service, err := s.project.CreateService(link.Target)
+		if err != nil {
+			return nil, err
+		}
+
+		// FIXME(vdemeester) container should not know service
+		containers, err := service.Containers(context.Background())
+		if err != nil {
+			return nil, err
+		}
+
+		if link.Type == project.RelTypeLink {
+			addLinks(links, service, link, containers)
+		}
+
+		if err != nil {
+			return nil, err
+		}
+	}
+	return links, nil
+}
+
+func addLinks(links map[string]string, service project.Service, rel project.ServiceRelationship, containers []project.Container) {
+	for _, container := range containers {
+		if _, ok := links[rel.Alias]; !ok {
+			links[rel.Alias] = container.Name()
+		}
+
+		links[container.Name()] = container.Name()
+	}
+}
+
+func addIpc(config *container.HostConfig, service project.Service, containers []project.Container, ipc string) (*container.HostConfig, error) {
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("Failed to find container for IPC %v", ipc)
+	}
+
+	id, err := containers[0].ID()
+	if err != nil {
+		return nil, err
+	}
+
+	config.IpcMode = container.IpcMode("container:" + id)
+	return config, nil
+}
+
+func addNetNs(config *container.HostConfig, service project.Service, containers []project.Container, networkMode string) (*container.HostConfig, error) {
+	if len(containers) == 0 {
+		return nil, fmt.Errorf("Failed to find container for networks ns %v", networkMode)
+	}
+
+	id, err := containers[0].ID()
+	if err != nil {
+		return nil, err
+	}
+
+	config.NetworkMode = container.NetworkMode("container:" + id)
+	return config, nil
+}
+
+func volumeBinds(volumes map[string]struct{}, container *types.ContainerJSON) []string {
+	result := make([]string, 0, len(container.Mounts))
+	for _, mount := range container.Mounts {
+		if _, ok := volumes[mount.Destination]; ok {
+			result = append(result, fmt.Sprint(mount.Source, ":", mount.Destination))
+		}
+	}
+	return result
+}

--- a/integration/scale_test.go
+++ b/integration/scale_test.go
@@ -35,10 +35,10 @@ func (s *CliSuite) TestScale(c *C) {
 	containers = s.GetContainersByProject(c, p)
 	c.Assert(1, Equals, len(containers))
 
-	cn = s.GetContainerByName(c, name2)
+	cn = s.GetContainerByName(c, name)
 	c.Assert(cn, IsNil)
 
-	cn = s.GetContainerByName(c, name)
+	cn = s.GetContainerByName(c, name2)
 	c.Assert(cn, NotNil)
 	c.Assert(cn.State.Running, Equals, true)
 }


### PR DESCRIPTION
… and thus Service too (with some other stuff) 🐍.

Overall the struct is way lighter, less intelligent *and* make way less
call. A `Container` now holds only a client, name, id and an actual
`types.ContainerJSON` docker container struct.

- This removes service and `Project`/`events.Notifier`.
- There is several way to create a `Container`:
  - Create an actual container with `CreateContainer`
  - Create a container from an existing one, with either `New` or
   `NewInspected`.
- Thus, removing any `Create*` method (use `CreateContainer` instead).
- Move *service* related method into services (`Recreate`, `Delete`,
  `OutOfSync`, anything related to `Create`).
- Remove `findExisting` and calls, the same with `withContainer` which
  are not needed anymore.
- Create a `service_create.go` file with service container creation
  code (because it was a lot)
- Update `Service` methods to use this updated `Container` struct.
- Makes `Scale` on service less flaky but not doing it in parallel (for
  now at least)

There is some improvements to come next :
- `Container` could (and should) be on its own `docker/container`
  package.
- `Service` will have to be refactor next (by removing dependencies on
  project).
- Move `Service` into its on `docker/service` package and split
  `service.go` into several smaller files.

*Note that `Service` and `Container` need an overall `godoc` rework, it's on my TODO :angel:*

/cc @joshwget 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>