### PR TITLE
Fix run command's service check logic

### DIFF
--- a/cli/app/app.go
+++ b/cli/app/app.go
@@ -174,7 +174,7 @@ func ProjectUp(p project.APIProject, c *cli.Context) error {
 
 // ProjectRun runs a given command within a service's container.
 func ProjectRun(p project.APIProject, c *cli.Context) error {
-	if len(c.Args()) == 1 {
+	if len(c.Args()) == 0 {
 		logrus.Fatal("No service specified")
 	}
 


### PR DESCRIPTION
The command would panic if no service were provided, or would not allow
running a service without additional comandParts.

Signed-off-by: Dustin Chapman <dustin.r.chapman@gmail.com>