### PR TITLE
Call Project.initialize before Project.Create

### DIFF
--- a/project/project_create.go
+++ b/project/project_create.go
@@ -14,6 +14,9 @@ func (p *Project) Create(ctx context.Context, options options.Create, services .
 	if options.NoRecreate && options.ForceRecreate {
 		return fmt.Errorf("no-recreate and force-recreate cannot be combined")
 	}
+	if err := p.initialize(ctx); err != nil {
+		return err
+	}
 	return p.perform(events.ProjectCreateStart, events.ProjectCreateDone, services, wrapperAction(func(wrapper *serviceWrapper, wrappers map[string]*serviceWrapper) {
 		wrapper.Do(wrappers, events.ServiceCreateStart, events.ServiceCreate, func(service Service) error {
 			return service.Create(ctx, options)


### PR DESCRIPTION
Volumes and networks should be initialized when calling create.

Signed-off-by: Josh Curl <josh@curl.me>