### PR TITLE
Create config separately

### DIFF
--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -406,15 +406,17 @@ services:
 	}
 }
 
-func TestParseNetworks(t *testing.T) {
-	composeFile := []byte(`networks:
+func TestNilNetworks(t *testing.T) {
+	composeFile := []byte(`
+version: '2'
+networks:
   public:`)
 
-	networkConfigs, err := ParseNetworks(composeFile)
+	config, err := CreateConfig(composeFile)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for key, networkConfig := range networkConfigs {
+	for key, networkConfig := range config.Networks {
 		if networkConfig == nil {
 			t.Fatalf("networkConfig %s was nil, shouldn't be", key)
 		}

--- a/config/merge_v1.go
+++ b/config/merge_v1.go
@@ -6,16 +6,10 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libcompose/utils"
-	"gopkg.in/yaml.v2"
 )
 
 // MergeServicesV1 merges a v1 compose file into an existing set of service configs
-func MergeServicesV1(existingServices *ServiceConfigs, environmentLookup EnvironmentLookup, resourceLookup ResourceLookup, file string, bytes []byte, options *ParseOptions) (map[string]*ServiceConfigV1, error) {
-	datas := make(RawServiceMap)
-	if err := yaml.Unmarshal(bytes, &datas); err != nil {
-		return nil, err
-	}
-
+func MergeServicesV1(existingServices *ServiceConfigs, environmentLookup EnvironmentLookup, resourceLookup ResourceLookup, file string, datas RawServiceMap, options *ParseOptions) (map[string]*ServiceConfigV1, error) {
 	if options.Interpolate {
 		if err := Interpolate(environmentLookup, &datas); err != nil {
 			return nil, err
@@ -116,10 +110,11 @@ func parseV1(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup,
 			return nil, err
 		}
 
-		var baseRawServices RawServiceMap
-		if err := yaml.Unmarshal(bytes, &baseRawServices); err != nil {
+		config, err := CreateConfig(bytes)
+		if err != nil {
 			return nil, err
 		}
+		baseRawServices := config.Services
 
 		if options.Interpolate {
 			err = Interpolate(environmentLookup, &baseRawServices)


### PR DESCRIPTION
This PR separates the creation of config from `Merge` function and puts it in `CreateConfig`. This is because unmarshmaling of bytes to config or RawServiceMap is required by `Merge`, `MergeServicesV1`, `MergeServicesV2` and `ParseV2`, and is currently done in `Merge`. The same code of config creation from `Merge` can be used in other places, but `Merge` does many other things so it can't be called from all functions. These functions that require config creations can directly call the function `CreateConfig` for that.  Based on the config.Version, for version 2, `CreateConfig` checks that no values in `config.Networks` and `config.Volumes` are `nil`. So the functions `ParseNetworks` and `ParseVolumes` can be removed. If version is not 2, `CreateConfig` creates a `RawServiceMap` and assigns to `config.Services`. 