### PR TITLE
Skip empty line and comment in env_file

### DIFF
--- a/config/merge.go
+++ b/config/merge.go
@@ -125,18 +125,21 @@ func readEnvFile(resourceLookup ResourceLookup, inFile string, serviceData RawSe
 		scanner := bufio.NewScanner(bytes.NewBuffer(content))
 		for scanner.Scan() {
 			line := strings.TrimSpace(scanner.Text())
-			key := strings.SplitAfter(line, "=")[0]
 
-			found := false
-			for _, v := range vars {
-				if strings.HasPrefix(v, key) {
-					found = true
-					break
+			if len(line) > 0 && !strings.HasPrefix(line, "#") {
+				key := strings.SplitAfter(line, "=")[0]
+
+				found := false
+				for _, v := range vars {
+					if strings.HasPrefix(v, key) {
+						found = true
+						break
+					}
 				}
-			}
 
-			if !found {
-				vars = append(vars, line)
+				if !found {
+					vars = append(vars, line)
+				}
 			}
 		}
 

--- a/config/merge_fixtures_test.go
+++ b/config/merge_fixtures_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -12,7 +13,7 @@ func TestMergeOnValidFixtures(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, file := range files {
-		if file.IsDir() {
+		if file.IsDir() || !strings.HasSuffix(file.Name(), ".yml") {
 			continue
 		}
 		data, err := ioutil.ReadFile(filepath.Join("testdata", file.Name()))

--- a/config/testdata/.env
+++ b/config/testdata/.env
@@ -1,0 +1,4 @@
+# This is a comment line
+
+FOO=foo
+BAR=bar


### PR DESCRIPTION
## WHAT
Skip empty line and comment line in env_file (e.g. `.env`).
This Pull Request makes it able to parse env_file like below:

```
#
# This is a sample .env file
#

GITHUB_TOKEN=hogehoge
SECRET_KEY_BASE=secretkeybase
```

Inspired by [github.com/docker/docker/runconfig/opts/envfile.go](https://github.com/docker/docker/blob/cc024095c99edfec556bb2f5840279490fff4218/runconfig/opts/envfile.go#L36-L53).