### PR TITLE
Fixes #425: Adds ability to use suffixes in docker-compose.yml

### DIFF
--- a/utils/util.go
+++ b/utils/util.go
@@ -49,7 +49,7 @@ func ConvertByJSON(src, target interface{}) error {
 
 	err = json.Unmarshal(newBytes, target)
 	if err != nil {
-		logrus.Errorf("Failed to unmarshall: %v\n%s", err, string(newBytes))
+		logrus.Errorf("Failed to unmarshal: %v\n%s", err, string(newBytes))
 	}
 	return err
 }
@@ -64,7 +64,7 @@ func Convert(src, target interface{}) error {
 
 	err = yaml.Unmarshal(newBytes, target)
 	if err != nil {
-		logrus.Errorf("Failed to unmarshall: %v\n%s", err, string(newBytes))
+		logrus.Errorf("Failed to unmarshal: %v\n%s", err, string(newBytes))
 	}
 	return err
 }

--- a/yaml/types_yaml.go
+++ b/yaml/types_yaml.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/strslice"
+	units "github.com/docker/go-units"
 )
 
 // StringorInt represents a string or an integer.
@@ -22,7 +23,10 @@ func (s *StringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	var stringType string
 	if err := unmarshal(&stringType); err == nil {
-		intType, err := strconv.ParseInt(stringType, 10, 64)
+		if stringType == "" {
+			return errors.New("Unmarshalled string is empty. Failed to convert to IntType")
+		}
+		intType, err := units.RAMInBytes(stringType)
 		if err != nil {
 			return err
 		}

--- a/yaml/types_yaml_test.go
+++ b/yaml/types_yaml_test.go
@@ -14,11 +14,11 @@ type StructStringorInt struct {
 }
 
 func TestStringorIntYaml(t *testing.T) {
-	for _, str := range []string{`{foo: 10}`, `{foo: "10"}`} {
+	for _, str := range []string{`{foo: 1048576}`, `{foo: "1048576"}`, `{foo: "1M"}`} {
 		s := StructStringorInt{}
 		yaml.Unmarshal([]byte(str), &s)
 
-		assert.Equal(t, StringorInt(10), s.Foo)
+		assert.Equal(t, StringorInt(1048576), s.Foo)
 
 		d, err := yaml.Marshal(&s)
 		assert.Nil(t, err)
@@ -26,7 +26,7 @@ func TestStringorIntYaml(t *testing.T) {
 		s2 := StructStringorInt{}
 		yaml.Unmarshal(d, &s2)
 
-		assert.Equal(t, StringorInt(10), s2.Foo)
+		assert.Equal(t, StringorInt(1048576), s2.Foo)
 	}
 }
 


### PR DESCRIPTION
Fixes #425 and https://github.com/aws/amazon-ecs-cli/issues/1
-Added ability to use suffixes
-Added test case for 1M in types_yaml_test.go.
-Changed existing string and int to match 1M
-Fixed typo

/cc @vdemeester 

![](http://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-10.jpg)
