### PR TITLE
Adding strictly typed Events to libcompose

### DIFF
--- a/docker/service.go
+++ b/docker/service.go
@@ -347,12 +347,14 @@ func (s *Service) up(ctx context.Context, imageName string, create bool, options
 			return err
 		}
 
+		s.project.Notify(events.NewContainerStartStartEvent(s.name, c.Name()))
+
 		err = c.Start(ctx)
 
 		if err == nil {
-			s.project.Notify(events.ContainerStarted, s.name, map[string]string{
-				"name": c.Name(),
-			})
+			s.project.Notify(events.NewContainerStartDoneEvent(s.name, c.Name()))
+		} else {
+			s.project.Notify(events.NewContainerStartFailedEvent(s.name, c.Name(), err))
 		}
 
 		return err
@@ -682,8 +684,7 @@ func (s *Service) Events(ctx context.Context, evts chan events.ContainerEvent) e
 			attributes[attr] = m.Actor.Attributes[attr]
 		}
 		e := events.ContainerEvent{
-			Service:    service,
-			Event:      m.Action,
+			Event:      events.NewEvent(service, m.Action),
 			Type:       m.Type,
 			ID:         m.Actor.ID,
 			Time:       time.Unix(m.Time, 0),

--- a/docker/service_create.go
+++ b/docker/service_create.go
@@ -56,13 +56,15 @@ func (s *Service) createContainer(ctx context.Context, namer Namer, oldContainer
 
 	logrus.Debugf("Creating container %s %#v", containerName, configWrapper)
 	// FIXME(vdemeester): long-term will be container.Create(…)
+	s.project.Notify(events.NewContainerCreateStartEvent(s.name, containerName))
+
 	container, err := CreateContainer(ctx, client, containerName, configWrapper)
 	if err != nil {
+		s.project.Notify(events.NewContainerCreateFailedEvent(s.name, containerName, err))
 		return nil, err
 	}
-	s.project.Notify(events.ContainerCreated, s.name, map[string]string{
-		"name": containerName,
-	})
+	s.project.Notify(events.NewContainerCreateDoneEvent(s.name, containerName))
+
 	return container, nil
 }
 

--- a/project/empty.go
+++ b/project/empty.go
@@ -133,7 +133,7 @@ func (e *EmptyNetworks) Initialize(ctx context.Context) error {
 	return nil
 }
 
-// Initialize implements Networks.Remove but does nothing.
+// Remove implements Networks.Remove but does nothing.
 func (e *EmptyNetworks) Remove(ctx context.Context) error {
 	return nil
 }

--- a/project/events/events.go
+++ b/project/events/events.go
@@ -2,13 +2,228 @@
 package events
 
 import (
-	"fmt"
 	"time"
 )
 
+/*** Event ***/
+// Event holds project-wide event informations.
+type Event interface {
+	String() string
+	Service() string
+}
+
+// baseEvent contains the base data for all events
+type baseEvent struct {
+	Event       string `json:"event"`
+	ServiceName string `json:"service"`
+}
+
+// String returns a string representation of the event
+func (b *baseEvent) String() string {
+	return b.Event
+}
+
+// Service returns the service name for the event
+func (b *baseEvent) Service() string {
+	return b.ServiceName
+}
+
+func NewEvent(event, service string) Event {
+	return &baseEvent{
+		Event:       event,
+		ServiceName: service,
+	}
+}
+
+/*** EventFactory ***/
+// EventFactory creates a new Event
+type EventFactory func() Event
+
+// EventFactory creates a new Event for a specified service
+type ServiceEventFactory func(service string) Event
+
+// ErrorEventFactory creates a new Event for a specified error
+type ErrorEventFactory func(err error) Event
+
+// ErrorServiceEventFactory creates a new Event for a specified service and error
+type ErrorServiceEventFactory func(service string, err error) Event
+
+/*** EventWrapper ***/
+// EventWrapper provides a wrapper around EventFactories to allow
+// state dependent Event generation
+type EventWrapper interface {
+	Started() Event
+	Failed(err error) Event
+	Done() Event
+	Action() string
+}
+
+type eventWrapper struct {
+	startedFactory EventFactory
+	failedFactory  ErrorEventFactory
+	doneFactory    EventFactory
+	action         string
+}
+
+// Started creates a new event using the provided EventFactory for
+// the 'started' condition
+func (wrapper *eventWrapper) Started() Event {
+	if wrapper.startedFactory != nil {
+		return wrapper.startedFactory()
+	} else {
+		return nil
+	}
+}
+
+// Failed creates a new event using the provided EventFactory for
+// the 'failed' condition
+func (wrapper *eventWrapper) Failed(err error) Event {
+	if wrapper.failedFactory != nil {
+		return wrapper.failedFactory(err)
+	} else {
+		return nil
+	}
+}
+
+// Done creates a new event using the provided EventFactory for
+// the 'done' condition
+func (wrapper *eventWrapper) Done() Event {
+	if wrapper.doneFactory != nil {
+		return wrapper.doneFactory()
+	} else {
+		return nil
+	}
+}
+
+// Action returns the name of the action this wrapper is supporting
+func (wrapper *eventWrapper) Action() string {
+	return wrapper.action
+}
+
+// NewServiceEventWrapper builds a wrapper around the provided ServiceEventFactories
+func NewEventWrapper(action string, started EventFactory, done EventFactory, failed ErrorEventFactory) EventWrapper {
+	return &eventWrapper{
+		startedFactory: started,
+		failedFactory:  failed,
+		doneFactory:    done,
+		action:         action,
+	}
+}
+
+// SeviceEventWrapper provides a wrapper around ServiceEventFactories to allow
+// state dependent Event generation
+type ServiceEventWrapper interface {
+	Started(string) Event
+	Failed(string, error) Event
+	Done(string) Event
+	Action() string
+}
+
+type serviceEventWrapper struct {
+	startedFactory ServiceEventFactory
+	failedFactory  ErrorServiceEventFactory
+	doneFactory    ServiceEventFactory
+	action         string
+}
+
+// Started creates a new event using the provided ServiceEventFactory for
+// the 'started' condition
+func (wrapper *serviceEventWrapper) Started(serviceName string) Event {
+	if wrapper.startedFactory != nil {
+		return wrapper.startedFactory(serviceName)
+	} else {
+		return nil
+	}
+}
+
+// Failed creates a new event using the provided ServiceEventFactory for
+// the 'failed' condition
+func (wrapper *serviceEventWrapper) Failed(serviceName string, err error) Event {
+	if wrapper.failedFactory != nil {
+		return wrapper.failedFactory(serviceName, err)
+	} else {
+		return nil
+	}
+}
+
+// Done creates a new event using the provided ServiceEventFactory for
+// the 'done' condition
+func (wrapper *serviceEventWrapper) Done(serviceName string) Event {
+	if wrapper.doneFactory != nil {
+		return wrapper.doneFactory(serviceName)
+	} else {
+		return nil
+	}
+}
+
+// Action returns the name of the action this wrapper is supporting
+func (wrapper *serviceEventWrapper) Action() string {
+	return wrapper.action
+}
+
+// NewServiceEventWrapper builds a wrapper around the provided ServiceEventFactories
+func NewServiceEventWrapper(action string, started ServiceEventFactory, done ServiceEventFactory, failed ErrorServiceEventFactory) ServiceEventWrapper {
+	return &serviceEventWrapper{
+		startedFactory: started,
+		failedFactory:  failed,
+		doneFactory:    done,
+		action:         action,
+	}
+}
+
+func NewDummyEventWrapper(action string) *dummyEventWrapper {
+	return &dummyEventWrapper{
+		action: action,
+	}
+}
+
+type dummyEventWrapper struct {
+	action string
+}
+
+func (*dummyEventWrapper) Started() Event {
+	return nil
+}
+
+func (*dummyEventWrapper) Done() Event {
+	return nil
+}
+func (*dummyEventWrapper) Failed(error) Event {
+	return nil
+}
+func (w *dummyEventWrapper) Action() string {
+	return w.action
+}
+
+func NewDummyServiceEventWrapper(action string) *dummyServiceEventWrapper {
+	return &dummyServiceEventWrapper{
+		action: action,
+	}
+}
+
+type dummyServiceEventWrapper struct {
+	action string
+}
+
+func (*dummyServiceEventWrapper) Started(string) Event {
+	return nil
+}
+
+func (*dummyServiceEventWrapper) Done(string) Event {
+	return nil
+}
+
+func (*dummyServiceEventWrapper) Failed(string, error) Event {
+	return nil
+}
+
+func (w *dummyServiceEventWrapper) Action() string {
+	return w.action
+}
+
 // Notifier defines the methods an event notifier should have.
 type Notifier interface {
-	Notify(eventType EventType, serviceName string, data map[string]string)
+	Notify(event Event)
 }
 
 // Emitter defines the methods an event emitter should have.
@@ -16,209 +231,1306 @@ type Emitter interface {
 	AddListener(c chan<- Event)
 }
 
-// Event holds project-wide event informations.
-type Event struct {
-	EventType   EventType
-	ServiceName string
-	Data        map[string]string
-}
-
 // ContainerEvent holds attributes of container events.
 type ContainerEvent struct {
-	Service    string            `json:"service"`
-	Event      string            `json:"event"`
+	Event
 	ID         string            `json:"id"`
 	Time       time.Time         `json:"time"`
 	Attributes map[string]string `json:"attributes"`
 	Type       string            `json:"type"`
 }
 
-// EventType defines a type of libcompose event.
-type EventType int
+// Represents a service being added to a project
+type ServiceAdd struct {
+	*baseEvent
+}
 
-// Definitions of libcompose events
-const (
-	NoEvent = EventType(iota)
-
-	ContainerCreated = EventType(iota)
-	ContainerStarted = EventType(iota)
-
-	ServiceAdd          = EventType(iota)
-	ServiceUpStart      = EventType(iota)
-	ServiceUpIgnored    = EventType(iota)
-	ServiceUp           = EventType(iota)
-	ServiceCreateStart  = EventType(iota)
-	ServiceCreate       = EventType(iota)
-	ServiceDeleteStart  = EventType(iota)
-	ServiceDelete       = EventType(iota)
-	ServiceDownStart    = EventType(iota)
-	ServiceDown         = EventType(iota)
-	ServiceRestartStart = EventType(iota)
-	ServiceRestart      = EventType(iota)
-	ServicePullStart    = EventType(iota)
-	ServicePull         = EventType(iota)
-	ServiceKillStart    = EventType(iota)
-	ServiceKill         = EventType(iota)
-	ServiceStartStart   = EventType(iota)
-	ServiceStart        = EventType(iota)
-	ServiceBuildStart   = EventType(iota)
-	ServiceBuild        = EventType(iota)
-	ServicePauseStart   = EventType(iota)
-	ServicePause        = EventType(iota)
-	ServiceUnpauseStart = EventType(iota)
-	ServiceUnpause      = EventType(iota)
-	ServiceStopStart    = EventType(iota)
-	ServiceStop         = EventType(iota)
-	ServiceRunStart     = EventType(iota)
-	ServiceRun          = EventType(iota)
-
-	VolumeAdd  = EventType(iota)
-	NetworkAdd = EventType(iota)
-
-	ProjectDownStart     = EventType(iota)
-	ProjectDownDone      = EventType(iota)
-	ProjectCreateStart   = EventType(iota)
-	ProjectCreateDone    = EventType(iota)
-	ProjectUpStart       = EventType(iota)
-	ProjectUpDone        = EventType(iota)
-	ProjectDeleteStart   = EventType(iota)
-	ProjectDeleteDone    = EventType(iota)
-	ProjectRestartStart  = EventType(iota)
-	ProjectRestartDone   = EventType(iota)
-	ProjectReload        = EventType(iota)
-	ProjectReloadTrigger = EventType(iota)
-	ProjectKillStart     = EventType(iota)
-	ProjectKillDone      = EventType(iota)
-	ProjectStartStart    = EventType(iota)
-	ProjectStartDone     = EventType(iota)
-	ProjectBuildStart    = EventType(iota)
-	ProjectBuildDone     = EventType(iota)
-	ProjectPauseStart    = EventType(iota)
-	ProjectPauseDone     = EventType(iota)
-	ProjectUnpauseStart  = EventType(iota)
-	ProjectUnpauseDone   = EventType(iota)
-	ProjectStopStart     = EventType(iota)
-	ProjectStopDone      = EventType(iota)
-)
-
-func (e EventType) String() string {
-	var m string
-	switch e {
-	case ContainerCreated:
-		m = "Created container"
-	case ContainerStarted:
-		m = "Started container"
-
-	case ServiceAdd:
-		m = "Adding"
-	case ServiceUpStart:
-		m = "Starting"
-	case ServiceUpIgnored:
-		m = "Ignoring"
-	case ServiceUp:
-		m = "Started"
-	case ServiceCreateStart:
-		m = "Creating"
-	case ServiceCreate:
-		m = "Created"
-	case ServiceDeleteStart:
-		m = "Deleting"
-	case ServiceDelete:
-		m = "Deleted"
-	case ServiceStopStart:
-		m = "Stopping"
-	case ServiceStop:
-		m = "Stopped"
-	case ServiceDownStart:
-		m = "Stopping"
-	case ServiceDown:
-		m = "Stopped"
-	case ServiceRestartStart:
-		m = "Restarting"
-	case ServiceRestart:
-		m = "Restarted"
-	case ServicePullStart:
-		m = "Pulling"
-	case ServicePull:
-		m = "Pulled"
-	case ServiceKillStart:
-		m = "Killing"
-	case ServiceKill:
-		m = "Killed"
-	case ServiceStartStart:
-		m = "Starting"
-	case ServiceStart:
-		m = "Started"
-	case ServiceBuildStart:
-		m = "Building"
-	case ServiceBuild:
-		m = "Built"
-	case ServiceRunStart:
-		m = "Executing"
-	case ServiceRun:
-		m = "Executed"
-	case ServicePauseStart:
-		m = "Pausing"
-	case ServicePause:
-		m = "Paused"
-	case ServiceUnpauseStart:
-		m = "Unpausing"
-	case ServiceUnpause:
-		m = "Unpaused"
-
-	case ProjectDownStart:
-		m = "Stopping project"
-	case ProjectDownDone:
-		m = "Project stopped"
-	case ProjectStopStart:
-		m = "Stopping project"
-	case ProjectStopDone:
-		m = "Project stopped"
-	case ProjectCreateStart:
-		m = "Creating project"
-	case ProjectCreateDone:
-		m = "Project created"
-	case ProjectUpStart:
-		m = "Starting project"
-	case ProjectUpDone:
-		m = "Project started"
-	case ProjectDeleteStart:
-		m = "Deleting project"
-	case ProjectDeleteDone:
-		m = "Project deleted"
-	case ProjectRestartStart:
-		m = "Restarting project"
-	case ProjectRestartDone:
-		m = "Project restarted"
-	case ProjectReload:
-		m = "Reloading project"
-	case ProjectReloadTrigger:
-		m = "Triggering project reload"
-	case ProjectKillStart:
-		m = "Killing project"
-	case ProjectKillDone:
-		m = "Project killed"
-	case ProjectStartStart:
-		m = "Starting project"
-	case ProjectStartDone:
-		m = "Project started"
-	case ProjectBuildStart:
-		m = "Building project"
-	case ProjectBuildDone:
-		m = "Project built"
-	case ProjectPauseStart:
-		m = "Pausing project"
-	case ProjectPauseDone:
-		m = "Project paused"
-	case ProjectUnpauseStart:
-		m = "Unpausing project"
-	case ProjectUnpauseDone:
-		m = "Project unpaused"
+// Creates a new Service Add event
+func NewServiceAddEvent(serviceName string) Event {
+	return &ServiceAdd{
+		&baseEvent{
+			Event:       "Service Added",
+			ServiceName: serviceName,
+		},
 	}
+}
 
-	if m == "" {
-		m = fmt.Sprintf("EventType: %d", int(e))
+// Represents a volume being added to a project service
+type VolumeAdd struct {
+	*baseEvent
+	Driver string
+}
+
+// Creates a new Volume Add event
+func NewVolumeAddEvent(serviceName, volumeDriver string) Event {
+	return &VolumeAdd{
+		baseEvent: &baseEvent{
+			Event:       "Volume Added",
+			ServiceName: serviceName,
+		},
+		Driver: volumeDriver,
 	}
+}
 
-	return m
+// Represents a network being added to a project service
+type NetworkAdd struct {
+	*baseEvent
+	Driver string
+}
+
+// Creates a new Network Add event
+func NewNetworkAddEvent(serviceName, networkDriver string) Event {
+	return &NetworkAdd{
+		baseEvent: &baseEvent{
+			Event:       "Network Added",
+			ServiceName: serviceName,
+		},
+		Driver: networkDriver,
+	}
+}
+
+// Represents a service build starting
+type ServiceBuildStart struct {
+	*baseEvent
+}
+
+// Creates a new service build starting event
+func NewServiceBuildStartEvent(serviceName string) Event {
+	return &ServiceBuildStart{
+		&baseEvent{
+			Event:       "Building service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service build completing
+type ServiceBuildDone struct {
+	*baseEvent
+}
+
+// Creates a new service build done event
+func NewServiceBuildDoneEvent(serviceName string) Event {
+	return &ServiceBuildDone{
+		&baseEvent{
+			Event:       "Service built",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service build failing
+type ServiceBuildFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service build failed event
+func NewServiceBuildFailedEvent(serviceName string, err error) Event {
+	return &ServiceBuildFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service build failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service create starting
+type ServiceCreateStart struct {
+	*baseEvent
+}
+
+// Creates a new service create starting event
+func NewServiceCreateStartEvent(serviceName string) Event {
+	return &ServiceCreateStart{
+		&baseEvent{
+			Event:       "Creating service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service create completing
+type ServiceCreateDone struct {
+	*baseEvent
+}
+
+// Creates a new service create done event
+func NewServiceCreateDoneEvent(serviceName string) Event {
+	return &ServiceCreateDone{
+		&baseEvent{
+			Event:       "Service created",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service create failing
+type ServiceCreateFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service create failed event
+func NewServiceCreateFailedEvent(serviceName string, err error) Event {
+	return &ServiceCreateFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service create failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service stop starting
+type ServiceStopStart struct {
+	*baseEvent
+}
+
+// Creates a new service stop starting event
+func NewServiceStopStartEvent(serviceName string) Event {
+	return &ServiceStopStart{
+		&baseEvent{
+			Event:       "Creating service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service stop completing
+type ServiceStopDone struct {
+	*baseEvent
+}
+
+// Creates a new service stop done event
+func NewServiceStopDoneEvent(serviceName string) Event {
+	return &ServiceStopDone{
+		&baseEvent{
+			Event:       "Service stopped",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service stop failing
+type ServiceStopFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service stop failed event
+func NewServiceStopFailedEvent(serviceName string, err error) Event {
+	return &ServiceStopFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service stop failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service restart starting
+type ServiceRestartStart struct {
+	*baseEvent
+}
+
+// Creates a new service restart starting event
+func NewServiceRestartStartEvent(serviceName string) Event {
+	return &ServiceRestartStart{
+		&baseEvent{
+			Event:       "Restarting service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service restart completing
+type ServiceRestartDone struct {
+	*baseEvent
+}
+
+// Creates a new service restart done event
+func NewServiceRestartDoneEvent(serviceName string) Event {
+	return &ServiceRestartDone{
+		&baseEvent{
+			Event:       "Service restarted",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service restart failing
+type ServiceRestartFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service restart failed event
+func NewServiceRestartFailedEvent(serviceName string, err error) Event {
+	return &ServiceRestartFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service restart failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service start starting
+type ServiceStartStart struct {
+	*baseEvent
+}
+
+// Creates a new service start starting event
+func NewServiceStartStartEvent(serviceName string) Event {
+	return &ServiceStartStart{
+		&baseEvent{
+			Event:       "Starting service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service start completing
+type ServiceStartDone struct {
+	*baseEvent
+}
+
+// Creates a new service start done event
+func NewServiceStartDoneEvent(serviceName string) Event {
+	return &ServiceStartDone{
+		&baseEvent{
+			Event:       "Service started",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service start failing
+type ServiceStartFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service start failed event
+func NewServiceStartFailedEvent(serviceName string, err error) Event {
+	return &ServiceStartFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service start failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service run starting
+type ServiceRunStart struct {
+	*baseEvent
+}
+
+// Creates a new service run starting event
+func NewServiceRunStartEvent(serviceName string) Event {
+	return &ServiceRunStart{
+		&baseEvent{
+			Event:       "Running service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service run completing
+type ServiceRunDone struct {
+	*baseEvent
+}
+
+// Creates a new service run done event
+func NewServiceRunDoneEvent(serviceName string) Event {
+	return &ServiceRunDone{
+		&baseEvent{
+			Event:       "Service run",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service run failing
+type ServiceRunFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service run failed event
+func NewServiceRunFailedEvent(serviceName string, err error) Event {
+	return &ServiceRunFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service run failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service up starting
+type ServiceUpStart struct {
+	*baseEvent
+}
+
+// Creates a new service up starting event
+func NewServiceUpStartEvent(serviceName string) Event {
+	return &ServiceUpStart{
+		&baseEvent{
+			Event:       "Starting service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service up completing
+type ServiceUpDone struct {
+	*baseEvent
+}
+
+// Creates a new service up done event
+func NewServiceUpDoneEvent(serviceName string) Event {
+	return &ServiceUpDone{
+		&baseEvent{
+			Event:       "Service started",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service up failing
+type ServiceUpFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service up failed event
+func NewServiceUpFailedEvent(serviceName string, err error) Event {
+	return &ServiceUpFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service start failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service up being ignored
+type ServiceUpIgnored struct {
+	*baseEvent
+}
+
+// Creates a new service up ignore event
+func NewServiceUpIgnoredEvent(serviceName string) Event {
+	return &ServiceUpFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service start ignored",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service pull starting
+type ServicePullStart struct {
+	*baseEvent
+}
+
+// Creates a new service pull starting event
+func NewServicePullStartEvent(serviceName string) Event {
+	return &ServicePullStart{
+		&baseEvent{
+			Event:       "Pulling service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service pull completing
+type ServicePullDone struct {
+	*baseEvent
+}
+
+// Creates a new service pull done event
+func NewServicePullDoneEvent(serviceName string) Event {
+	return &ServicePullDone{
+		&baseEvent{
+			Event:       "Service pulled",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service pull failing
+type ServicePullFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service pull failed event
+func NewServicePullFailedEvent(serviceName string, err error) Event {
+	return &ServicePullFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service pull failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service delete starting
+type ServiceDeleteStart struct {
+	*baseEvent
+}
+
+// Creates a new service delete starting event
+func NewServiceDeleteStartEvent(serviceName string) Event {
+	return &ServiceDeleteStart{
+		&baseEvent{
+			Event:       "Deleting service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service delete completing
+type ServiceDeleteDone struct {
+	*baseEvent
+}
+
+// Creates a new service delete done event
+func NewServiceDeleteDoneEvent(serviceName string) Event {
+	return &ServiceDeleteDone{
+		&baseEvent{
+			Event:       "Service deleted",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service delete failing
+type ServiceDeleteFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service delete failed event
+func NewServiceDeleteFailedEvent(serviceName string, err error) Event {
+	return &ServiceDeleteFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service delete failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service kill starting
+type ServiceKillStart struct {
+	*baseEvent
+}
+
+// Creates a new service kill starting event
+func NewServiceKillStartEvent(serviceName string) Event {
+	return &ServiceKillStart{
+		&baseEvent{
+			Event:       "Killing service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service kill completing
+type ServiceKillDone struct {
+	*baseEvent
+}
+
+// Creates a new service kill done event
+func NewServiceKillDoneEvent(serviceName string) Event {
+	return &ServiceKillDone{
+		&baseEvent{
+			Event:       "Service killed",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service kill failing
+type ServiceKillFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service kill failed event
+func NewServiceKillFailedEvent(serviceName string, err error) Event {
+	return &ServiceKillFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service kill failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service pause starting
+type ServicePauseStart struct {
+	*baseEvent
+}
+
+// Creates a new service pause starting event
+func NewServicePauseStartEvent(serviceName string) Event {
+	return &ServicePauseStart{
+		&baseEvent{
+			Event:       "Pausing service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service pause completing
+type ServicePauseDone struct {
+	*baseEvent
+}
+
+// Creates a new service pause done event
+func NewServicePauseDoneEvent(serviceName string) Event {
+	return &ServicePauseDone{
+		&baseEvent{
+			Event:       "Service paused",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service pause failing
+type ServicePauseFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service pause failed event
+func NewServicePauseFailedEvent(serviceName string, err error) Event {
+	return &ServicePauseFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service pause failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service unpause starting
+type ServiceUnpauseStart struct {
+	*baseEvent
+}
+
+// Creates a new service unpause starting event
+func NewServiceUnpauseStartEvent(serviceName string) Event {
+	return &ServiceUnpauseStart{
+		&baseEvent{
+			Event:       "Unpause service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service unpause completing
+type ServiceUnpauseDone struct {
+	*baseEvent
+}
+
+// Creates a new service unpause done event
+func NewServiceUnpauseDoneEvent(serviceName string) Event {
+	return &ServiceUnpauseDone{
+		&baseEvent{
+			Event:       "Service unpaused",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service unpause failing
+type ServiceUnpauseFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service unpause failed event
+func NewServiceUnpauseFailedEvent(serviceName string, err error) Event {
+	return &ServiceUnpauseFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service unpause failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a service down starting
+type ServiceDownStart struct {
+	*baseEvent
+}
+
+// Creates a new service down starting event
+func NewServiceDownStartEvent(serviceName string) Event {
+	return &ServiceDownStart{
+		&baseEvent{
+			Event:       "Stopping service",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service down completing
+type ServiceDownDone struct {
+	*baseEvent
+}
+
+// Creates a new service down done event
+func NewServiceDownDoneEvent(serviceName string) Event {
+	return &ServiceDownDone{
+		&baseEvent{
+			Event:       "Service stopped",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a service down failing
+type ServiceDownFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new service down failed event
+func NewServiceDownFailedEvent(serviceName string, err error) Event {
+	return &ServiceDownFailed{
+		baseEvent: &baseEvent{
+			Event:       "Service stop failed",
+			ServiceName: serviceName,
+		},
+		err: err,
+	}
+}
+
+// Represents a project restart starting
+type ProjectRestartStart struct {
+	*baseEvent
+}
+
+// Creates a new project restart starting event
+func NewProjectRestartStartEvent() Event {
+	return &ProjectRestartStart{
+		&baseEvent{
+			Event: "Restarting project",
+		},
+	}
+}
+
+// Represents a project restart completing
+type ProjectRestartDone struct {
+	*baseEvent
+}
+
+// Creates a new project restart done event
+func NewProjectRestartDoneEvent() Event {
+	return &ProjectRestartDone{
+		&baseEvent{
+			Event: "Project restarted",
+		},
+	}
+}
+
+// Represents a project restart failing
+type ProjectRestartFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project restart failed event
+func NewProjectRestartFailedEvent(err error) Event {
+	return &ProjectRestartFailed{
+		baseEvent: &baseEvent{
+			Event: "Project restart failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project start starting
+type ProjectStartStart struct {
+	*baseEvent
+}
+
+// Creates a new project start starting event
+func NewProjectStartStartEvent() Event {
+	return &ProjectStartStart{
+		&baseEvent{
+			Event: "Starting project",
+		},
+	}
+}
+
+// Represents a project start completing
+type ProjectStartDone struct {
+	*baseEvent
+}
+
+// Creates a new project start done event
+func NewProjectStartDoneEvent() Event {
+	return &ProjectStartDone{
+		&baseEvent{
+			Event: "Project started",
+		},
+	}
+}
+
+// Represents a project start failing
+type ProjectStartFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project start failed event
+func NewProjectStartFailedEvent(err error) Event {
+	return &ProjectStartFailed{
+		baseEvent: &baseEvent{
+			Event: "Project start failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project up starting
+type ProjectUpStart struct {
+	*baseEvent
+}
+
+// Creates a new project up starting event
+func NewProjectUpStartEvent() Event {
+	return &ProjectUpStart{
+		&baseEvent{
+			Event: "Starting project",
+		},
+	}
+}
+
+// Represents a project up completing
+type ProjectUpDone struct {
+	*baseEvent
+}
+
+// Creates a new project up done event
+func NewProjectUpDoneEvent() Event {
+	return &ProjectUpDone{
+		&baseEvent{
+			Event: "Project started",
+		},
+	}
+}
+
+// Represents a project up failing
+type ProjectUpFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project up failed event
+func NewProjectUpFailedEvent(err error) Event {
+	return &ProjectUpFailed{
+		baseEvent: &baseEvent{
+			Event: "Project up failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project down starting
+type ProjectDownStart struct {
+	*baseEvent
+}
+
+// Creates a new project down starting event
+func NewProjectDownStartEvent() Event {
+	return &ProjectDownStart{
+		&baseEvent{
+			Event: "Stopping project",
+		},
+	}
+}
+
+// Represents a project down completing
+type ProjectDownDone struct {
+	*baseEvent
+}
+
+// Creates a new project down done event
+func NewProjectDownDoneEvent() Event {
+	return &ProjectDownDone{
+		&baseEvent{
+			Event: "Project stopped",
+		},
+	}
+}
+
+// Represents a project down failing
+type ProjectDownFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project down failed event
+func NewProjectDownFailedEvent(err error) Event {
+	return &ProjectDownFailed{
+		baseEvent: &baseEvent{
+			Event: "Project down failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project delete starting
+type ProjectDeleteStart struct {
+	*baseEvent
+}
+
+// Creates a new project delete starting event
+func NewProjectDeleteStartEvent() Event {
+	return &ProjectDeleteStart{
+		&baseEvent{
+			Event: "Deleting project",
+		},
+	}
+}
+
+// Represents a project delete completing
+type ProjectDeleteDone struct {
+	*baseEvent
+}
+
+// Creates a new project delete done event
+func NewProjectDeleteDoneEvent() Event {
+	return &ProjectDeleteDone{
+		&baseEvent{
+			Event: "Project deleted",
+		},
+	}
+}
+
+// Represents a project delete failing
+type ProjectDeleteFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project delete failed event
+func NewProjectDeleteFailedEvent(err error) Event {
+	return &ProjectDeleteFailed{
+		baseEvent: &baseEvent{
+			Event: "Project delete failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project kill starting
+type ProjectKillStart struct {
+	*baseEvent
+}
+
+// Creates a new project kill starting event
+func NewProjectKillStartEvent() Event {
+	return &ProjectKillStart{
+		&baseEvent{
+			Event: "Killing project",
+		},
+	}
+}
+
+// Represents a project kill completing
+type ProjectKillDone struct {
+	*baseEvent
+}
+
+// Creates a new project kill done event
+func NewProjectKillDoneEvent() Event {
+	return &ProjectKillDone{
+		&baseEvent{
+			Event: "Project killed",
+		},
+	}
+}
+
+// Represents a project kill failing
+type ProjectKillFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project kill failed event
+func NewProjectKillFailedEvent(err error) Event {
+	return &ProjectKillFailed{
+		baseEvent: &baseEvent{
+			Event: "Project kill failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project pause starting
+type ProjectPauseStart struct {
+	*baseEvent
+}
+
+// Creates a new project pause starting event
+func NewProjectPauseStartEvent() Event {
+	return &ProjectPauseStart{
+		&baseEvent{
+			Event: "Pausing project",
+		},
+	}
+}
+
+// Represents a project pause completing
+type ProjectPauseDone struct {
+	*baseEvent
+}
+
+// Creates a new project pause done event
+func NewProjectPauseDoneEvent() Event {
+	return &ProjectPauseDone{
+		&baseEvent{
+			Event: "Project paused",
+		},
+	}
+}
+
+// Represents a project pause failing
+type ProjectPauseFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project pause failed event
+func NewProjectPauseFailedEvent(err error) Event {
+	return &ProjectPauseFailed{
+		baseEvent: &baseEvent{
+			Event: "Project pause failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project unpause starting
+type ProjectUnpauseStart struct {
+	*baseEvent
+}
+
+// Creates a new project unpause starting event
+func NewProjectUnpauseStartEvent() Event {
+	return &ProjectUnpauseStart{
+		&baseEvent{
+			Event: "Unpausing project",
+		},
+	}
+}
+
+// Represents a project unpause completing
+type ProjectUnpauseDone struct {
+	*baseEvent
+}
+
+// Creates a new project unpause done event
+func NewProjectUnpauseDoneEvent() Event {
+	return &ProjectUnpauseDone{
+		&baseEvent{
+			Event: "Project unpaused",
+		},
+	}
+}
+
+// Represents a project unpause failing
+type ProjectUnpauseFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project unpause failed event
+func NewProjectUnpauseFailedEvent(err error) Event {
+	return &ProjectUnpauseFailed{
+		baseEvent: &baseEvent{
+			Event: "Project unpause failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project build starting
+type ProjectBuildStart struct {
+	*baseEvent
+}
+
+// Creates a new project build starting event
+func NewProjectBuildStartEvent() Event {
+	return &ProjectBuildStart{
+		&baseEvent{
+			Event: "Building project",
+		},
+	}
+}
+
+// Represents a project build completing
+type ProjectBuildDone struct {
+	*baseEvent
+}
+
+// Creates a new project build done event
+func NewProjectBuildDoneEvent() Event {
+	return &ProjectBuildDone{
+		&baseEvent{
+			Event: "Project built",
+		},
+	}
+}
+
+// Represents a project build failing
+type ProjectBuildFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project build failed event
+func NewProjectBuildFailedEvent(err error) Event {
+	return &ProjectBuildFailed{
+		baseEvent: &baseEvent{
+			Event: "Project build failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project creating
+type ProjectCreateStart struct {
+	*baseEvent
+}
+
+// Creates a new project creating event
+func NewProjectCreateStartEvent() Event {
+	return &ProjectCreateStart{
+		&baseEvent{
+			Event: "Create project",
+		},
+	}
+}
+
+// Represents a project create completing
+type ProjectCreateDone struct {
+	*baseEvent
+}
+
+// Creates a new project create done event
+func NewProjectCreateDoneEvent() Event {
+	return &ProjectCreateDone{
+		&baseEvent{
+			Event: "Project created",
+		},
+	}
+}
+
+// Represents a project create failing
+type ProjectCreateFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project create failed event
+func NewProjectCreateFailedEvent(err error) Event {
+	return &ProjectCreateFailed{
+		baseEvent: &baseEvent{
+			Event: "Project create failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project stop
+type ProjectStopStart struct {
+	*baseEvent
+}
+
+// Creates a new project stopping event
+func NewProjectStopStartEvent() Event {
+	return &ProjectStopStart{
+		&baseEvent{
+			Event: "Stop project",
+		},
+	}
+}
+
+// Represents a project stop completing
+type ProjectStopDone struct {
+	*baseEvent
+}
+
+// Creates a new project stop done event
+func NewProjectStopDoneEvent() Event {
+	return &ProjectStopDone{
+		&baseEvent{
+			Event: "Project stopped",
+		},
+	}
+}
+
+// Represents a project stop failing
+type ProjectStopFailed struct {
+	*baseEvent
+	err error
+}
+
+// Creates a new project stop failed event
+func NewProjectStopFailedEvent(err error) Event {
+	return &ProjectStopFailed{
+		baseEvent: &baseEvent{
+			Event: "Project stop failed",
+		},
+		err: err,
+	}
+}
+
+// Represents a project reload completing
+type ProjectReloadDone struct {
+	*baseEvent
+}
+
+// Creates a new project reload done event
+func NewProjectReloadDoneEvent(serviceName string) Event {
+	return &ProjectReloadDone{
+		&baseEvent{
+			Event:       "Project reloaded",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a project reload triggered
+type ProjectReloadTriggered struct {
+	*baseEvent
+}
+
+// Creates a new project reload triggered event
+func NewProjectReloadTriggeredEvent(serviceName string) Event {
+	return &ProjectReloadTriggered{
+		baseEvent: &baseEvent{
+			Event:       "Project reloading",
+			ServiceName: serviceName,
+		},
+	}
+}
+
+// Represents a container create
+type ContainerCreateStart struct {
+	*baseEvent
+	ContainerName string
+}
+
+// Creates a new container creating event
+func NewContainerCreateStartEvent(serviceName, containerName string) Event {
+	return &ContainerCreateStart{
+		baseEvent: &baseEvent{
+			Event:       "Creating container",
+			ServiceName: serviceName,
+		},
+		ContainerName: containerName,
+	}
+}
+
+// Represents a container create completing
+type ContainerCreateDone struct {
+	*baseEvent
+	ContainerName string
+}
+
+// Creates a new container create done event
+func NewContainerCreateDoneEvent(serviceName, containerName string) Event {
+	return &ContainerCreateDone{
+		baseEvent: &baseEvent{
+			Event:       "Container created",
+			ServiceName: serviceName,
+		},
+		ContainerName: containerName,
+	}
+}
+
+// Represents a container create failing
+type ContainerCreateFailed struct {
+	*baseEvent
+	err           error
+	ContainerName string
+}
+
+// Creates a new container create failed event
+func NewContainerCreateFailedEvent(serviceName, containerName string, err error) Event {
+	return &ContainerCreateFailed{
+		baseEvent: &baseEvent{
+			Event:       "Container create failed",
+			ServiceName: serviceName,
+		},
+		err:           err,
+		ContainerName: containerName,
+	}
+}
+
+// Represents a container start
+type ContainerStartStart struct {
+	*baseEvent
+	ContainerName string
+}
+
+// Creates a new container starting event
+func NewContainerStartStartEvent(serviceName, containerName string) Event {
+	return &ContainerStartStart{
+		baseEvent: &baseEvent{
+			Event:       "Starting container",
+			ServiceName: serviceName,
+		},
+		ContainerName: containerName,
+	}
+}
+
+// Represents a container start completing
+type ContainerStartDone struct {
+	*baseEvent
+	ContainerName string
+}
+
+// Creates a new container start done event
+func NewContainerStartDoneEvent(serviceName, containerName string) Event {
+	return &ContainerStartDone{
+		baseEvent: &baseEvent{
+			Event:       "Container started",
+			ServiceName: serviceName,
+		},
+		ContainerName: containerName,
+	}
+}
+
+// Represents a container start failing
+type ContainerStartFailed struct {
+	*baseEvent
+	err           error
+	ContainerName string
+}
+
+// Creates a new container start failed event
+func NewContainerStartFailedEvent(serviceName, containerName string, err error) Event {
+	return &ContainerStartFailed{
+		baseEvent: &baseEvent{
+			Event:       "Container start failed",
+			ServiceName: serviceName,
+		},
+		err:           err,
+		ContainerName: containerName,
+	}
 }

--- a/project/events/events_test.go
+++ b/project/events/events_test.go
@@ -1,21 +1,114 @@
 package events
 
 import (
-	"fmt"
+	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestEventEquality(t *testing.T) {
-	if fmt.Sprintf("%s", ServiceStart) != "Started" ||
-		fmt.Sprintf("%v", ServiceStart) != "Started" {
-		t.Fatalf("EventServiceStart String() doesn't work: %s %v", ServiceStart, ServiceStart)
+const (
+	action      = "foo"
+	serviceName = "bar"
+)
+
+var (
+	testErr = errors.New("test error")
+)
+
+func TestNewEvent(t *testing.T) {
+	event := NewEvent(action, serviceName)
+	assert.Equal(t, serviceName, event.Service())
+	assert.Equal(t, action, event.String())
+}
+
+func TestEventWrapper(t *testing.T) {
+	startedEvent := NewEvent("started", serviceName)
+	startedFunc := func() Event {
+		return startedEvent
+	}
+	doneEvent := NewEvent("done", serviceName)
+	doneFunc := func() Event {
+		return doneEvent
+	}
+	var failedErr error
+	failedEvent := NewEvent("failed", serviceName)
+	failedFunc := func(err error) Event {
+		failedErr = err
+		return failedEvent
+	}
+	eventWrapper := NewEventWrapper(action, startedFunc, doneFunc, failedFunc)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	assert.Equal(t, startedEvent, eventWrapper.Started())
+	assert.Equal(t, doneEvent, eventWrapper.Done())
+	assert.Equal(t, failedEvent, eventWrapper.Failed(testErr))
+	assert.Equal(t, testErr, failedErr)
+}
+
+func TestEventWrapperNil(t *testing.T) {
+	eventWrapper := NewEventWrapper(action, nil, nil, nil)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	assert.Nil(t, eventWrapper.Started())
+	assert.Nil(t, eventWrapper.Done())
+	assert.Nil(t, eventWrapper.Failed(testErr))
+}
+
+func TestServiceEventWrapper(t *testing.T) {
+	startedFunc := func(s string) Event {
+		return NewEvent("started", s)
 	}
 
-	if fmt.Sprintf("%s", ServiceStart) != fmt.Sprintf("%s", ServiceUp) {
-		t.Fatal("Event messages do not match")
+	doneFunc := func(s string) Event {
+		return NewEvent("done", s)
+	}
+	var failedErr error
+	failedFunc := func(s string, err error) Event {
+		failedErr = err
+		return NewEvent("failed", s)
 	}
 
-	if ServiceStart == ServiceUp {
-		t.Fatal("Events match")
-	}
+	eventWrapper := NewServiceEventWrapper(action, startedFunc, doneFunc, failedFunc)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	e1 := eventWrapper.Started(serviceName)
+	assert.Equal(t, "started", e1.String())
+	assert.Equal(t, serviceName, e1.Service())
+
+	e2 := eventWrapper.Done(serviceName)
+	assert.Equal(t, "done", e2.String())
+	assert.Equal(t, serviceName, e2.Service())
+
+	e3 := eventWrapper.Failed(serviceName, testErr)
+	assert.Equal(t, "failed", e3.String())
+	assert.Equal(t, serviceName, e3.Service())
+	assert.Equal(t, testErr, failedErr)
+}
+
+func TestServiceEventWrapperNil(t *testing.T) {
+	eventWrapper := NewServiceEventWrapper(action, nil, nil, nil)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	assert.Nil(t, eventWrapper.Started(serviceName))
+	assert.Nil(t, eventWrapper.Done(serviceName))
+	assert.Nil(t, eventWrapper.Failed(serviceName, testErr))
+}
+
+func TestDummyEventWrapper(t *testing.T) {
+	eventWrapper := NewDummyEventWrapper(action)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	assert.Nil(t, eventWrapper.Started())
+	assert.Nil(t, eventWrapper.Done())
+	assert.Nil(t, eventWrapper.Failed(testErr))
+}
+
+func TestDummyServiceEventWrapper(t *testing.T) {
+	eventWrapper := NewDummyServiceEventWrapper(action)
+	assert.Equal(t, action, eventWrapper.Action())
+
+	assert.Nil(t, eventWrapper.Started(serviceName))
+	assert.Nil(t, eventWrapper.Done(serviceName))
+	assert.Nil(t, eventWrapper.Failed(serviceName, testErr))
 }

--- a/project/events/events_test.go
+++ b/project/events/events_test.go
@@ -13,7 +13,7 @@ const (
 )
 
 var (
-	testErr = errors.New("test error")
+	errTest = errors.New("test error")
 )
 
 func TestNewEvent(t *testing.T) {
@@ -23,39 +23,6 @@ func TestNewEvent(t *testing.T) {
 }
 
 func TestEventWrapper(t *testing.T) {
-	startedEvent := NewEvent("started", serviceName)
-	startedFunc := func() Event {
-		return startedEvent
-	}
-	doneEvent := NewEvent("done", serviceName)
-	doneFunc := func() Event {
-		return doneEvent
-	}
-	var failedErr error
-	failedEvent := NewEvent("failed", serviceName)
-	failedFunc := func(err error) Event {
-		failedErr = err
-		return failedEvent
-	}
-	eventWrapper := NewEventWrapper(action, startedFunc, doneFunc, failedFunc)
-	assert.Equal(t, action, eventWrapper.Action())
-
-	assert.Equal(t, startedEvent, eventWrapper.Started())
-	assert.Equal(t, doneEvent, eventWrapper.Done())
-	assert.Equal(t, failedEvent, eventWrapper.Failed(testErr))
-	assert.Equal(t, testErr, failedErr)
-}
-
-func TestEventWrapperNil(t *testing.T) {
-	eventWrapper := NewEventWrapper(action, nil, nil, nil)
-	assert.Equal(t, action, eventWrapper.Action())
-
-	assert.Nil(t, eventWrapper.Started())
-	assert.Nil(t, eventWrapper.Done())
-	assert.Nil(t, eventWrapper.Failed(testErr))
-}
-
-func TestServiceEventWrapper(t *testing.T) {
 	startedFunc := func(s string) Event {
 		return NewEvent("started", s)
 	}
@@ -69,7 +36,7 @@ func TestServiceEventWrapper(t *testing.T) {
 		return NewEvent("failed", s)
 	}
 
-	eventWrapper := NewServiceEventWrapper(action, startedFunc, doneFunc, failedFunc)
+	eventWrapper := NewEventWrapper(action, startedFunc, doneFunc, failedFunc)
 	assert.Equal(t, action, eventWrapper.Action())
 
 	e1 := eventWrapper.Started(serviceName)
@@ -80,35 +47,26 @@ func TestServiceEventWrapper(t *testing.T) {
 	assert.Equal(t, "done", e2.String())
 	assert.Equal(t, serviceName, e2.Service())
 
-	e3 := eventWrapper.Failed(serviceName, testErr)
+	e3 := eventWrapper.Failed(serviceName, errTest)
 	assert.Equal(t, "failed", e3.String())
 	assert.Equal(t, serviceName, e3.Service())
-	assert.Equal(t, testErr, failedErr)
+	assert.Equal(t, errTest, failedErr)
 }
 
-func TestServiceEventWrapperNil(t *testing.T) {
-	eventWrapper := NewServiceEventWrapper(action, nil, nil, nil)
+func TestEventWrapperNil(t *testing.T) {
+	eventWrapper := NewEventWrapper(action, nil, nil, nil)
 	assert.Equal(t, action, eventWrapper.Action())
 
 	assert.Nil(t, eventWrapper.Started(serviceName))
 	assert.Nil(t, eventWrapper.Done(serviceName))
-	assert.Nil(t, eventWrapper.Failed(serviceName, testErr))
+	assert.Nil(t, eventWrapper.Failed(serviceName, errTest))
 }
 
 func TestDummyEventWrapper(t *testing.T) {
 	eventWrapper := NewDummyEventWrapper(action)
 	assert.Equal(t, action, eventWrapper.Action())
 
-	assert.Nil(t, eventWrapper.Started())
-	assert.Nil(t, eventWrapper.Done())
-	assert.Nil(t, eventWrapper.Failed(testErr))
-}
-
-func TestDummyServiceEventWrapper(t *testing.T) {
-	eventWrapper := NewDummyServiceEventWrapper(action)
-	assert.Equal(t, action, eventWrapper.Action())
-
 	assert.Nil(t, eventWrapper.Started(serviceName))
 	assert.Nil(t, eventWrapper.Done(serviceName))
-	assert.Nil(t, eventWrapper.Failed(serviceName, testErr))
+	assert.Nil(t, eventWrapper.Failed(serviceName, errTest))
 }

--- a/project/listener.go
+++ b/project/listener.go
@@ -1,35 +1,10 @@
 package project
 
 import (
-	"bytes"
+	"encoding/json"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcompose/project/events"
-)
-
-var (
-	infoEvents = map[events.EventType]bool{
-		events.ServiceDeleteStart:  true,
-		events.ServiceDelete:       true,
-		events.ServiceDownStart:    true,
-		events.ServiceDown:         true,
-		events.ServiceStopStart:    true,
-		events.ServiceStop:         true,
-		events.ServiceKillStart:    true,
-		events.ServiceKill:         true,
-		events.ServiceCreateStart:  true,
-		events.ServiceCreate:       true,
-		events.ServiceStartStart:   true,
-		events.ServiceStart:        true,
-		events.ServiceRestartStart: true,
-		events.ServiceRestart:      true,
-		events.ServiceUpStart:      true,
-		events.ServiceUp:           true,
-		events.ServicePauseStart:   true,
-		events.ServicePause:        true,
-		events.ServiceUnpauseStart: true,
-		events.ServiceUnpause:      true,
-	}
 )
 
 type defaultListener struct {
@@ -50,32 +25,93 @@ func NewDefaultListener(p *Project) chan<- events.Event {
 
 func (d *defaultListener) start() {
 	for event := range d.listenChan {
-		buffer := bytes.NewBuffer(nil)
-		if event.Data != nil {
-			for k, v := range event.Data {
-				if buffer.Len() > 0 {
-					buffer.WriteString(", ")
-				}
-				buffer.WriteString(k)
-				buffer.WriteString("=")
-				buffer.WriteString(v)
-			}
-		}
+		data, err := json.Marshal(event)
 
-		if event.EventType == events.ServiceUp {
+		switch event.(type) {
+		case *events.ServiceUpDone:
 			d.upCount++
 		}
 
 		logf := logrus.Debugf
 
-		if infoEvents[event.EventType] {
+		if infoLevel(event) {
 			logf = logrus.Infof
 		}
 
-		if event.ServiceName == "" {
-			logf("Project [%s]: %s %s", d.project.Name, event.EventType, buffer.Bytes())
+		if err != nil {
+			logf("Failed to Marshal Event [%s] for Project %s. Error: [%s]", event.String(), d.project.Name, err.Error())
+
+		} else if event.Service() == "" {
+			logf("Project [%s]: %s %s", d.project.Name, event.String(), data)
 		} else {
-			logf("[%d/%d] [%s]: %s %s", d.upCount, d.project.ServiceConfigs.Len(), event.ServiceName, event.EventType, buffer.Bytes())
+			logf("[%d/%d] [%s]: %s %s", d.upCount, d.project.ServiceConfigs.Len(), event.Service(), event.String(), data)
 		}
+	}
+}
+
+func infoLevel(event events.Event) bool {
+	switch event.(type) {
+	case *events.ServiceDeleteStart:
+		return true
+	case *events.ServiceDeleteDone:
+		return true
+	case *events.ServiceDeleteFailed:
+		return true
+	case *events.ServiceDownStart:
+		return true
+	case *events.ServiceDownDone:
+		return true
+	case *events.ServiceDownFailed:
+		return true
+	case *events.ServiceStopStart:
+		return true
+	case *events.ServiceStopDone:
+		return true
+	case *events.ServiceStopFailed:
+		return true
+	case *events.ServiceKillStart:
+		return true
+	case *events.ServiceKillDone:
+		return true
+	case *events.ServiceKillFailed:
+		return true
+	case *events.ServiceCreateStart:
+		return true
+	case *events.ServiceCreateDone:
+		return true
+	case *events.ServiceCreateFailed:
+		return true
+	case *events.ServiceStartStart:
+		return true
+	case *events.ServiceStartDone:
+		return true
+	case *events.ServiceStartFailed:
+		return true
+	case *events.ServiceRestartStart:
+		return true
+	case *events.ServiceRestartDone:
+		return true
+	case *events.ServiceRestartFailed:
+		return true
+	case *events.ServiceUpStart:
+		return true
+	case *events.ServiceUpDone:
+		return true
+	case *events.ServiceUpFailed:
+		return true
+	case *events.ServicePauseStart:
+		return true
+	case *events.ServicePauseDone:
+		return true
+	case *events.ServicePauseFailed:
+		return true
+	case *events.ServiceUnpauseStart:
+		return true
+	case *events.ServiceUnpauseDone:
+		return true
+	case *events.ServiceUnpauseFailed:
+		return true
+	default:
+		return false
 	}
 }

--- a/project/project.go
+++ b/project/project.go
@@ -146,7 +146,7 @@ func (p *Project) CreateService(name string) (Service, error) {
 
 // AddConfig adds the specified service config for the specified name.
 func (p *Project) AddConfig(name string, config *config.ServiceConfig) error {
-	p.Notify(events.ServiceAdd, name, nil)
+	p.Notify(events.NewServiceAddEvent(name))
 
 	p.ServiceConfigs.Add(name, config)
 	p.reload = append(p.reload, name)
@@ -156,14 +156,14 @@ func (p *Project) AddConfig(name string, config *config.ServiceConfig) error {
 
 // AddVolumeConfig adds the specified volume config for the specified name.
 func (p *Project) AddVolumeConfig(name string, config *config.VolumeConfig) error {
-	p.Notify(events.VolumeAdd, name, nil)
+	p.Notify(events.NewVolumeAddEvent(name, config.Driver))
 	p.VolumeConfigs[name] = config
 	return nil
 }
 
 // AddNetworkConfig adds the specified network config for the specified name.
 func (p *Project) AddNetworkConfig(name string, config *config.NetworkConfig) error {
-	p.Notify(events.NetworkAdd, name, nil)
+	p.Notify(events.NewNetworkAddEvent(name, config.Driver))
 	p.NetworkConfigs[name] = config
 	return nil
 }
@@ -335,8 +335,10 @@ func (p *Project) loadWrappers(wrappers map[string]*serviceWrapper, servicesToCo
 
 // Build builds the specified services (like docker build).
 func (p *Project) Build(ctx context.Context, buildOptions options.Build, services ...string) error {
-	return p.perform(events.ProjectBuildStart, events.ProjectBuildDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceBuildStart, events.ServiceBuild, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Build", events.NewProjectBuildStartEvent, events.NewProjectBuildDoneEvent, events.NewProjectBuildFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Build", events.NewServiceBuildStartEvent, events.NewServiceBuildDoneEvent, events.NewServiceBuildFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Build(ctx, buildOptions)
 		})
 	}), nil)
@@ -347,8 +349,10 @@ func (p *Project) Create(ctx context.Context, options options.Create, services .
 	if options.NoRecreate && options.ForceRecreate {
 		return fmt.Errorf("no-recreate and force-recreate cannot be combined")
 	}
-	return p.perform(events.ProjectCreateStart, events.ProjectCreateDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceCreateStart, events.ServiceCreate, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Create", events.NewProjectCreateStartEvent, events.NewProjectCreateDoneEvent, events.NewProjectCreateFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Create", events.NewServiceCreateStartEvent, events.NewServiceCreateDoneEvent, events.NewServiceCreateFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Create(ctx, options)
 		})
 	}), nil)
@@ -356,8 +360,10 @@ func (p *Project) Create(ctx context.Context, options options.Create, services .
 
 // Stop stops the specified services (like docker stop).
 func (p *Project) Stop(ctx context.Context, timeout int, services ...string) error {
-	return p.perform(events.ProjectStopStart, events.ProjectStopDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceStopStart, events.ServiceStop, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Stop", events.NewProjectStopStartEvent, events.NewProjectStopDoneEvent, events.NewProjectStopFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Stop", events.NewServiceStopStartEvent, events.NewServiceStopDoneEvent, events.NewServiceStopFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Stop(ctx, timeout)
 		})
 	}), nil)
@@ -368,45 +374,55 @@ func (p *Project) Down(ctx context.Context, opts options.Down, services ...strin
 	if !opts.RemoveImages.Valid() {
 		return fmt.Errorf("--rmi flag must be local, all or empty")
 	}
-	if err := p.Stop(ctx, 10, services...); err != nil {
-		return err
-	}
-	if opts.RemoveOrphans {
-		if err := p.runtime.RemoveOrphans(ctx, p.Name, p.ServiceConfigs); err != nil {
+	p.Notify(events.NewProjectDownStartEvent())
+	err := func() error {
+		if err := p.Stop(ctx, 10, services...); err != nil {
 			return err
 		}
-	}
-	if err := p.Delete(ctx, options.Delete{
-		RemoveVolume: opts.RemoveVolume,
-	}, services...); err != nil {
-		return err
-	}
+		if opts.RemoveOrphans {
+			if err := p.runtime.RemoveOrphans(ctx, p.Name, p.ServiceConfigs); err != nil {
+				return err
+			}
+		}
+		if err := p.Delete(ctx, options.Delete{
+			RemoveVolume: opts.RemoveVolume,
+		}, services...); err != nil {
+			return err
+		}
 
-	networks, err := p.context.NetworksFactory.Create(p.Name, p.NetworkConfigs, p.ServiceConfigs, p.isNetworkEnabled())
-	if err != nil {
-		return err
-	}
-	if err := networks.Remove(ctx); err != nil {
-		return err
-	}
-
-	if opts.RemoveVolume {
-		volumes, err := p.context.VolumesFactory.Create(p.Name, p.VolumeConfigs, p.ServiceConfigs, p.isVolumeEnabled())
+		networks, err := p.context.NetworksFactory.Create(p.Name, p.NetworkConfigs, p.ServiceConfigs, p.isNetworkEnabled())
 		if err != nil {
 			return err
 		}
-		if err := volumes.Remove(ctx); err != nil {
+		if err := networks.Remove(ctx); err != nil {
 			return err
 		}
-	}
 
-	return p.forEach([]string{}, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.NoEvent, events.NoEvent, func(service Service) error {
-			return service.RemoveImage(ctx, opts.RemoveImages)
+		if opts.RemoveVolume {
+			volumes, err := p.context.VolumesFactory.Create(p.Name, p.VolumeConfigs, p.ServiceConfigs, p.isVolumeEnabled())
+			if err != nil {
+				return err
+			}
+			if err := volumes.Remove(ctx); err != nil {
+				return err
+			}
+		}
+
+		return p.forEach([]string{}, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+			serviceEventWrapper := events.NewServiceEventWrapper("Service Down", events.NewServiceDownStartEvent, events.NewServiceDownDoneEvent, events.NewServiceDownFailedEvent)
+			wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
+				return service.RemoveImage(ctx, opts.RemoveImages)
+			})
+		}), func(service Service) error {
+			return service.Create(ctx, options.Create{})
 		})
-	}), func(service Service) error {
-		return service.Create(ctx, options.Create{})
-	})
+	}
+	if err != nil {
+		p.Notify(events.NewProjectDownFailedEvent(err))
+	} else {
+		p.Notify(events.NewProjectDownDoneEvent())
+	}
+	return err
 }
 
 // RemoveOrphans implements project.RuntimeProject.RemoveOrphans.
@@ -417,8 +433,10 @@ func (p *Project) RemoveOrphans(ctx context.Context) error {
 
 // Restart restarts the specified services (like docker restart).
 func (p *Project) Restart(ctx context.Context, timeout int, services ...string) error {
-	return p.perform(events.ProjectRestartStart, events.ProjectRestartDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceRestartStart, events.ServiceRestart, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Restart", events.NewProjectRestartStartEvent, events.NewProjectRestartDoneEvent, events.NewProjectRestartFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Restart", events.NewServiceRestartStartEvent, events.NewServiceRestartDoneEvent, events.NewServiceRestartFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Restart(ctx, timeout)
 		})
 	}), nil)
@@ -464,8 +482,10 @@ func (p *Project) Ps(ctx context.Context, onlyID bool, services ...string) (Info
 
 // Start starts the specified services (like docker start).
 func (p *Project) Start(ctx context.Context, services ...string) error {
-	return p.perform(events.ProjectStartStart, events.ProjectStartDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceStartStart, events.ServiceStart, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Start", events.NewProjectStartStartEvent, events.NewProjectStartDoneEvent, events.NewProjectStartFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Project Start", events.NewServiceStartStartEvent, events.NewServiceStartDoneEvent, events.NewServiceStartFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Start(ctx)
 		})
 	}), nil)
@@ -482,7 +502,8 @@ func (p *Project) Run(ctx context.Context, serviceName string, commandParts []st
 	}
 	var exitCode int
 	err := p.forEach([]string{}, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceRunStart, events.ServiceRun, func(service Service) error {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Run", events.NewServiceRunStartEvent, events.NewServiceRunDoneEvent, events.NewServiceRunFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			if service.Name() == serviceName {
 				code, err := service.Run(ctx, commandParts, opts)
 				exitCode = code
@@ -501,8 +522,10 @@ func (p *Project) Up(ctx context.Context, options options.Up, services ...string
 	if err := p.initialize(ctx); err != nil {
 		return err
 	}
-	return p.perform(events.ProjectUpStart, events.ProjectUpDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(wrappers, events.ServiceUpStart, events.ServiceUp, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Up", events.NewProjectUpStartEvent, events.NewProjectUpDoneEvent, events.NewProjectUpFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Up", events.NewServiceUpStartEvent, events.NewServiceUpDoneEvent, events.NewServiceUpFailedEvent)
+		wrapper.Do(wrappers, serviceEventWrapper, func(service Service) error {
 			return service.Up(ctx, options)
 		})
 	}), func(service Service) error {
@@ -513,7 +536,7 @@ func (p *Project) Up(ctx context.Context, options options.Up, services ...string
 // Log aggregates and prints out the logs for the specified services.
 func (p *Project) Log(ctx context.Context, follow bool, services ...string) error {
 	return p.forEach(services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.NoEvent, events.NoEvent, func(service Service) error {
+		wrapper.Do(nil, events.NewDummyServiceEventWrapper("Log"), func(service Service) error {
 			return service.Log(ctx, follow)
 		})
 	}), nil)
@@ -553,7 +576,8 @@ func (p *Project) Scale(ctx context.Context, timeout int, servicesScale map[stri
 // Pull pulls the specified services (like docker pull).
 func (p *Project) Pull(ctx context.Context, services ...string) error {
 	return p.forEach(services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServicePullStart, events.ServicePull, func(service Service) error {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Pull", events.NewServicePullStartEvent, events.NewServicePullDoneEvent, events.NewServicePullFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Pull(ctx)
 		})
 	}), nil)
@@ -564,7 +588,7 @@ func (p *Project) Pull(ctx context.Context, services ...string) error {
 func (p *Project) Containers(ctx context.Context, filter Filter, services ...string) ([]string, error) {
 	containers := []string{}
 	err := p.forEach(services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.NoEvent, events.NoEvent, func(service Service) error {
+		wrapper.Do(nil, events.NewDummyServiceEventWrapper("Container List"), func(service Service) error {
 			serviceContainers, innerErr := service.Containers(ctx)
 			if innerErr != nil {
 				return innerErr
@@ -607,8 +631,10 @@ func (p *Project) Containers(ctx context.Context, filter Filter, services ...str
 
 // Delete removes the specified services (like docker rm).
 func (p *Project) Delete(ctx context.Context, options options.Delete, services ...string) error {
-	return p.perform(events.ProjectDeleteStart, events.ProjectDeleteDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceDeleteStart, events.ServiceDelete, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Delete", events.NewProjectDeleteStartEvent, events.NewProjectDeleteDoneEvent, events.NewProjectDeleteFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Delete", events.NewServiceDeleteStartEvent, events.NewServiceDeleteDoneEvent, events.NewServiceDeleteFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Delete(ctx, options)
 		})
 	}), nil)
@@ -616,8 +642,10 @@ func (p *Project) Delete(ctx context.Context, options options.Delete, services .
 
 // Kill kills the specified services (like docker kill).
 func (p *Project) Kill(ctx context.Context, signal string, services ...string) error {
-	return p.perform(events.ProjectKillStart, events.ProjectKillDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceKillStart, events.ServiceKill, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Kill", events.NewProjectKillStartEvent, events.NewProjectKillDoneEvent, events.NewProjectKillFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Pull", events.NewServiceKillStartEvent, events.NewServiceKillDoneEvent, events.NewServiceKillFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Kill(ctx, signal)
 		})
 	}), nil)
@@ -625,8 +653,10 @@ func (p *Project) Kill(ctx context.Context, signal string, services ...string) e
 
 // Pause pauses the specified services containers (like docker pause).
 func (p *Project) Pause(ctx context.Context, services ...string) error {
-	return p.perform(events.ProjectPauseStart, events.ProjectPauseDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServicePauseStart, events.ServicePause, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Pause", events.NewProjectPauseStartEvent, events.NewProjectPauseDoneEvent, events.NewProjectPauseFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Pause", events.NewServicePauseStartEvent, events.NewServicePauseDoneEvent, events.NewServicePauseFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Pause(ctx)
 		})
 	}), nil)
@@ -634,19 +664,25 @@ func (p *Project) Pause(ctx context.Context, services ...string) error {
 
 // Unpause pauses the specified services containers (like docker pause).
 func (p *Project) Unpause(ctx context.Context, services ...string) error {
-	return p.perform(events.ProjectUnpauseStart, events.ProjectUnpauseDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
-		wrapper.Do(nil, events.ServiceUnpauseStart, events.ServiceUnpause, func(service Service) error {
+	eventWrapper := events.NewEventWrapper("Project Pause", events.NewProjectUnpauseStartEvent, events.NewProjectUnpauseDoneEvent, events.NewProjectUnpauseFailedEvent)
+	return p.perform(eventWrapper, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
+		serviceEventWrapper := events.NewServiceEventWrapper("Service Pause", events.NewServiceUnpauseStartEvent, events.NewServiceUnpauseDoneEvent, events.NewServiceUnpauseFailedEvent)
+		wrapper.Do(nil, serviceEventWrapper, func(service Service) error {
 			return service.Unpause(ctx)
 		})
 	}), nil)
 }
 
-func (p *Project) perform(start, done events.EventType, services []string, action wrapperAction, cycleAction serviceAction) error {
-	p.Notify(start, "", nil)
+func (p *Project) perform(eventWrapper events.EventWrapper, services []string, action wrapperAction, cycleAction serviceAction) error {
+	p.Notify(eventWrapper.Started())
 
 	err := p.forEach(services, action, cycleAction)
 
-	p.Notify(done, "", nil)
+	if err != nil {
+		p.Notify(eventWrapper.Done())
+	} else {
+		p.Notify(eventWrapper.Failed(err))
+	}
 	return err
 }
 
@@ -792,17 +828,11 @@ func (p *Project) AddListener(c chan<- events.Event) {
 	}
 }
 
-// Notify notifies all project listener with the specified eventType, service name and datas.
+// Notify notifies all project listener with the specified event
 // This implements implicitly events.Notifier interface.
-func (p *Project) Notify(eventType events.EventType, serviceName string, data map[string]string) {
-	if eventType == events.NoEvent {
+func (p *Project) Notify(event events.Event) {
+	if event == nil {
 		return
-	}
-
-	event := events.Event{
-		EventType:   eventType,
-		ServiceName: serviceName,
-		Data:        data,
 	}
 
 	for _, l := range p.listeners {

--- a/project/service-wrapper.go
+++ b/project/service-wrapper.go
@@ -83,7 +83,7 @@ func (s *serviceWrapper) waitForDeps(wrappers map[string]*serviceWrapper) bool {
 	return true
 }
 
-func (s *serviceWrapper) Do(wrappers map[string]*serviceWrapper, eventWrapper events.ServiceEventWrapper, action func(service Service) error) {
+func (s *serviceWrapper) Do(wrappers map[string]*serviceWrapper, eventWrapper events.EventWrapper, action func(service Service) error) {
 	defer s.done.Done()
 
 	if s.state == StateExecuted {

--- a/project/service-wrapper.go
+++ b/project/service-wrapper.go
@@ -56,7 +56,7 @@ func (s *serviceWrapper) Ignore() {
 	defer s.done.Done()
 
 	s.state = StateExecuted
-	s.project.Notify(events.ServiceUpIgnored, s.service.Name(), nil)
+	s.project.Notify(events.NewServiceUpIgnoredEvent(s.service.Name()))
 }
 
 func (s *serviceWrapper) waitForDeps(wrappers map[string]*serviceWrapper) bool {
@@ -71,7 +71,7 @@ func (s *serviceWrapper) waitForDeps(wrappers map[string]*serviceWrapper) bool {
 
 		if wrapper, ok := wrappers[dep.Target]; ok {
 			if wrapper.Wait() == ErrRestart {
-				s.project.Notify(events.ProjectReload, wrapper.service.Name(), nil)
+				s.project.Notify(events.NewProjectReloadDoneEvent(wrapper.service.Name()))
 				s.err = ErrRestart
 				return false
 			}
@@ -83,7 +83,7 @@ func (s *serviceWrapper) waitForDeps(wrappers map[string]*serviceWrapper) bool {
 	return true
 }
 
-func (s *serviceWrapper) Do(wrappers map[string]*serviceWrapper, start, done events.EventType, action func(service Service) error) {
+func (s *serviceWrapper) Do(wrappers map[string]*serviceWrapper, eventWrapper events.ServiceEventWrapper, action func(service Service) error) {
 	defer s.done.Done()
 
 	if s.state == StateExecuted {
@@ -96,16 +96,17 @@ func (s *serviceWrapper) Do(wrappers map[string]*serviceWrapper, start, done eve
 
 	s.state = StateExecuted
 
-	s.project.Notify(start, s.service.Name(), nil)
+	s.project.Notify(eventWrapper.Started(s.service.Name()))
 
 	s.err = action(s.service)
 	if s.err == ErrRestart {
-		s.project.Notify(done, s.service.Name(), nil)
-		s.project.Notify(events.ProjectReloadTrigger, s.service.Name(), nil)
+		s.project.Notify(eventWrapper.Done(s.service.Name()))
+		s.project.Notify(events.NewProjectReloadTriggeredEvent(s.service.Name()))
 	} else if s.err != nil {
-		log.Errorf("Failed %s %s : %v", start, s.name, s.err)
+		log.Errorf("Failed %s %s : %v", eventWrapper.Action(), s.name, s.err)
+		s.project.Notify(eventWrapper.Failed(s.service.Name(), s.err))
 	} else {
-		s.project.Notify(done, s.service.Name(), nil)
+		s.project.Notify(eventWrapper.Done(s.service.Name()))
 	}
 }
 


### PR DESCRIPTION
This change updates all project, service and container events to be heavily typed,
which allows event readers to expect specific fields rather than reading from an
attribute map

Replaces https://github.com/docker/libcompose/pull/164

This is ready for review.

The main point of this change is that instead of using an event code enum, this now uses strict struct types. This allows select type-casting on the event read side, and as a result users can expect specific structures with clear fields and functions instead of having to look up specific values which may or may not be in the map and may or may not be valid as blank.

The downside of this approach is that it is very explicit and a lot of structs are generated. There is also some field misuse (project events have an un-used serviceName field), however the alternative for this would be to have two sets of interfaces for generating events (factory and wrapper)

To fit with the project/project and docker/service way of creating events en-masse, this ships with EventFactory (creates on-demand events for a specified service name) and EventWrapper (creates started/created/done events depending on if the action succeeded). This allow the struct typing to fit better into the more meta-approach of bulk-service actions using wrappers.
