### PR TITLE
Allows the use of float values in environment variables

### DIFF
--- a/yaml/types_yaml.go
+++ b/yaml/types_yaml.go
@@ -217,6 +217,8 @@ func toSepMapParts(value map[interface{}]interface{}, sep string) ([]string, err
 				parts = append(parts, sk+sep+strconv.Itoa(sv))
 			} else if sv, ok := v.(int64); ok {
 				parts = append(parts, sk+sep+strconv.FormatInt(sv, 10))
+			} else if sv, ok := v.(float64); ok {
+				parts = append(parts, sk+sep+strconv.FormatFloat(sv, 'f', -1, 64))
 			} else if v == nil {
 				parts = append(parts, sk)
 			} else {


### PR DESCRIPTION
When converting a docker-compose file with float values as environment
variables, libcompose errors out.

Example:

```
version: "2"

services:
    redis:
      image: redis:3.0
      environment:
        foo: 0.3
```

Errors out with: `Cannot unmarshal '0.3' of type float64 into a string value`

This commit fixes the issue by detecting if a float value has been
passed and successfully converting it to a string variable.