### PR TITLE
Refactor and expose convertKeysToStrings

### DIFF
--- a/config/validation.go
+++ b/config/validation.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/docker/libcompose/utils"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -70,53 +71,20 @@ func getValue(val interface{}, context string) string {
 	return ""
 }
 
-// Converts map[interface{}]interface{} to map[string]interface{} recursively
-// gojsonschema only accepts map[string]interface{}
 func convertServiceMapKeysToStrings(serviceMap RawServiceMap) RawServiceMap {
 	newServiceMap := make(RawServiceMap)
-
 	for k, v := range serviceMap {
 		newServiceMap[k] = convertServiceKeysToStrings(v)
 	}
-
 	return newServiceMap
 }
 
 func convertServiceKeysToStrings(service RawService) RawService {
 	newService := make(RawService)
-
 	for k, v := range service {
-		newService[k] = convertKeysToStrings(v)
+		newService[k] = utils.ConvertKeysToStrings(v)
 	}
-
 	return newService
-}
-
-func convertKeysToStrings(item interface{}) interface{} {
-	switch typedDatas := item.(type) {
-
-	case map[interface{}]interface{}:
-		newMap := make(map[string]interface{})
-
-		for key, value := range typedDatas {
-			stringKey := key.(string)
-			newMap[stringKey] = convertKeysToStrings(value)
-		}
-		return newMap
-
-	case []interface{}:
-		// newArray := make([]interface{}, 0) will cause golint to complain
-		var newArray []interface{}
-		newArray = make([]interface{}, 0)
-
-		for _, value := range typedDatas {
-			newArray = append(newArray, convertKeysToStrings(value))
-		}
-		return newArray
-
-	default:
-		return item
-	}
 }
 
 var dockerConfigHints = map[string]string{

--- a/utils/util.go
+++ b/utils/util.go
@@ -135,3 +135,28 @@ func Merge(coll1, coll2 []string) []string {
 	}
 	return r
 }
+
+// ConvertKeysToStrings converts map[interface{}] to map[string] recursively
+func ConvertKeysToStrings(item interface{}) interface{} {
+	switch typedDatas := item.(type) {
+	case map[string]interface{}:
+		for key, value := range typedDatas {
+			typedDatas[key] = ConvertKeysToStrings(value)
+		}
+		return typedDatas
+	case map[interface{}]interface{}:
+		newMap := make(map[string]interface{})
+		for key, value := range typedDatas {
+			stringKey := key.(string)
+			newMap[stringKey] = ConvertKeysToStrings(value)
+		}
+		return newMap
+	case []interface{}:
+		for i, value := range typedDatas {
+			typedDatas[i] = ConvertKeysToStrings(value)
+		}
+		return typedDatas
+	default:
+		return item
+	}
+}


### PR DESCRIPTION
`convertKeysToStrings` is a really useful function that I use across multiple projects. It's also pretty general, so it makes sense to move this to the `utils` package.

Signed-off-by: Josh Curl <josh@curl.me>