### PR TITLE
Move stopped container handling to cli/app package

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -557,7 +557,7 @@ func (s *Service) Kill(ctx context.Context, signal string) error {
 func (s *Service) Delete(ctx context.Context, options options.Delete) error {
 	return s.collectContainersAndDo(ctx, func(c *Container) error {
 		running, _ := c.IsRunning(ctx)
-		if !running {
+		if !running || options.RemoveRunning {
 			return c.Remove(ctx, options.RemoveVolume)
 		}
 		return nil

--- a/project/interface.go
+++ b/project/interface.go
@@ -37,6 +37,7 @@ type APIProject interface {
 	CreateService(name string) (Service, error)
 	AddConfig(name string, config *config.ServiceConfig) error
 	Load(bytes []byte) error
+	ListStoppedContainers(ctx context.Context, services ...string) ([]string, error)
 }
 
 // RuntimeProject defines runtime-specific methods for a libcompose implementation.

--- a/project/options/types.go
+++ b/project/options/types.go
@@ -9,8 +9,8 @@ type Build struct {
 
 // Delete holds options of compose rm.
 type Delete struct {
-	RemoveVolume         bool
-	BeforeDeleteCallback func([]string) bool
+	RemoveVolume  bool
+	RemoveRunning bool
 }
 
 // Down holds options of compose down.

--- a/project/project.go
+++ b/project/project.go
@@ -494,8 +494,8 @@ func (p *Project) Pull(ctx context.Context, services ...string) error {
 	}), nil)
 }
 
-// listStoppedContainers lists the stopped containers for the specified services.
-func (p *Project) listStoppedContainers(ctx context.Context, services ...string) ([]string, error) {
+// ListStoppedContainers lists the stopped containers for the specified services.
+func (p *Project) ListStoppedContainers(ctx context.Context, services ...string) ([]string, error) {
 	stoppedContainers := []string{}
 	err := p.forEach(services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
 		wrapper.Do(nil, events.NoEvent, events.NoEvent, func(service Service) error {
@@ -529,18 +529,6 @@ func (p *Project) listStoppedContainers(ctx context.Context, services ...string)
 
 // Delete removes the specified services (like docker rm).
 func (p *Project) Delete(ctx context.Context, options options.Delete, services ...string) error {
-	stoppedContainers, err := p.listStoppedContainers(ctx, services...)
-	if err != nil {
-		return err
-	}
-	if len(stoppedContainers) == 0 {
-		p.Notify(events.ProjectDeleteDone, "", nil)
-		fmt.Println("No stopped containers")
-		return nil
-	}
-	if options.BeforeDeleteCallback != nil && !options.BeforeDeleteCallback(stoppedContainers) {
-		return nil
-	}
 	return p.perform(events.ProjectDeleteStart, events.ProjectDeleteDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
 		wrapper.Do(nil, events.ServiceDeleteStart, events.ServiceDelete, func(service Service) error {
 			return service.Delete(ctx, options)


### PR DESCRIPTION
Some logic around the `rm` CLI command is currently in `project.Delete`. This makes `project.Delete` difficult for general library usage. Move this logic to the `cli/app` package.

Signed-off-by: Josh Curl <josh@curl.me>