### PR TITLE
Remove returned error in ID and IsRunning…

### DIFF
--- a/docker/container/container.go
+++ b/docker/container/container.go
@@ -168,9 +168,8 @@ func (c *Container) Kill(ctx context.Context, signal string) error {
 }
 
 // IsRunning returns the running state of the container.
-// FIXME(vdemeester): remove the nil error here
-func (c *Container) IsRunning(ctx context.Context) (bool, error) {
-	return c.container.State.Running, nil
+func (c *Container) IsRunning(ctx context.Context) bool {
+	return c.container.State.Running
 }
 
 // Run creates, start and attach to the container based on the image name,
@@ -292,16 +291,6 @@ func (c *Container) Start(ctx context.Context) error {
 	return nil
 }
 
-// ID returns the container Id.
-func (c *Container) ID() (string, error) {
-	return c.container.ID, nil
-}
-
-// Name returns the container name.
-func (c *Container) Name() string {
-	return c.container.Name
-}
-
 // Restart restarts the container if existing, does nothing otherwise.
 func (c *Container) Restart(ctx context.Context, timeout int) error {
 	timeoutDuration := time.Duration(timeout) * time.Second
@@ -353,6 +342,21 @@ func (c *Container) Port(ctx context.Context, port string) (string, error) {
 // Networks returns the containers network
 func (c *Container) Networks() (map[string]*network.EndpointSettings, error) {
 	return c.container.NetworkSettings.Networks, nil
+}
+
+// ID returns the container Id.
+func (c *Container) ID() string {
+	return c.container.ID
+}
+
+// ShortID return the container Id in its short form
+func (c *Container) ShortID() string {
+	return c.container.ID[:12]
+}
+
+// Name returns the container name.
+func (c *Container) Name() string {
+	return c.container.Name
 }
 
 // Image returns the container image. Depending on the engine version its either

--- a/docker/service/convert.go
+++ b/docker/service/convert.go
@@ -212,10 +212,7 @@ func Convert(c *config.ServiceConfig, ctx project.Context, clientFactory compose
 				}
 				if len(containers) != 0 {
 					container := containers[0]
-					containerID, err := container.ID()
-					if err != nil {
-						return nil, nil, err
-					}
+					containerID := container.ID()
 					networkMode = "container:" + containerID
 				}
 				// FIXME(vdemeester) log/warn in case of len(containers) == 0

--- a/docker/service/service.go
+++ b/docker/service/service.go
@@ -232,8 +232,7 @@ func (s *Service) constructContainers(ctx context.Context, count int) ([]*contai
 			return nil, err
 		}
 
-		// FIXME(vdemeester) use property/method instead
-		id, _ := c.ID()
+		id := c.ID()
 		logrus.Debugf("Created container %s: %v", id, c.Name())
 
 		result = append(result, c)
@@ -380,8 +379,7 @@ func (s *Service) connectContainerToNetworks(ctx context.Context, c *container.C
 				// FIXME(vdemeester) implement alias checking (to not disconnect/reconnect for nothing)
 				aliasPresent := false
 				for _, alias := range existingNetwork.Aliases {
-					// FIXME(vdemeester) use shortID instead of ID
-					ID, _ := c.ID()
+					ID := c.ShortID()
 					if alias == ID {
 						aliasPresent = true
 					}
@@ -403,7 +401,7 @@ func (s *Service) connectContainerToNetworks(ctx context.Context, c *container.C
 
 // NetworkDisconnect disconnects the container from the specified network
 func (s *Service) NetworkDisconnect(ctx context.Context, c *container.Container, net *yaml.Network, oneOff bool) error {
-	containerID, _ := c.ID()
+	containerID := c.ID()
 	client := s.clientFactory.Create(s)
 	return client.NetworkDisconnect(ctx, net.RealName, containerID, true)
 }
@@ -411,7 +409,7 @@ func (s *Service) NetworkDisconnect(ctx context.Context, c *container.Container,
 // NetworkConnect connects the container to the specified network
 // FIXME(vdemeester) will be refactor with Container refactoring
 func (s *Service) NetworkConnect(ctx context.Context, c *container.Container, net *yaml.Network, oneOff bool) error {
-	containerID, _ := c.ID()
+	containerID := c.ID()
 	client := s.clientFactory.Create(s)
 	internalLinks, err := s.getLinks()
 	if err != nil {
@@ -469,7 +467,7 @@ func (s *Service) recreateIfNeeded(ctx context.Context, c *container.Container, 
 
 func (s *Service) recreate(ctx context.Context, c *container.Container) (*container.Container, error) {
 	name := c.Name()
-	id, _ := c.ID()
+	id := c.ID()
 	newName := fmt.Sprintf("%s_%s", name, id[:12])
 	logrus.Debugf("Renaming %s => %s", name, newName)
 	if err := c.Rename(ctx, newName); err != nil {
@@ -481,7 +479,7 @@ func (s *Service) recreate(ctx context.Context, c *container.Container) (*contai
 	if err != nil {
 		return nil, err
 	}
-	newID, _ := newContainer.ID()
+	newID := newContainer.ID()
 	logrus.Debugf("Created replacement container %s", newID)
 	if err := c.Remove(ctx, false); err != nil {
 		logrus.Errorf("Failed to remove old container %s", c.Name())
@@ -566,7 +564,7 @@ func (s *Service) Kill(ctx context.Context, signal string) error {
 // Delete implements Service.Delete. It removes any containers related to the service.
 func (s *Service) Delete(ctx context.Context, options options.Delete) error {
 	return s.collectContainersAndDo(ctx, func(c *container.Container) error {
-		running, _ := c.IsRunning(ctx)
+		running := c.IsRunning(ctx)
 		if !running || options.RemoveRunning {
 			return c.Remove(ctx, options.RemoveVolume)
 		}

--- a/docker/service/service_create.go
+++ b/docker/service/service_create.go
@@ -155,11 +155,7 @@ func addIpc(config *containertypes.HostConfig, service project.Service, containe
 		return nil, fmt.Errorf("Failed to find container for IPC %v", ipc)
 	}
 
-	id, err := containers[0].ID()
-	if err != nil {
-		return nil, err
-	}
-
+	id := containers[0].ID()
 	config.IpcMode = containertypes.IpcMode("container:" + id)
 	return config, nil
 }
@@ -169,11 +165,7 @@ func addNetNs(config *containertypes.HostConfig, service project.Service, contai
 		return nil, fmt.Errorf("Failed to find container for networks ns %v", networkMode)
 	}
 
-	id, err := containers[0].ID()
-	if err != nil {
-		return nil, err
-	}
-
+	id := containers[0].ID()
 	config.NetworkMode = containertypes.NetworkMode("container:" + id)
 	return config, nil
 }

--- a/project/container.go
+++ b/project/container.go
@@ -6,8 +6,8 @@ import (
 
 // Container defines what a libcompose container provides.
 type Container interface {
-	ID() (string, error)
+	ID() string
 	Name() string
 	Port(ctx context.Context, port string) (string, error)
-	IsRunning(ctx context.Context) (bool, error)
+	IsRunning(ctx context.Context) bool
 }

--- a/project/project_containers.go
+++ b/project/project_containers.go
@@ -5,7 +5,6 @@ import (
 
 	"golang.org/x/net/context"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libcompose/project/events"
 )
 
@@ -21,10 +20,7 @@ func (p *Project) Containers(ctx context.Context, filter Filter, services ...str
 			}
 
 			for _, container := range serviceContainers {
-				running, innerErr := container.IsRunning(ctx)
-				if innerErr != nil {
-					log.Error(innerErr)
-				}
+				running := container.IsRunning(ctx)
 				switch filter.State {
 				case Running:
 					if !running {
@@ -40,10 +36,7 @@ func (p *Project) Containers(ctx context.Context, filter Filter, services ...str
 					// Invalid state filter
 					return fmt.Errorf("Invalid container filter: %s", filter.State)
 				}
-				containerID, innerErr := container.ID()
-				if innerErr != nil {
-					log.Error(innerErr)
-				}
+				containerID := container.ID()
 				containers = append(containers, containerID)
 			}
 			return nil


### PR DESCRIPTION
… for containers. It wasn't needed anymore 🐯.

It also introduces a `container.ShortID()` method 👼.

/cc @joshwget 

🐸

Signed-off-by: Vincent Demeester vincent@sbr.pm
