### PR TITLE
Adding GetServiceConfig to project interface

### DIFF
--- a/project/interface.go
+++ b/project/interface.go
@@ -39,6 +39,8 @@ type APIProject interface {
 	AddConfig(name string, config *config.ServiceConfig) error
 	Load(bytes []byte) error
 	Containers(ctx context.Context, filter Filter, services ...string) ([]string, error)
+
+	GetServiceConfig(service string) (*config.ServiceConfig, bool)
 }
 
 // Filter holds filter element to filter containers

--- a/project/project.go
+++ b/project/project.go
@@ -98,7 +98,7 @@ func (p *Project) Parse() error {
 // CreateService creates a service with the specified name based. If there
 // is no config in the project for this service, it will return an error.
 func (p *Project) CreateService(name string) (Service, error) {
-	existing, ok := p.ServiceConfigs.Get(name)
+	existing, ok := p.GetServiceConfig(name)
 	if !ok {
 		return nil, fmt.Errorf("Failed to find service: %s", name)
 	}
@@ -502,6 +502,12 @@ func (p *Project) Notify(eventType events.EventType, serviceName string, data ma
 	for _, l := range p.listeners {
 		l <- event
 	}
+}
+
+// GetServiceConfig looks up a service config for a given service name, returning the ServiceConfig
+// object and a bool flag indicating whether it was found
+func (p *Project) GetServiceConfig(name string) (*config.ServiceConfig, bool) {
+	return p.ServiceConfigs.Get(name)
 }
 
 // IsNamedVolume returns whether the specified volume (string) is a named volume or not.

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -80,6 +80,32 @@ func TestTwoCall(t *testing.T) {
 	}
 }
 
+func TestGetServiceConfig(t *testing.T) {
+
+	p := NewProject(&Context{}, nil, nil)
+	p.ServiceConfigs = config.NewServiceConfigs()
+	fooService := &config.ServiceConfig{}
+	p.ServiceConfigs.Add("foo", fooService)
+
+	config, ok := p.GetServiceConfig("foo")
+	if !ok {
+		t.Fatal("Foo service not found")
+	}
+
+	if config != fooService {
+		t.Fatal("Incorrect Service Config returned")
+	}
+
+	config, ok = p.GetServiceConfig("unknown")
+	if ok {
+		t.Fatal("Found service incorrectly")
+	}
+
+	if config != nil {
+		t.Fatal("Incorrect Service Config returned")
+	}
+}
+
 func TestParseWithBadContent(t *testing.T) {
 	p := NewProject(&Context{
 		ComposeBytes: [][]byte{


### PR DESCRIPTION
This change allows an APIProject type to return service configs for by name which
can be viewed and edited by the caller.

Solves #377 