### PR TITLE
Revert "Remove ctx.Context field from Service struct."

### DIFF
--- a/docker/service/convert.go
+++ b/docker/service/convert.go
@@ -17,6 +17,7 @@ import (
 	composecontainer "github.com/docker/libcompose/docker/container"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/utils"
+	// "github.com/docker/libcompose/yaml"
 )
 
 // ConfigWrapper wraps Config, HostConfig and NetworkingConfig for a container.

--- a/docker/service/service.go
+++ b/docker/service/service.go
@@ -22,7 +22,6 @@ import (
 	"github.com/docker/libcompose/docker/ctx"
 	"github.com/docker/libcompose/docker/image"
 	"github.com/docker/libcompose/labels"
-	"github.com/docker/libcompose/logger"
 	"github.com/docker/libcompose/project"
 	"github.com/docker/libcompose/project/events"
 	"github.com/docker/libcompose/project/options"
@@ -37,8 +36,10 @@ type Service struct {
 	project       *project.Project
 	serviceConfig *config.ServiceConfig
 	clientFactory composeclient.Factory
-	loggerFactory logger.Factory
 	authLookup    auth.Lookup
+
+	// FIXME(vdemeester) remove this at some point
+	context *ctx.Context
 }
 
 // NewService creates a service
@@ -49,7 +50,7 @@ func NewService(name string, serviceConfig *config.ServiceConfig, context *ctx.C
 		serviceConfig: serviceConfig,
 		clientFactory: context.ClientFactory,
 		authLookup:    context.AuthLookup,
-		loggerFactory: context.LoggerFactory,
+		context:       context,
 	}
 }
 
@@ -198,7 +199,7 @@ func (s *Service) build(ctx context.Context, buildOptions options.Build) error {
 		NoCache:          buildOptions.NoCache,
 		ForceRemove:      buildOptions.ForceRemove,
 		Pull:             buildOptions.Pull,
-		LoggerFactory:    s.loggerFactory,
+		LoggerFactory:    s.context.LoggerFactory,
 	}
 	return builder.Build(ctx, s.imageName())
 }
@@ -584,7 +585,7 @@ func (s *Service) Log(ctx context.Context, follow bool) error {
 		if s.Config().ContainerName != "" {
 			name = s.Config().ContainerName
 		}
-		l := s.loggerFactory.CreateContainerLogger(name)
+		l := s.context.LoggerFactory.CreateContainerLogger(name)
 		return c.Log(ctx, l, follow)
 	})
 }


### PR DESCRIPTION
Reverts docker/libcompose#368

Looks like I merged this before CI kicked in and now it's breaking the build on master. If the fix was straightforward I would have just done that, but it doesn't look like it is.

Signed-off-by: Josh Curl <josh@curl.me>