### PR TITLE
Adding event generator using go-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ $ go generate
 $ go build -o libcompose ./cli/main
 ```
 
+### Generating Events
+
+Event structs are generated from stub json definitions. Any time an Event struct needs to be updated, the go file should not be updated, but rather the json document with the fields and types. In order to update the struct definitions run `make build` or `make generate`, which will use gojson to update the structs.
 
 ## Running
 

--- a/events/test.json
+++ b/events/test.json
@@ -1,0 +1,4 @@
+{
+  "service_name": "",
+  "text": ""
+}

--- a/project/events/test.go
+++ b/project/events/test.go
@@ -1,0 +1,6 @@
+package events
+
+type Test struct {
+	ServiceName string `json:"service_name"`
+	Text        string `json:"text"`
+}

--- a/script/generate-events
+++ b/script/generate-events
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+FILES=events/*.json
+
+go get github.com/ChimeraCoder/gojson/gojson
+
+for f in $FILES
+do
+  echo "Generating event for $f..."
+  EVENT_FILENAME=`basename ${f}`
+  EVENT_NAME="${EVENT_FILENAME%%.*}"
+  STRUCT_NAME=`echo "$EVENT_NAME" | sed -r 's/(^|_)([a-z])/\U\2/g'`
+  gojson -input $f -o project/events/${EVENT_NAME}.go -pkg events -name "$STRUCT_NAME"
+done

--- a/script/make.sh
+++ b/script/make.sh
@@ -10,6 +10,7 @@ DEFAULT_BUNDLES=(
     validate-git-marks
     validate-lint
     validate-vet
+    generate-events
     binary
 
     test-unit


### PR DESCRIPTION
This will automatically generate new event structs every time `make build`
or `make generate-events` is run.

This includes a test event struct which can be removed once we have actual events to generate
