### PR TITLE
Support mem_reservation service property

### DIFF
--- a/config/schema.go
+++ b/config/schema.go
@@ -86,6 +86,7 @@ var schemaDataV1 = `{
         "log_opt": {"type": "object"},
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
+        "mem_reservation": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
         "mem_swappiness": {"type": "integer"},
         "net": {"type": "string"},

--- a/config/schema.go
+++ b/config/schema.go
@@ -298,6 +298,7 @@ var servicesSchemaDataV2 = `{
 
         "mac_address": {"type": "string"},
         "mem_limit": {"type": ["number", "string"]},
+        "mem_reservation": {"type": ["number", "string"]},
         "memswap_limit": {"type": ["number", "string"]},
         "mem_swappiness": {"type": "integer"},
         "network_mode": {"type": "string"},

--- a/config/types.go
+++ b/config/types.go
@@ -117,6 +117,7 @@ type ServiceConfig struct {
 	Logging        Log                  `yaml:"logging,omitempty"`
 	MacAddress     string               `yaml:"mac_address,omitempty"`
 	MemLimit       yaml.MemStringorInt  `yaml:"mem_limit,omitempty"`
+	MemReservation yaml.MemStringorInt  `yaml:"mem_reservation,omitempty"`
 	MemSwapLimit   yaml.MemStringorInt  `yaml:"memswap_limit,omitempty"`
 	MemSwappiness  yaml.MemStringorInt  `yaml:"mem_swappiness,omitempty"`
 	NetworkMode    string               `yaml:"network_mode,omitempty"`

--- a/docker/service/convert.go
+++ b/docker/service/convert.go
@@ -184,16 +184,17 @@ func Convert(c *config.ServiceConfig, ctx project.Context, clientFactory compose
 	memorySwappiness := int64(c.MemSwappiness)
 
 	resources := container.Resources{
-		CgroupParent:     c.CgroupParent,
-		Memory:           int64(c.MemLimit),
-		MemorySwap:       int64(c.MemSwapLimit),
-		MemorySwappiness: &memorySwappiness,
-		CPUShares:        int64(c.CPUShares),
-		CPUQuota:         int64(c.CPUQuota),
-		CpusetCpus:       c.CPUSet,
-		Ulimits:          ulimits,
-		Devices:          deviceMappings,
-		OomKillDisable:   &c.OomKillDisable,
+		CgroupParent:      c.CgroupParent,
+		Memory:            int64(c.MemLimit),
+		MemoryReservation: int64(c.MemReservation),
+		MemorySwap:        int64(c.MemSwapLimit),
+		MemorySwappiness:  &memorySwappiness,
+		CPUShares:         int64(c.CPUShares),
+		CPUQuota:          int64(c.CPUQuota),
+		CpusetCpus:        c.CPUSet,
+		Ulimits:           ulimits,
+		Devices:           deviceMappings,
+		OomKillDisable:    &c.OomKillDisable,
 	}
 
 	networkMode := c.NetworkMode

--- a/docker/service/convert_test.go
+++ b/docker/service/convert_test.go
@@ -138,6 +138,17 @@ func TestMemSwappiness(t *testing.T) {
 	assert.Equal(t, int64(10), *hostCfg.MemorySwappiness)
 }
 
+func TestMemReservation(t *testing.T) {
+	ctx := &ctx.Context{}
+	sc := &config.ServiceConfig{
+		MemReservation: 100000,
+	}
+	_, hostCfg, err := Convert(sc, ctx.Context, nil)
+	assert.Nil(t, err)
+
+	assert.Equal(t, int64(100000), hostCfg.MemoryReservation)
+}
+
 func TestOomKillDisable(t *testing.T) {
 	ctx := &ctx.Context{}
 	sc := &config.ServiceConfig{


### PR DESCRIPTION
Docker supports `--memory-reservation=""`, this adds support for that property.

See https://github.com/docker/compose/pull/3723 for relevant docker-compose equiv. 

~~I looked for where to test this, but couldn't find a good spot. Suggestions?~~