### PR TITLE
Parse multifile COMPOSE_FILE envvar, w/ side effect

### DIFF
--- a/cli/docker/app/factory_test.go
+++ b/cli/docker/app/factory_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"flag"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,6 +53,91 @@ func TestProjectFactoryProjectNameIsNormalized(t *testing.T) {
 
 		if p.(*project.Project).Name != projectCase.expected {
 			t.Fatalf("expected %s, got %s", projectCase.expected, p.(*project.Project).Name)
+		}
+	}
+}
+
+func TestProjectFactoryFileArgMayContainMultipleFiles(t *testing.T) {
+	sep := string(os.PathListSeparator)
+	fileCases := []struct {
+		requested []string
+		available []string
+		expected  []string
+	}{
+		{
+			requested: []string{},
+			available: []string{"docker-compose.yml"},
+			expected:  []string{"docker-compose.yml"},
+		},
+		{
+			requested: []string{},
+			available: []string{"docker-compose.yml", "docker-compose.override.yml"},
+			expected:  []string{"docker-compose.yml", "docker-compose.override.yml"},
+		},
+		{
+			requested: []string{"one.yml"},
+			available: []string{"one.yml"},
+			expected:  []string{"one.yml"},
+		},
+		{
+			requested: []string{"one.yml"},
+			available: []string{"docker-compose.yml", "one.yml"},
+			expected:  []string{"one.yml"},
+		},
+		{
+			requested: []string{"one.yml", "two.yml", "three.yml"},
+			available: []string{"one.yml", "two.yml", "three.yml"},
+			expected:  []string{"one.yml", "two.yml", "three.yml"},
+		},
+		{
+			requested: []string{"one.yml" + sep + "two.yml" + sep + "three.yml"},
+			available: []string{"one.yml", "two.yml", "three.yml"},
+			expected:  []string{"one.yml", "two.yml", "three.yml"},
+		},
+		{
+			requested: []string{"one.yml" + sep + "two.yml", "three.yml" + sep + "four.yml"},
+			available: []string{"one.yml", "two.yml", "three.yml", "four.yml"},
+			expected:  []string{"one.yml", "two.yml", "three.yml", "four.yml"},
+		},
+		{
+			requested: []string{"one.yml", "two.yml" + sep + "three.yml"},
+			available: []string{"one.yml", "two.yml", "three.yml"},
+			expected:  []string{"one.yml", "two.yml", "three.yml"},
+		},
+	}
+
+	for _, fileCase := range fileCases {
+		tmpDir, err := ioutil.TempDir("", "project-factory-test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(tmpDir)
+		if err = os.Chdir(tmpDir); err != nil {
+			t.Fatal(err)
+		}
+
+		for _, file := range fileCase.available {
+			ioutil.WriteFile(file, []byte(`hello:
+    image: busybox`), 0700)
+		}
+		globalSet := flag.NewFlagSet("test", 0)
+		// Set the project-name flag
+		globalSet.String("project-name", "example", "doc")
+		// Set the compose file flag
+		fcr := cli.StringSlice(fileCase.requested)
+		globalSet.Var(&fcr, "file", "doc")
+		c := cli.NewContext(nil, globalSet, nil)
+		factory := &ProjectFactory{}
+		p, err := factory.Create(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		for i, v := range p.(*project.Project).Files {
+			if v != fileCase.expected[i] {
+				t.Fatalf("requested %s, available %s, expected %s, got %s",
+					fileCase.requested, fileCase.available, fileCase.expected, p.(*project.Project).Files)
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #212

urfave/cli does not distinguish whether the first string in the slice
comes from the envvar or is from a flag. Worse off, it appends the flag
values to the envvar value instead of overriding it. To ensure the
multifile envvar case is always handled, the first string must always be
split. It gives a more consistent behavior, then, to split each string
in the slice. With this side effect, the following is possible and
would merge the compose files left to right:

```
$ COMPOSE_FILE=a.yml:b.yml ./libcompose-cli -f c.yml -f d.yml:e.yml up
```

Signed-off-by: Dustin Chapman <dustin.r.chapman@gmail.com>