### PR TITLE
Update dependency path for docker/docker/pkg/plugingetter

### DIFF
--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -9,7 +9,7 @@ clone git github.com/Sirupsen/logrus v0.10.0
 clone git github.com/urfave/cli v1.18.0
 clone git github.com/docker/distribution 77b9d2997abcded79a5314970fe69a44c93c25fb
 clone git github.com/vbatts/tar-split v0.9.11
-clone git github.com/docker/docker 601004e1a714d77d3a43e957b8ae8adbc867b280
+clone git github.com/docker/docker 8658748ef716e43a5f6d834825d818012ed6e2c4 
 clone git github.com/docker/go-units f2145db703495b2e525c59662db69a7344b00bb8
 clone git github.com/docker/go-connections 988efe982fdecb46f01d53465878ff1f2ff411ce
 clone git github.com/flynn/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff

--- a/hack/vendor.sh
+++ b/hack/vendor.sh
@@ -9,7 +9,7 @@ clone git github.com/Sirupsen/logrus v0.10.0
 clone git github.com/urfave/cli v1.18.0
 clone git github.com/docker/distribution 77b9d2997abcded79a5314970fe69a44c93c25fb
 clone git github.com/vbatts/tar-split v0.9.11
-clone git github.com/docker/docker 8658748ef716e43a5f6d834825d818012ed6e2c4 
+clone git github.com/docker/docker 8658748ef716e43a5f6d834825d818012ed6e2c4
 clone git github.com/docker/go-units f2145db703495b2e525c59662db69a7344b00bb8
 clone git github.com/docker/go-connections 988efe982fdecb46f01d53465878ff1f2ff411ce
 clone git github.com/flynn/go-shlex 3f9db97f856818214da2e1057f8ad84803971cff

--- a/test/nop.go
+++ b/test/nop.go
@@ -196,6 +196,11 @@ func (client *NopClient) ContainerWait(ctx context.Context, container string) (i
 	return 0, errNoEngine
 }
 
+// ContainersPrune requests the daemon to delete unused data
+func (client *NopClient) ContainersPrune(ctx context.Context, cfg types.ContainersPruneConfig) (types.ContainersPruneReport, error) {
+	return types.ContainersPruneReport{}, errNoEngine
+}
+
 // CopyFromContainer gets the content from the container and returns it as a Reader to manipulate it in the host
 func (client *NopClient) CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error) {
 	return nil, types.ContainerPathStat{}, errNoEngine
@@ -204,6 +209,11 @@ func (client *NopClient) CopyFromContainer(ctx context.Context, container, srcPa
 // CopyToContainer copies content into the container filesystem
 func (client *NopClient) CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error {
 	return errNoEngine
+}
+
+// DiskUsage requests the current data usage from the daemon
+func (client *NopClient) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
+	return types.DiskUsage{}, errNoEngine
 }
 
 // Events returns a stream of events in the daemon in a ReadCloser
@@ -274,6 +284,11 @@ func (client *NopClient) ImageSave(ctx context.Context, images []string) (io.Rea
 // ImageTag tags an image in the docker host
 func (client *NopClient) ImageTag(ctx context.Context, image, ref string) error {
 	return errNoEngine
+}
+
+// ImagesPrune requests the daemon to delete unused data
+func (client *NopClient) ImagesPrune(ctx context.Context, cfg types.ImagesPruneConfig) (types.ImagesPruneReport, error) {
+	return types.ImagesPruneReport{}, errNoEngine
 }
 
 // Info returns information about the docker server
@@ -353,4 +368,9 @@ func (client *NopClient) VolumeList(ctx context.Context, filter filters.Args) (t
 // VolumeRemove removes a volume from the docker host
 func (client *NopClient) VolumeRemove(ctx context.Context, volumeID string, force bool) error {
 	return errNoEngine
+}
+
+// VolumesPrune requests the daemon to delete unused data
+func (client *NopClient) VolumesPrune(ctx context.Context, cfg types.VolumesPruneConfig) (types.VolumesPruneReport, error) {
+	return types.VolumesPruneReport{}, errNoEngine
 }

--- a/vendor/github.com/docker/docker/api/types/client.go
+++ b/vendor/github.com/docker/docker/api/types/client.go
@@ -153,7 +153,8 @@ type ImageBuildOptions struct {
 	Squash bool
 	// CacheFrom specifies images that are used for matching cache. Images
 	// specified here do not need to have a valid parent chain to match cache.
-	CacheFrom []string
+	CacheFrom   []string
+	SecurityOpt []string
 }
 
 // ImageBuildResponse holds information

--- a/vendor/github.com/docker/docker/api/types/types.go
+++ b/vendor/github.com/docker/docker/api/types/types.go
@@ -95,8 +95,10 @@ type Image struct {
 	RepoDigests []string
 	Created     int64
 	Size        int64
+	SharedSize  int64
 	VirtualSize int64
 	Labels      map[string]string
+	Containers  int64
 }
 
 // GraphDriverData returns Image's graph driver config info
@@ -129,6 +131,7 @@ type ImageInspect struct {
 	Config          *container.Config
 	Architecture    string
 	Os              string
+	OsVersion       string `json:",omitempty"`
 	Size            int64
 	VirtualSize     int64
 	GraphDriver     GraphDriverData
@@ -430,6 +433,12 @@ type MountPoint struct {
 	Propagation mount.Propagation
 }
 
+// VolumeUsageData holds information regarding the volume usage
+type VolumeUsageData struct {
+	Size     int64 // Size holds how much disk space is used by the (local driver only). Sets to -1 if not provided.
+	RefCount int   // RefCount holds the number of containers having this volume attached to them. Sets to -1 if not provided.
+}
+
 // Volume represents the configuration of a volume for the remote API
 type Volume struct {
 	Name       string                 // Name is the name of the volume
@@ -438,6 +447,7 @@ type Volume struct {
 	Status     map[string]interface{} `json:",omitempty"` // Status provides low-level status information about the volume
 	Labels     map[string]string      // Labels is metadata specific to the volume
 	Scope      string                 // Scope describes the level at which the volume exists (e.g. `global` for cluster-wide or `local` for machine level)
+	UsageData  *VolumeUsageData       `json:",omitempty"`
 }
 
 // VolumesListResponse contains the response for the remote API:
@@ -525,4 +535,50 @@ type Checkpoint struct {
 type Runtime struct {
 	Path string   `json:"path"`
 	Args []string `json:"runtimeArgs,omitempty"`
+}
+
+// DiskUsage contains response of Remote API:
+// GET "/system/df"
+type DiskUsage struct {
+	LayersSize int64
+	Images     []*Image
+	Containers []*Container
+	Volumes    []*Volume
+}
+
+// ImagesPruneConfig contains the configuration for Remote API:
+// POST "/images/prune"
+type ImagesPruneConfig struct {
+	DanglingOnly bool
+}
+
+// ContainersPruneConfig contains the configuration for Remote API:
+// POST "/images/prune"
+type ContainersPruneConfig struct {
+}
+
+// VolumesPruneConfig contains the configuration for Remote API:
+// POST "/images/prune"
+type VolumesPruneConfig struct {
+}
+
+// ContainersPruneReport contains the response for Remote API:
+// POST "/containers/prune"
+type ContainersPruneReport struct {
+	ContainersDeleted []string
+	SpaceReclaimed    uint64
+}
+
+// VolumesPruneReport contains the response for Remote API:
+// POST "/volumes/prune"
+type VolumesPruneReport struct {
+	VolumesDeleted []string
+	SpaceReclaimed uint64
+}
+
+// ImagesPruneReport contains the response for Remote API:
+// POST "/images/prune"
+type ImagesPruneReport struct {
+	ImagesDeleted  []ImageDelete
+	SpaceReclaimed uint64
 }

--- a/vendor/github.com/docker/docker/client/README.md
+++ b/vendor/github.com/docker/docker/client/README.md
@@ -1,37 +1,35 @@
-## Client
+## Go client for the Docker Remote API
 
-The client package implements a fully featured http client to interact with the Docker engine. It's modeled after the requirements of the Docker engine CLI, but it can also serve other purposes.
+The `docker` command uses this package to communicate with the daemon. It can also be used by your own Go applications to do anything the command-line interface does – running containers, pulling images, managing swarms, etc.
 
-### Usage
-
-You can use this client package in your applications by creating a new client object. Then use that object to execute operations against the remote server. Follow the example below to see how to list all the containers running in a Docker engine host:
+For example, to list running containers (the equivalent of `docker ps`):
 
 ```go
 package main
 
 import (
-	"fmt"
 	"context"
+	"fmt"
 
-	"github.com/docker/docker/client"
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
 func main() {
-	defaultHeaders := map[string]string{"User-Agent": "engine-api-cli-1.0"}
-	cli, err := client.NewClient("unix:///var/run/docker.sock", "v1.22", nil, defaultHeaders)
+	cli, err := client.NewEnvClient()
 	if err != nil {
 		panic(err)
 	}
 
-	options := types.ContainerListOptions{All: true}
-	containers, err := cli.ContainerList(context.Background(), options)
+	containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
 	if err != nil {
 		panic(err)
 	}
 
-	for _, c := range containers {
-		fmt.Println(c.ID)
+	for _, container := range containers {
+		fmt.Printf("%s %s\n", container.ID[:10], container.Image)
 	}
 }
 ```
+
+[Full documentation is available on GoDoc.](https://godoc.org/github.com/docker/docker/client)

--- a/vendor/github.com/docker/docker/client/client.go
+++ b/vendor/github.com/docker/docker/client/client.go
@@ -1,3 +1,48 @@
+/*
+Package client is a Go client for the Docker Remote API.
+
+The "docker" command uses this package to communicate with the daemon. It can also
+be used by your own Go applications to do anything the command-line interface does
+– running containers, pulling images, managing swarms, etc.
+
+For more information about the Remote API, see the documentation:
+https://docs.docker.com/engine/reference/api/docker_remote_api/
+
+Usage
+
+You use the library by creating a client object and calling methods on it. The
+client can be created either from environment variables with NewEnvClient, or
+configured manually with NewClient.
+
+For example, to list running containers (the equivalent of "docker ps"):
+
+	package main
+
+	import (
+		"context"
+		"fmt"
+
+		"github.com/docker/docker/api/types"
+		"github.com/docker/docker/client"
+	)
+
+	func main() {
+		cli, err := client.NewEnvClient()
+		if err != nil {
+			panic(err)
+		}
+
+		containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{})
+		if err != nil {
+			panic(err)
+		}
+
+		for _, container := range containers {
+			fmt.Printf("%s %s\n", container.ID[:10], container.Image)
+		}
+	}
+
+*/
 package client
 
 import (
@@ -18,6 +63,8 @@ const DefaultVersion string = "1.23"
 // Client is the API client that performs all operations
 // against a docker server.
 type Client struct {
+	// scheme sets the scheme for the client
+	scheme string
 	// host holds the server address to connect to
 	host string
 	// proto holds the client protocol i.e. unix.
@@ -86,18 +133,31 @@ func NewClient(host string, version string, client *http.Client, httpHeaders map
 		return nil, err
 	}
 
-	if client == nil {
-		client = &http.Client{}
-	}
-
-	if client.Transport == nil {
-		// setup the transport, if not already present
+	if client != nil {
+		if _, ok := client.Transport.(*http.Transport); !ok {
+			return nil, fmt.Errorf("unable to verify TLS configuration, invalid transport %v", client.Transport)
+		}
+	} else {
 		transport := new(http.Transport)
 		sockets.ConfigureTransport(transport, proto, addr)
-		client.Transport = transport
+		client = &http.Client{
+			Transport: transport,
+		}
+	}
+
+	scheme := "http"
+	tlsConfig := resolveTLSConfig(client.Transport)
+	if tlsConfig != nil {
+		// TODO(stevvooe): This isn't really the right way to write clients in Go.
+		// `NewClient` should probably only take an `*http.Client` and work from there.
+		// Unfortunately, the model of having a host-ish/url-thingy as the connection
+		// string has us confusing protocol and transport layers. We continue doing
+		// this to avoid breaking existing clients but this should be addressed.
+		scheme = "https"
 	}
 
 	return &Client{
+		scheme:            scheme,
 		host:              host,
 		proto:             proto,
 		addr:              addr,

--- a/vendor/github.com/docker/docker/client/container_prune.go
+++ b/vendor/github.com/docker/docker/client/container_prune.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"golang.org/x/net/context"
+)
+
+// ContainersPrune requests the daemon to delete unused data
+func (cli *Client) ContainersPrune(ctx context.Context, cfg types.ContainersPruneConfig) (types.ContainersPruneReport, error) {
+	var report types.ContainersPruneReport
+
+	serverResp, err := cli.post(ctx, "/containers/prune", nil, cfg, nil)
+	if err != nil {
+		return report, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+		return report, fmt.Errorf("Error retrieving disk usage: %v", err)
+	}
+
+	return report, nil
+}

--- a/vendor/github.com/docker/docker/client/disk_usage.go
+++ b/vendor/github.com/docker/docker/client/disk_usage.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"golang.org/x/net/context"
+)
+
+// DiskUsage requests the current data usage from the daemon
+func (cli *Client) DiskUsage(ctx context.Context) (types.DiskUsage, error) {
+	var du types.DiskUsage
+
+	serverResp, err := cli.get(ctx, "/system/df", nil, nil)
+	if err != nil {
+		return du, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	if err := json.NewDecoder(serverResp.body).Decode(&du); err != nil {
+		return du, fmt.Errorf("Error retrieving disk usage: %v", err)
+	}
+
+	return du, nil
+}

--- a/vendor/github.com/docker/docker/client/errors.go
+++ b/vendor/github.com/docker/docker/client/errors.go
@@ -30,7 +30,7 @@ type imageNotFoundError struct {
 	imageID string
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e imageNotFoundError) NotFound() bool {
 	return true
 }
@@ -51,7 +51,7 @@ type containerNotFoundError struct {
 	containerID string
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e containerNotFoundError) NotFound() bool {
 	return true
 }
@@ -72,7 +72,7 @@ type networkNotFoundError struct {
 	networkID string
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e networkNotFoundError) NotFound() bool {
 	return true
 }
@@ -93,12 +93,12 @@ type volumeNotFoundError struct {
 	volumeID string
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e volumeNotFoundError) NotFound() bool {
 	return true
 }
 
-// Error returns a string representation of a networkNotFoundError
+// Error returns a string representation of a volumeNotFoundError
 func (e volumeNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such volume: %s", e.volumeID)
 }
@@ -136,7 +136,7 @@ func (e nodeNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such node: %s", e.nodeID)
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e nodeNotFoundError) NotFound() bool {
 	return true
 }
@@ -158,7 +158,7 @@ func (e serviceNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such service: %s", e.serviceID)
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e serviceNotFoundError) NotFound() bool {
 	return true
 }
@@ -180,7 +180,7 @@ func (e taskNotFoundError) Error() string {
 	return fmt.Sprintf("Error: No such task: %s", e.taskID)
 }
 
-// NoFound indicates that this error type is of NotFound
+// NotFound indicates that this error type is of NotFound
 func (e taskNotFoundError) NotFound() bool {
 	return true
 }

--- a/vendor/github.com/docker/docker/client/hijack.go
+++ b/vendor/github.com/docker/docker/client/hijack.go
@@ -47,12 +47,7 @@ func (cli *Client) postHijacked(ctx context.Context, path string, query url.Valu
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "tcp")
 
-	tlsConfig, err := resolveTLSConfig(cli.client.Transport)
-	if err != nil {
-		return types.HijackedResponse{}, err
-	}
-
-	conn, err := dial(cli.proto, cli.addr, tlsConfig)
+	conn, err := dial(cli.proto, cli.addr, resolveTLSConfig(cli.client.Transport))
 	if err != nil {
 		if strings.Contains(err.Error(), "connection refused") {
 			return types.HijackedResponse{}, fmt.Errorf("Cannot connect to the Docker daemon. Is 'docker daemon' running on this host?")

--- a/vendor/github.com/docker/docker/client/image_build.go
+++ b/vendor/github.com/docker/docker/client/image_build.go
@@ -49,7 +49,8 @@ func (cli *Client) ImageBuild(ctx context.Context, buildContext io.Reader, optio
 
 func imageBuildOptionsToQuery(options types.ImageBuildOptions) (url.Values, error) {
 	query := url.Values{
-		"t": options.Tags,
+		"t":           options.Tags,
+		"securityopt": options.SecurityOpt,
 	}
 	if options.SuppressOutput {
 		query.Set("q", "1")

--- a/vendor/github.com/docker/docker/client/image_prune.go
+++ b/vendor/github.com/docker/docker/client/image_prune.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"golang.org/x/net/context"
+)
+
+// ImagesPrune requests the daemon to delete unused data
+func (cli *Client) ImagesPrune(ctx context.Context, cfg types.ImagesPruneConfig) (types.ImagesPruneReport, error) {
+	var report types.ImagesPruneReport
+
+	serverResp, err := cli.post(ctx, "/images/prune", nil, cfg, nil)
+	if err != nil {
+		return report, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+		return report, fmt.Errorf("Error retrieving disk usage: %v", err)
+	}
+
+	return report, nil
+}

--- a/vendor/github.com/docker/docker/client/interface.go
+++ b/vendor/github.com/docker/docker/client/interface.go
@@ -61,6 +61,7 @@ type ContainerAPIClient interface {
 	ContainerWait(ctx context.Context, container string) (int, error)
 	CopyFromContainer(ctx context.Context, container, srcPath string) (io.ReadCloser, types.ContainerPathStat, error)
 	CopyToContainer(ctx context.Context, container, path string, content io.Reader, options types.CopyToContainerOptions) error
+	ContainersPrune(ctx context.Context, cfg types.ContainersPruneConfig) (types.ContainersPruneReport, error)
 }
 
 // ImageAPIClient defines API client methods for the images
@@ -78,6 +79,7 @@ type ImageAPIClient interface {
 	ImageSearch(ctx context.Context, term string, options types.ImageSearchOptions) ([]registry.SearchResult, error)
 	ImageSave(ctx context.Context, images []string) (io.ReadCloser, error)
 	ImageTag(ctx context.Context, image, ref string) error
+	ImagesPrune(ctx context.Context, cfg types.ImagesPruneConfig) (types.ImagesPruneReport, error)
 }
 
 // NetworkAPIClient defines API client methods for the networks
@@ -124,6 +126,7 @@ type SystemAPIClient interface {
 	Events(ctx context.Context, options types.EventsOptions) (<-chan events.Message, <-chan error)
 	Info(ctx context.Context) (types.Info, error)
 	RegistryLogin(ctx context.Context, auth types.AuthConfig) (types.AuthResponse, error)
+	DiskUsage(ctx context.Context) (types.DiskUsage, error)
 }
 
 // VolumeAPIClient defines API client methods for the volumes
@@ -133,4 +136,5 @@ type VolumeAPIClient interface {
 	VolumeInspectWithRaw(ctx context.Context, volumeID string) (types.Volume, []byte, error)
 	VolumeList(ctx context.Context, filter filters.Args) (types.VolumesListResponse, error)
 	VolumeRemove(ctx context.Context, volumeID string, force bool) error
+	VolumesPrune(ctx context.Context, cfg types.VolumesPruneConfig) (types.VolumesPruneReport, error)
 }

--- a/vendor/github.com/docker/docker/client/transport.go
+++ b/vendor/github.com/docker/docker/client/transport.go
@@ -18,34 +18,11 @@ func (tf transportFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // resolveTLSConfig attempts to resolve the tls configuration from the
 // RoundTripper.
-func resolveTLSConfig(transport http.RoundTripper) (*tls.Config, error) {
+func resolveTLSConfig(transport http.RoundTripper) *tls.Config {
 	switch tr := transport.(type) {
 	case *http.Transport:
-		return tr.TLSClientConfig, nil
-	case transportFunc:
-		return nil, nil // detect this type for testing.
+		return tr.TLSClientConfig
 	default:
-		return nil, errTLSConfigUnavailable
+		return nil
 	}
-}
-
-// resolveScheme detects a tls config on the transport and returns the
-// appropriate http scheme.
-//
-// TODO(stevvooe): This isn't really the right way to write clients in Go.
-// `NewClient` should probably only take an `*http.Client` and work from there.
-// Unfortunately, the model of having a host-ish/url-thingy as the connection
-// string has us confusing protocol and transport layers. We continue doing
-// this to avoid breaking existing clients but this should be addressed.
-func resolveScheme(transport http.RoundTripper) (string, error) {
-	c, err := resolveTLSConfig(transport)
-	if err != nil {
-		return "", err
-	}
-
-	if c != nil {
-		return "https", nil
-	}
-
-	return "http", nil
 }

--- a/vendor/github.com/docker/docker/client/volume_prune.go
+++ b/vendor/github.com/docker/docker/client/volume_prune.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/docker/docker/api/types"
+	"golang.org/x/net/context"
+)
+
+// VolumesPrune requests the daemon to delete unused data
+func (cli *Client) VolumesPrune(ctx context.Context, cfg types.VolumesPruneConfig) (types.VolumesPruneReport, error) {
+	var report types.VolumesPruneReport
+
+	serverResp, err := cli.post(ctx, "/volumes/prune", nil, cfg, nil)
+	if err != nil {
+		return report, err
+	}
+	defer ensureReaderClosed(serverResp)
+
+	if err := json.NewDecoder(serverResp.body).Decode(&report); err != nil {
+		return report, fmt.Errorf("Error retrieving disk usage: %v", err)
+	}
+
+	return report, nil
+}

--- a/vendor/github.com/docker/docker/daemon/graphdriver/driver.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/driver.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
-	"github.com/docker/docker/plugin/getter"
+	"github.com/docker/docker/pkg/plugingetter"
 )
 
 // FsMagic unsigned id of the filesystem in use.
@@ -135,11 +135,11 @@ func Register(name string, initFunc InitFunc) error {
 }
 
 // GetDriver initializes and returns the registered driver
-func GetDriver(name, home string, options []string, uidMaps, gidMaps []idtools.IDMap, plugingetter getter.PluginGetter) (Driver, error) {
+func GetDriver(name, home string, options []string, uidMaps, gidMaps []idtools.IDMap, pg plugingetter.PluginGetter) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
 		return initFunc(filepath.Join(home, name), options, uidMaps, gidMaps)
 	}
-	if pluginDriver, err := lookupPlugin(name, home, options, plugingetter); err == nil {
+	if pluginDriver, err := lookupPlugin(name, home, options, pg); err == nil {
 		return pluginDriver, nil
 	}
 	logrus.Errorf("Failed to GetDriver graph %s %s", name, home)
@@ -156,10 +156,10 @@ func getBuiltinDriver(name, home string, options []string, uidMaps, gidMaps []id
 }
 
 // New creates the driver and initializes it at the specified root.
-func New(root string, name string, options []string, uidMaps, gidMaps []idtools.IDMap, plugingetter getter.PluginGetter) (Driver, error) {
+func New(root string, name string, options []string, uidMaps, gidMaps []idtools.IDMap, pg plugingetter.PluginGetter) (Driver, error) {
 	if name != "" {
 		logrus.Debugf("[graphdriver] trying provided driver: %s", name) // so the logs show specified driver
-		return GetDriver(name, root, options, uidMaps, gidMaps, plugingetter)
+		return GetDriver(name, root, options, uidMaps, gidMaps, pg)
 	}
 
 	// Guess for prior driver

--- a/vendor/github.com/docker/docker/daemon/graphdriver/plugin.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/plugin.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/docker/docker/plugin/getter"
+	"github.com/docker/docker/pkg/plugingetter"
 )
 
 type pluginClient interface {
@@ -18,8 +18,8 @@ type pluginClient interface {
 	SendFile(string, io.Reader, interface{}) error
 }
 
-func lookupPlugin(name, home string, opts []string, pluginGetter getter.PluginGetter) (Driver, error) {
-	pl, err := pluginGetter.Get(name, "GraphDriver", getter.LOOKUP)
+func lookupPlugin(name, home string, opts []string, pg plugingetter.PluginGetter) (Driver, error) {
+	pl, err := pg.Get(name, "GraphDriver", plugingetter.LOOKUP)
 	if err != nil {
 		return nil, fmt.Errorf("Error looking up graphdriver plugin %s: %v", name, err)
 	}

--- a/vendor/github.com/docker/docker/daemon/graphdriver/plugin_unsupported.go
+++ b/vendor/github.com/docker/docker/daemon/graphdriver/plugin_unsupported.go
@@ -2,8 +2,8 @@
 
 package graphdriver
 
-import "github.com/docker/docker/plugin/getter"
+import "github.com/docker/docker/pkg/plugingetter"
 
-func lookupPlugin(name, home string, opts []string, plugingetter getter.PluginGetter) (Driver, error) {
+func lookupPlugin(name, home string, opts []string, pg plugingetter.PluginGetter) (Driver, error) {
 	return nil, ErrNotSupported
 }

--- a/vendor/github.com/docker/docker/layer/layer.go
+++ b/vendor/github.com/docker/docker/layer/layer.go
@@ -170,6 +170,7 @@ type MountInit func(root string) error
 type Store interface {
 	Register(io.Reader, ChainID) (Layer, error)
 	Get(ChainID) (Layer, error)
+	Map() map[ChainID]Layer
 	Release(Layer) ([]Metadata, error)
 
 	CreateRWLayer(id string, parent ChainID, mountLabel string, initFunc MountInit, storageOpt map[string]string) (RWLayer, error)

--- a/vendor/github.com/docker/docker/layer/layer_store.go
+++ b/vendor/github.com/docker/docker/layer/layer_store.go
@@ -13,8 +13,8 @@ import (
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/idtools"
+	"github.com/docker/docker/pkg/plugingetter"
 	"github.com/docker/docker/pkg/stringid"
-	"github.com/docker/docker/plugin/getter"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"
 )
@@ -45,7 +45,7 @@ type StoreOptions struct {
 	GraphDriverOptions        []string
 	UIDMaps                   []idtools.IDMap
 	GIDMaps                   []idtools.IDMap
-	PluginGetter              getter.PluginGetter
+	PluginGetter              plugingetter.PluginGetter
 }
 
 // NewStoreFromOptions creates a new Store instance
@@ -358,6 +358,19 @@ func (ls *layerStore) Get(l ChainID) (Layer, error) {
 	}
 
 	return layer.getReference(), nil
+}
+
+func (ls *layerStore) Map() map[ChainID]Layer {
+	ls.layerL.Lock()
+	defer ls.layerL.Unlock()
+
+	layers := map[ChainID]Layer{}
+
+	for k, v := range ls.layerMap {
+		layers[k] = v
+	}
+
+	return layers
 }
 
 func (ls *layerStore) deleteLayer(layer *roLayer, metadata *Metadata) error {

--- a/vendor/github.com/docker/docker/pkg/archive/archive.go
+++ b/vendor/github.com/docker/docker/pkg/archive/archive.go
@@ -1050,7 +1050,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 		return nil
 	})
 	defer func() {
-		if er := <-errC; err != nil {
+		if er := <-errC; err == nil && er != nil {
 			err = er
 		}
 	}()

--- a/vendor/github.com/docker/docker/pkg/plugingetter/getter.go
+++ b/vendor/github.com/docker/docker/pkg/plugingetter/getter.go
@@ -1,4 +1,4 @@
-package getter
+package plugingetter
 
 import "github.com/docker/docker/pkg/plugins"
 

--- a/vendor/github.com/docker/docker/pkg/term/term_windows.go
+++ b/vendor/github.com/docker/docker/pkg/term/term_windows.go
@@ -71,8 +71,8 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 		}
 	}
 
-	if os.Getenv("ConEmuANSI") == "ON" {
-		// The ConEmu terminal emulates ANSI on output streams well.
+	if os.Getenv("ConEmuANSI") == "ON" || os.Getenv("ConsoleZVersion") != "" {
+		// The ConEmu and ConsoleZ terminals emulate ANSI on output streams well.
 		emulateStdin = true
 		emulateStdout = false
 		emulateStderr = false

--- a/vendor/github.com/docker/docker/runconfig/opts/parse.go
+++ b/vendor/github.com/docker/docker/runconfig/opts/parse.go
@@ -105,6 +105,7 @@ type ContainerOptions struct {
 	autoRemove        bool
 	init              bool
 	initPath          string
+	credentialSpec    string
 
 	Image string
 	Args  []string
@@ -173,6 +174,7 @@ func AddFlags(flags *pflag.FlagSet) *ContainerOptions {
 	flags.BoolVar(&copts.privileged, "privileged", false, "Give extended privileges to this container")
 	flags.Var(&copts.securityOpt, "security-opt", "Security Options")
 	flags.StringVar(&copts.usernsMode, "userns", "", "User namespace to use")
+	flags.StringVar(&copts.credentialSpec, "credentialspec", "", "Credential spec for managed service account (Windows only)")
 
 	// Network and port publishing flag
 	flags.Var(&copts.extraHosts, "add-host", "Add a custom host-to-IP mapping (host:ip)")


### PR DESCRIPTION
`github.com/docker/docker/plugin/getter` now lives at `github.com/docker/docker/pkg/plugingetter`. Updating vendored dependencies to reference the new package name. The outdated package name causes failures in dependency saving/restoration in some cases.