### PR TITLE
Create the default network if required.

### DIFF
--- a/docker/network/network.go
+++ b/docker/network/network.go
@@ -169,6 +169,12 @@ func NetworksFromServices(cli client.NetworkAPIClient, projectName string, netwo
 			networkNames[network.Name] = network
 		}
 	}
+	if len(networkConfigs) == 0 {
+		network := NewNetwork(projectName, "default", &config.NetworkConfig{
+			Driver: "bridge",
+		}, cli)
+		networks = append(networks, network)
+	}
 	for name, config := range networkConfigs {
 		network := NewNetwork(projectName, name, config, cli)
 		networks = append(networks, network)

--- a/docker/network/network_test.go
+++ b/docker/network/network_test.go
@@ -34,7 +34,12 @@ func TestNetworksFromServices(t *testing.T) {
 		expectedError    bool
 	}{
 		{
-			expectedNetworks: []*Network{},
+			expectedNetworks: []*Network{
+				{
+					name:        "default",
+					projectName: "prj",
+				},
+			},
 		},
 		{
 			networkConfigs: map[string]*config.NetworkConfig{

--- a/integration/volume_test.go
+++ b/integration/volume_test.go
@@ -77,6 +77,7 @@ func (s *CliSuite) TestNamedVolume(c *C) {
 }
 
 func (s *CliSuite) TestV2Volume(c *C) {
+	testRequires(c, not(DaemonVersionIs("1.9")))
 	p := s.ProjectFromText(c, "up", `version: "2"
 services:
   with_volume:

--- a/project/project.go
+++ b/project/project.go
@@ -160,7 +160,7 @@ func (p *Project) CreateService(name string) (Service, error) {
 					parts := strings.SplitN(envValue[0], "=", 2)
 					config.Build.Args[parts[0]] = parts[1]
 				default:
-					return nil, fmt.Errorf("Tried to set Build Arg %#v to multi-value %#v.", arg, envValue)
+					return nil, fmt.Errorf("tried to set Build Arg %#v to multi-value %#v", arg, envValue)
 				}
 			}
 		}
@@ -267,10 +267,12 @@ func (p *Project) handleNetworkConfig() {
 				serviceConfig.Networks = &yaml.Networks{
 					Networks: []*yaml.Network{
 						{
-							Name: "default",
+							Name:     "default",
+							RealName: fmt.Sprintf("%s_%s", p.Name, "default"),
 						},
 					},
 				}
+				p.AddNetworkConfig("default", &config.NetworkConfig{})
 			}
 			// Consolidate the name of the network
 			// FIXME(vdemeester) probably shouldn't be there, maybe move that to interface/factory


### PR DESCRIPTION
This make sure we create and use a default network if no other networks exists and/or some services don't use a defined network.

- [ ] Needs more tests :angel: 
- [x] I think I need to cover the case where one service has a defined network but not the other one

Should fix #319 

/cc @joshwget @dansteen 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>