### PR TITLE
Add default project lookup values

### DIFF
--- a/docker/project.go
+++ b/docker/project.go
@@ -1,9 +1,6 @@
 package docker
 
 import (
-	"os"
-	"path/filepath"
-
 	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
@@ -17,31 +14,11 @@ import (
 	"github.com/docker/libcompose/docker/service"
 	"github.com/docker/libcompose/docker/volume"
 	"github.com/docker/libcompose/labels"
-	"github.com/docker/libcompose/lookup"
 	"github.com/docker/libcompose/project"
 )
 
 // NewProject creates a Project with the specified context.
 func NewProject(context *ctx.Context, parseOptions *config.ParseOptions) (project.APIProject, error) {
-	if context.ResourceLookup == nil {
-		context.ResourceLookup = &lookup.FileResourceLookup{}
-	}
-
-	if context.EnvironmentLookup == nil {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return nil, err
-		}
-		context.EnvironmentLookup = &lookup.ComposableEnvLookup{
-			Lookups: []config.EnvironmentLookup{
-				&lookup.EnvfileLookup{
-					Path: filepath.Join(cwd, ".env"),
-				},
-				&lookup.OsEnvLookup{},
-			},
-		}
-	}
-
 	if context.AuthLookup == nil {
 		context.AuthLookup = auth.NewConfigLookup(context.ConfigFile)
 	}

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -110,6 +110,19 @@ func TestParseWithGoodContent(t *testing.T) {
 	}
 }
 
+func TestParseWithDefaultEnvironmentLookup(t *testing.T) {
+	p := NewProject(&Context{
+		ComposeBytes: [][]byte{
+			[]byte("not-garbage:\n  image: foo:${version}"),
+		},
+	}, nil, nil)
+
+	err := p.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 type TestEnvironmentLookup struct {
 }
 


### PR DESCRIPTION
Fix issue #372 

+ Both `project` and `docker` packages’ NewProject functions will have default values of:
1. context.ResourceLookup
2. context.EnvironmentLookup

+ Unit test for Default EnvironmentLookup in project.NewProject

Signed-off-by: Weiteng Huang weiteng.huang@gmail.com; weiteng.huang@concur.com