### PR TITLE
Added consistency in build

### DIFF
--- a/config/merge_v2.go
+++ b/config/merge_v2.go
@@ -180,8 +180,13 @@ func resolveContextV2(inFile string, serviceData RawService) RawService {
 	} else {
 		current = path.Join(current, context)
 	}
-
-	build["context"] = current
+	if _, ok := serviceData["build"].(string); ok {
+		//build is specified as a string containing a path to the build context
+		serviceData["build"] = current
+	} else {
+		//build is specified as an object with the path specified under context
+		build["context"] = current
+	}
 
 	return serviceData
 }


### PR DESCRIPTION
this commit will fix #449 by showing same build context when it is mentioned
either as a string containing a path to the build context,
or an object with the path specified under context.