### PR TITLE
Adding ServiceConfigs function to get dependent services

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -1,9 +1,14 @@
 package config
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/docker/libcompose/yaml"
+)
+
+const (
+	servicePrefix = "service:"
 )
 
 // EnvironmentLookup defines methods to provides environment variable loading.
@@ -233,6 +238,62 @@ func (c *ServiceConfigs) All() map[string]*ServiceConfig {
 	return c.m
 }
 
+// DependentServices returns a complete list of services needed to start the specified
+// service, including the passed service
+func (c *ServiceConfigs) DependentServices(name string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	serviceSet := map[string]bool{}
+
+	c.addDependentServices(name, serviceSet)
+
+	keys := make([]string, len(serviceSet))
+	i := 0
+	for k := range serviceSet {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
+func (c *ServiceConfigs) addDependentServices(name string, dependencies map[string]bool) {
+	config, ok := c.Get(name)
+	if ok {
+		dependencies[name] = true
+		for _, l := range config.Links {
+			linkServiceName := serviceFromColonString(l)
+			_, ok := dependencies[linkServiceName]
+			if !ok {
+				c.addDependentServices(linkServiceName, dependencies)
+			}
+		}
+
+		for _, v := range config.VolumesFrom {
+			volumeServiceName := serviceFromColonString(v)
+			_, ok := dependencies[volumeServiceName]
+			if !ok {
+				c.addDependentServices(volumeServiceName, dependencies)
+			}
+		}
+
+		for _, s := range config.DependsOn {
+			_, ok := dependencies[s]
+			if !ok {
+				c.addDependentServices(s, dependencies)
+			}
+		}
+
+		if strings.HasPrefix(config.NetworkMode, servicePrefix) {
+			networkService := strings.TrimPrefix(config.NetworkMode, servicePrefix)
+			_, ok := dependencies[networkService]
+			if !ok {
+				c.addDependentServices(networkService, dependencies)
+			}
+		}
+	}
+}
+
 // RawService is represent a Service in map form unparsed
 type RawService map[string]interface{}
 
@@ -245,4 +306,9 @@ type ParseOptions struct {
 	Validate    bool
 	Preprocess  func(RawServiceMap) (RawServiceMap, error)
 	Postprocess func(map[string]*ServiceConfig) (map[string]*ServiceConfig, error)
+}
+
+func serviceFromColonString(colonString string) string {
+	parts := strings.SplitN(colonString, ":", 2)
+	return parts[len(parts)-1]
 }

--- a/config/types_test.go
+++ b/config/types_test.go
@@ -1,0 +1,138 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDependentServices(t *testing.T) {
+	serviceConfigs := NewServiceConfigs()
+	serviceConfigs.Add("serviceA", &ServiceConfig{})
+	serviceConfigs.Add("serviceB", &ServiceConfig{
+		Links: []string{"serviceA"},
+	})
+
+	serviceConfigs.Add("serviceC", &ServiceConfig{
+		VolumesFrom: []string{"serviceB"},
+	})
+
+	serviceConfigs.Add("serviceD", &ServiceConfig{
+		VolumesFrom: []string{"serviceB"},
+		DependsOn:   []string{"serviceC"},
+	})
+
+	serviceConfigs.Add("serviceE", &ServiceConfig{
+		NetworkMode: "service:serviceA",
+	})
+
+	serviceADeps := serviceConfigs.DependentServices("serviceA")
+	assert.Equal(t, true, containsString(serviceADeps, "serviceA"))
+	assert.Equal(t, false, containsString(serviceADeps, "serviceB"))
+	assert.Equal(t, false, containsString(serviceADeps, "serviceC"))
+	assert.Equal(t, false, containsString(serviceADeps, "serviceD"))
+	assert.Equal(t, false, containsString(serviceADeps, "serviceE"))
+	assert.Equal(t, 1, len(serviceADeps))
+
+	serviceBDeps := serviceConfigs.DependentServices("serviceB")
+	assert.Equal(t, true, containsString(serviceBDeps, "serviceA"))
+	assert.Equal(t, true, containsString(serviceBDeps, "serviceB"))
+	assert.Equal(t, false, containsString(serviceBDeps, "serviceC"))
+	assert.Equal(t, false, containsString(serviceBDeps, "serviceD"))
+	assert.Equal(t, false, containsString(serviceBDeps, "serviceE"))
+	assert.Equal(t, 2, len(serviceBDeps))
+
+	serviceCDeps := serviceConfigs.DependentServices("serviceC")
+	assert.Equal(t, true, containsString(serviceCDeps, "serviceA"))
+	assert.Equal(t, true, containsString(serviceCDeps, "serviceB"))
+	assert.Equal(t, true, containsString(serviceCDeps, "serviceC"))
+	assert.Equal(t, false, containsString(serviceCDeps, "serviceD"))
+	assert.Equal(t, false, containsString(serviceCDeps, "serviceE"))
+	assert.Equal(t, 3, len(serviceCDeps))
+
+	serviceDDeps := serviceConfigs.DependentServices("serviceD")
+	assert.Equal(t, true, containsString(serviceDDeps, "serviceA"))
+	assert.Equal(t, true, containsString(serviceDDeps, "serviceB"))
+	assert.Equal(t, true, containsString(serviceDDeps, "serviceC"))
+	assert.Equal(t, true, containsString(serviceDDeps, "serviceD"))
+	assert.Equal(t, false, containsString(serviceDDeps, "serviceE"))
+	assert.Equal(t, 4, len(serviceDDeps))
+
+	serviceEDeps := serviceConfigs.DependentServices("serviceE")
+	assert.Equal(t, true, containsString(serviceEDeps, "serviceA"))
+	assert.Equal(t, false, containsString(serviceEDeps, "serviceB"))
+	assert.Equal(t, false, containsString(serviceEDeps, "serviceC"))
+	assert.Equal(t, false, containsString(serviceEDeps, "serviceD"))
+	assert.Equal(t, true, containsString(serviceEDeps, "serviceE"))
+	assert.Equal(t, 2, len(serviceEDeps))
+}
+
+func TestDependentServicesInvalid(t *testing.T) {
+	serviceConfigs := NewServiceConfigs()
+	serviceConfigs.Add("serviceA", &ServiceConfig{})
+	serviceConfigs.Add("serviceB", &ServiceConfig{
+		Links: []string{"foobar"},
+	})
+
+	serviceADeps := serviceConfigs.DependentServices("serviceA")
+	assert.Equal(t, true, containsString(serviceADeps, "serviceA"))
+	assert.Equal(t, false, containsString(serviceADeps, "serviceB"))
+	assert.Equal(t, false, containsString(serviceADeps, "foobar"))
+	assert.Equal(t, 1, len(serviceADeps))
+
+	serviceBDeps := serviceConfigs.DependentServices("serviceB")
+	assert.Equal(t, false, containsString(serviceBDeps, "serviceA"))
+	assert.Equal(t, true, containsString(serviceBDeps, "serviceB"))
+	assert.Equal(t, false, containsString(serviceBDeps, "foobar"))
+	assert.Equal(t, 1, len(serviceBDeps))
+}
+
+func TestDependentServicesDuplicate(t *testing.T) {
+	serviceConfigs := NewServiceConfigs()
+	serviceConfigs.Add("serviceA", &ServiceConfig{})
+	serviceConfigs.Add("serviceB", &ServiceConfig{
+		Links: []string{"serviceA"},
+	})
+	serviceConfigs.Add("serviceC", &ServiceConfig{
+		Links:       []string{"serviceA"},
+		VolumesFrom: []string{"serviceA"},
+		DependsOn:   []string{"serviceB"},
+	})
+
+	serviceCDeps := serviceConfigs.DependentServices("serviceC")
+	assert.Equal(t, true, containsString(serviceCDeps, "serviceA"))
+	assert.Equal(t, true, containsString(serviceCDeps, "serviceB"))
+	assert.Equal(t, true, containsString(serviceCDeps, "serviceC"))
+	assert.Equal(t, 3, len(serviceCDeps))
+}
+
+func TestDependentServicesLoop(t *testing.T) {
+	// Loops are invalid configuration, however its good to know
+	// the code wont loop
+	serviceConfigs := NewServiceConfigs()
+	serviceConfigs.Add("serviceA", &ServiceConfig{
+		Links: []string{"serviceB"},
+	})
+	serviceConfigs.Add("serviceB", &ServiceConfig{
+		Links: []string{"serviceA"},
+	})
+
+	serviceADeps := serviceConfigs.DependentServices("serviceA")
+	assert.Equal(t, true, containsString(serviceADeps, "serviceA"))
+	assert.Equal(t, true, containsString(serviceADeps, "serviceB"))
+	assert.Equal(t, 2, len(serviceADeps))
+
+	serviceBDeps := serviceConfigs.DependentServices("serviceB")
+	assert.Equal(t, true, containsString(serviceBDeps, "serviceA"))
+	assert.Equal(t, true, containsString(serviceBDeps, "serviceB"))
+	assert.Equal(t, 2, len(serviceBDeps))
+}
+
+func containsString(set []string, str string) bool {
+	for _, s := range set {
+		if str == s {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This change adds in a function to config/ServiceConfigs to provide back a list of dependent services required to start a specified service, including the passed service. This is recursively generated based on the docker/compose functionality here: https://github.com/docker/compose/blob/acfe100686fd95d524ff102c0b5fccff0bc79d8c/compose/service.py#L519

This can be used to translate a service name into a service array which can be passed directly to a compose action.

e.g.

```
app:
  build: ./
  links:
   - db
db:
  image: postgres
test:
  build: ./
  dockerfile_path: Dockerfile.test
```

```
 services := serviceConfig.GetDependentServices("app") //returns ["app", "db"]
 err = project.Up(context.Background(), options.Up{}, services...)
```

In a later PR we can bake this change in by default and have actions automatically determine dependencies