### PR TITLE
Do not panic with null volume configurations

### DIFF
--- a/docker/volume/volume.go
+++ b/docker/volume/volume.go
@@ -81,14 +81,18 @@ func (v *Volume) create(ctx context.Context) error {
 
 // NewVolume creates a new volume from the specified name and config.
 func NewVolume(projectName, name string, config *config.VolumeConfig, client client.VolumeAPIClient) *Volume {
-	return &Volume{
-		client:        client,
-		projectName:   projectName,
-		name:          name,
-		driver:        config.Driver,
-		driverOptions: config.DriverOpts,
-		external:      config.External.External,
+	vol := &Volume{
+		client:      client,
+		projectName: projectName,
+		name:        name,
 	}
+	if config != nil {
+		vol.driver = config.Driver
+		vol.driverOptions = config.DriverOpts
+		vol.external = config.External.External
+
+	}
+	return vol
 }
 
 // Volumes holds a list of volume

--- a/docker/volume/volume_test.go
+++ b/docker/volume/volume_test.go
@@ -30,6 +30,19 @@ func TestVolumesFromServices(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			volumeConfigs: map[string]*config.VolumeConfig{
+				"vol1": nil,
+			},
+			services: map[string]*config.ServiceConfig{},
+			expectedVolumes: []*Volume{
+				{
+					name:        "vol1",
+					projectName: "prj",
+				},
+			},
+			expectedError: false,
+		},
 	}
 
 	for index, c := range cases {

--- a/project/project.go
+++ b/project/project.go
@@ -312,7 +312,7 @@ func (p *Project) handleVolumeConfig() {
 				}
 
 				vol, ok := p.VolumeConfigs[volume.Source]
-				if !ok {
+				if !ok || vol == nil {
 					continue
 				}
 


### PR DESCRIPTION
Fix for #430.

I fixed the issue by simply null checks.
Should we substitute these nil values with the default value on parsing timing?
