### PR TITLE
Refactor CLI Populate function

### DIFF
--- a/cli/command/command.go
+++ b/cli/command/command.go
@@ -1,9 +1,26 @@
 package command
 
 import (
+	"os"
+
 	"github.com/docker/libcompose/cli/app"
+	"github.com/docker/libcompose/project"
 	"github.com/urfave/cli"
 )
+
+// Populate updates the specified project context based on command line arguments and subcommands.
+func Populate(context *project.Context, c *cli.Context) {
+	context.ComposeFiles = c.GlobalStringSlice("file")
+
+	if len(context.ComposeFiles) == 0 {
+		context.ComposeFiles = []string{"docker-compose.yml"}
+		if _, err := os.Stat("docker-compose.override.yml"); err == nil {
+			context.ComposeFiles = append(context.ComposeFiles, "docker-compose.override.yml")
+		}
+	}
+
+	context.ProjectName = c.GlobalString("project-name")
+}
 
 // CreateCommand defines the libcompose create subcommand.
 func CreateCommand(factory app.ProjectFactory) cli.Command {

--- a/cli/docker/app/commands.go
+++ b/cli/docker/app/commands.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/libcompose/cli/command"
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/docker/client"
 	"github.com/urfave/cli"
@@ -41,6 +42,8 @@ func DockerClientFlags() []cli.Flag {
 
 // Populate updates the specified docker context based on command line arguments and subcommands.
 func Populate(context *docker.Context, c *cli.Context) {
+	command.Populate(&context.Context, c)
+
 	context.ConfigDir = c.String("configdir")
 
 	opts := client.Options{}

--- a/cli/docker/app/factory.go
+++ b/cli/docker/app/factory.go
@@ -1,8 +1,6 @@
 package app
 
 import (
-	"os"
-
 	"github.com/docker/libcompose/cli/logger"
 	"github.com/docker/libcompose/docker"
 	"github.com/docker/libcompose/project"
@@ -18,17 +16,5 @@ func (p *ProjectFactory) Create(c *cli.Context) (project.APIProject, error) {
 	context := &docker.Context{}
 	context.LoggerFactory = logger.NewColorLoggerFactory()
 	Populate(context, c)
-
-	context.ComposeFiles = c.GlobalStringSlice("file")
-
-	if len(context.ComposeFiles) == 0 {
-		context.ComposeFiles = []string{"docker-compose.yml"}
-		if _, err := os.Stat("docker-compose.override.yml"); err == nil {
-			context.ComposeFiles = append(context.ComposeFiles, "docker-compose.override.yml")
-		}
-	}
-
-	context.ProjectName = c.GlobalString("project-name")
-
 	return docker.NewProject(context, nil)
 }


### PR DESCRIPTION
Some of the logic for populating a project context from a CLI context is embedded in the Docker `ProjectFactory`. Separate it so this functionality can be used independently.

Signed-off-by: Josh Curl <josh@curl.me>