### PR TITLE
Carry #411 & #425 — Supporting human readable for memory related values

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -45,9 +45,9 @@ type ServiceConfigV1 struct {
 	Links         yaml.MaporColonSlice `yaml:"links,omitempty"`
 	LogDriver     string               `yaml:"log_driver,omitempty"`
 	MacAddress    string               `yaml:"mac_address,omitempty"`
-	MemLimit      yaml.StringorInt     `yaml:"mem_limit,omitempty"`
-	MemSwapLimit  yaml.StringorInt     `yaml:"memswap_limit,omitempty"`
-	MemSwappiness yaml.StringorInt     `yaml:"mem_swappiness,omitempty"`
+	MemLimit      yaml.MemStringorInt  `yaml:"mem_limit,omitempty"`
+	MemSwapLimit  yaml.MemStringorInt  `yaml:"memswap_limit,omitempty"`
+	MemSwappiness yaml.MemStringorInt  `yaml:"mem_swappiness,omitempty"`
 	Name          string               `yaml:"name,omitempty"`
 	Net           string               `yaml:"net,omitempty"`
 	OomScoreAdj   yaml.StringorInt     `yaml:"oom_score_adj,omitempty"`
@@ -58,7 +58,7 @@ type ServiceConfigV1 struct {
 	Privileged    bool                 `yaml:"privileged,omitempty"`
 	Restart       string               `yaml:"restart,omitempty"`
 	ReadOnly      bool                 `yaml:"read_only,omitempty"`
-	ShmSize       yaml.StringorInt     `yaml:"shm_size,omitempty"`
+	ShmSize       yaml.MemStringorInt  `yaml:"shm_size,omitempty"`
 	StdinOpen     bool                 `yaml:"stdin_open,omitempty"`
 	SecurityOpt   []string             `yaml:"security_opt,omitempty"`
 	StopSignal    string               `yaml:"stop_signal,omitempty"`
@@ -115,9 +115,9 @@ type ServiceConfig struct {
 	Links         yaml.MaporColonSlice `yaml:"links,omitempty"`
 	Logging       Log                  `yaml:"logging,omitempty"`
 	MacAddress    string               `yaml:"mac_address,omitempty"`
-	MemLimit      yaml.StringorInt     `yaml:"mem_limit,omitempty"`
-	MemSwapLimit  yaml.StringorInt     `yaml:"memswap_limit,omitempty"`
-	MemSwappiness yaml.StringorInt     `yaml:"mem_swappiness,omitempty"`
+	MemLimit      yaml.MemStringorInt  `yaml:"mem_limit,omitempty"`
+	MemSwapLimit  yaml.MemStringorInt  `yaml:"memswap_limit,omitempty"`
+	MemSwappiness yaml.MemStringorInt  `yaml:"mem_swappiness,omitempty"`
 	NetworkMode   string               `yaml:"network_mode,omitempty"`
 	Networks      *yaml.Networks       `yaml:"networks,omitempty"`
 	OomScoreAdj   yaml.StringorInt     `yaml:"oom_score_adj,omitempty"`
@@ -125,7 +125,7 @@ type ServiceConfig struct {
 	Ports         []string             `yaml:"ports,omitempty"`
 	Privileged    bool                 `yaml:"privileged,omitempty"`
 	SecurityOpt   []string             `yaml:"security_opt,omitempty"`
-	ShmSize       yaml.StringorInt     `yaml:"shm_size,omitempty"`
+	ShmSize       yaml.MemStringorInt  `yaml:"shm_size,omitempty"`
 	StopSignal    string               `yaml:"stop_signal,omitempty"`
 	Tmpfs         yaml.Stringorslice   `yaml:"tmpfs,omitempty"`
 	VolumeDriver  string               `yaml:"volume_driver,omitempty"`

--- a/docker/service/convert_test.go
+++ b/docker/service/convert_test.go
@@ -130,7 +130,7 @@ func TestIsolation(t *testing.T) {
 func TestMemSwappiness(t *testing.T) {
 	ctx := &ctx.Context{}
 	sc := &config.ServiceConfig{
-		MemSwappiness: yaml.StringorInt(10),
+		MemSwappiness: yaml.MemStringorInt(10),
 	}
 	_, hostCfg, err := Convert(sc, ctx.Context, nil)
 	assert.Nil(t, err)

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -202,6 +202,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
   multiple:
     image: busybox
     mem_limit: "40m"
+    memswap_limit: 40000000
     ports:
       - 10000`)
 
@@ -244,4 +245,5 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 	assert.Equal(t, "multi", multipleConfig.ContainerName)
 	assert.Equal(t, []string{"8000", "9000", "10000"}, multipleConfig.Ports)
 	assert.Equal(t, yaml.MemStringorInt(41943040), multipleConfig.MemLimit)
+	assert.Equal(t, yaml.MemStringorInt(40000000), multipleConfig.MemSwapLimit)
 }

--- a/project/project_test.go
+++ b/project/project_test.go
@@ -201,7 +201,7 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 	configThree := []byte(`
   multiple:
     image: busybox
-    mem_limit: 40000000
+    mem_limit: "40m"
     ports:
       - 10000`)
 
@@ -243,5 +243,5 @@ func TestParseWithMultipleComposeFiles(t *testing.T) {
 	assert.Equal(t, "busybox", multipleConfig.Image)
 	assert.Equal(t, "multi", multipleConfig.ContainerName)
 	assert.Equal(t, []string{"8000", "9000", "10000"}, multipleConfig.Ports)
-	assert.Equal(t, yaml.StringorInt(40000000), multipleConfig.MemLimit)
+	assert.Equal(t, yaml.MemStringorInt(41943040), multipleConfig.MemLimit)
 }

--- a/yaml/types_yaml.go
+++ b/yaml/types_yaml.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/api/types/strslice"
+	"github.com/docker/go-units"
 )
 
 // StringorInt represents a string or an integer.
@@ -23,6 +24,7 @@ func (s *StringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var stringType string
 	if err := unmarshal(&stringType); err == nil {
 		intType, err := strconv.ParseInt(stringType, 10, 64)
+
 		if err != nil {
 			return err
 		}
@@ -31,6 +33,32 @@ func (s *StringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	return errors.New("Failed to unmarshal StringorInt")
+}
+
+// MemStringorInt represents a string or an integer
+// the String supports notations like 10m for then Megabyte of memory
+type MemStringorInt int64
+
+// UnmarshalYAML implements the Unmarshaller interface.
+func (s *MemStringorInt) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var intType int64
+	if err := unmarshal(&intType); err == nil {
+		*s = MemStringorInt(intType)
+		return nil
+	}
+
+	var stringType string
+	if err := unmarshal(&stringType); err == nil {
+		intType, err := units.RAMInBytes(stringType)
+
+		if err != nil {
+			return err
+		}
+		*s = MemStringorInt(intType)
+		return nil
+	}
+
+	return errors.New("Failed to unmarshal MemStringorInt")
 }
 
 // Stringorslice represents


### PR DESCRIPTION
Closes #411 #425

---

Currently libcompose fails to parse compose files that use human readable strings for mem_limit, such as 40m for 40Mbyte. 
These simple changes would make it work, but would also have the side effect that libcompose would accept this kind of human readable string in other places as well (where it would not make sense).
It is therefore not a complete solution.  
I wonder how a complete solution would look like.Would we need to introduce another type
MemStringorInt, which would be used wherever memory values are specified?

---

Fixes #425 and https://github.com/aws/amazon-ecs-cli/issues/1
-Added ability to use suffixes
-Added test case for 1M in types_yaml_test.go.
-Changed existing string and int to match 1M
-Fixed typo

/cc @vdemeester 

![](http://static.boredpanda.com/blog/wp-content/uuuploads/cute-baby-animals/cute-baby-animals-10.jpg)
