### PR TITLE
Carry #409 — Add filtering on project ps

### DIFF
--- a/project/project_ps.go
+++ b/project/project_ps.go
@@ -1,13 +1,17 @@
 package project
 
-import (
-	"golang.org/x/net/context"
-)
+import "golang.org/x/net/context"
 
 // Ps list containers for the specified services.
 func (p *Project) Ps(ctx context.Context, services ...string) (InfoSet, error) {
 	allInfo := InfoSet{}
-	for _, name := range p.ServiceConfigs.Keys() {
+
+	if len(services) == 0 {
+		services = p.ServiceConfigs.Keys()
+	}
+
+	for _, name := range services {
+
 		service, err := p.CreateService(name)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Carry #409 – Implements correct filtering for project services listing as specified in documentation.

Closes #409 

👼 🐸