### PR TITLE
Expose builder.createTar

### DIFF
--- a/docker/builder/builder.go
+++ b/docker/builder/builder.go
@@ -47,7 +47,7 @@ type DaemonBuilder struct {
 // Build implements Builder. It consumes the docker build API endpoint and sends
 // a tar of the specified service build context.
 func (d *DaemonBuilder) Build(ctx context.Context, imageName string) error {
-	buildCtx, err := createTar(d.ContextDirectory, d.Dockerfile)
+	buildCtx, err := CreateTar(d.ContextDirectory, d.Dockerfile)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (d *DaemonBuilder) Build(ctx context.Context, imageName string) error {
 }
 
 // CreateTar create a build context tar for the specified project and service name.
-func createTar(contextDirectory, dockerfile string) (io.ReadCloser, error) {
+func CreateTar(contextDirectory, dockerfile string) (io.ReadCloser, error) {
 	// This code was ripped off from docker/api/client/build.go
 	dockerfileName := filepath.Join(contextDirectory, dockerfile)
 


### PR DESCRIPTION
Exposes the `createTar` function in `docker/builder/builder.go`. We make use of this function and it was exposed prior to #230.

On a related note, there is some code in `docker/builder` that can probably be moved to a separate package. Some of the code doesn't depend on a Docker daemon (such as `createTar`) and it would be helpful to have a clear separation for these pieces.

Signed-off-by: Josh Curl <josh@curl.me>