### PR TITLE
Attempting to expose docker auth configs to libcompose users

### DIFF
--- a/docker/auth/auth.go
+++ b/docker/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/cli/config/configfile"
 	"github.com/docker/docker/registry"
@@ -10,11 +11,83 @@ import (
 type Lookup interface {
 	All() map[string]types.AuthConfig
 	Lookup(repoInfo *registry.RepositoryInfo) types.AuthConfig
+	GetAuthConfigMap() map[string]Config
+	SetAuthConfigMap(configMap map[string]Config) error
 }
 
 // ConfigLookup implements AuthLookup by reading a Docker config file
 type ConfigLookup struct {
 	*configfile.ConfigFile
+}
+
+// Config contains authorization information for connecting to a Registry
+type Config struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+
+	// Email is an optional value associated with the username.
+	// This field is deprecated and will be removed in a later
+	// version of docker.
+	Email string `json:"email,omitempty"`
+
+	ServerAddress string `json:"serveraddress,omitempty"`
+
+	// IdentityToken is used to authenticate the user and get
+	// an access token for the registry.
+	IdentityToken string `json:"identitytoken,omitempty"`
+
+	// RegistryToken is a bearer token to be sent to a registry
+	RegistryToken string `json:"registrytoken,omitempty"`
+}
+
+// SetAuthConfigMap Update the docker auth config maps
+func (c *ConfigLookup) SetAuthConfigMap(configMap map[string]Config) error {
+	if c.ConfigFile == nil {
+		return errors.New("ConfigFile not set in lookup")
+	}
+	authConfigMap := map[string]types.AuthConfig{}
+	for k, v := range configMap {
+		authConfigMap[k] = configToDockerTypeAuth(v)
+	}
+	c.ConfigFile.AuthConfigs = authConfigMap
+	return nil
+}
+
+// GetAuthConfigMap This will return all of the AuthConfigurations
+func (c *ConfigLookup) GetAuthConfigMap() map[string]Config {
+	if c.ConfigFile == nil {
+		return map[string]Config{}
+	}
+	configMap := map[string]Config{}
+	for k, v := range c.All() {
+		configMap[k] = dockerTypeAuthToConfig(v)
+	}
+	return configMap
+}
+
+func configToDockerTypeAuth(c Config) types.AuthConfig {
+	return types.AuthConfig{
+		Username:      c.Username,
+		Password:      c.Password,
+		Auth:          c.Auth,
+		Email:         c.Email,
+		ServerAddress: c.ServerAddress,
+		IdentityToken: c.IdentityToken,
+		RegistryToken: c.RegistryToken,
+	}
+}
+
+func dockerTypeAuthToConfig(ac types.AuthConfig) Config {
+	return Config{
+		Username:      ac.Username,
+		Password:      ac.Password,
+		Auth:          ac.Auth,
+		Email:         ac.Email,
+		ServerAddress: ac.ServerAddress,
+		IdentityToken: ac.IdentityToken,
+		RegistryToken: ac.RegistryToken,
+	}
 }
 
 // NewConfigLookup creates a new ConfigLookup for a given context


### PR DESCRIPTION
RFC:
I ran into an issue the other day: https://github.com/docker/libcompose/issues/186#issuecomment-287549617 after a recent update to docker. Essentially libcompose no longer worked with the specific format of auth file on my computer.

I was going to try to fix this directly in my own project but I was getting errors accessing the vendor structs and type mismatch errors when trying to use the docker libraries directly. It was really kind of frustrating to have to dig into all of the auth just to get a access to a private registry.

I then went on to realize I could just do something like this:
```go
        // ac is a AuthConfig from docker library
	dockerContext.AuthLookup = auth.NewConfigLookup(dockerContext.ConfigFile)
	thing := dockerContext.ConfigFile.AuthConfigs["docker.example.com"]
	thing.Username=      ac.Username
	thing.Password=      ac.Password
	thing.Auth=          ac.Auth
	thing.Email=         ac.Email
	thing.ServerAddress= ac.ServerAddress
	thing.IdentityToken= ac.IdentityToken
	thing.RegistryToken= ac.RegistryToken
	dockerContext.ConfigFile.AuthConfigs["docker.example.com"] = thing
```
I had already written the code that exposed a auth.Config struct and the helper methods. I'm not really sure which way is better and I still have to write some unit tests around the code I am submitting. There could be something else entirely that I missed so I thought best to open a PR and discuss.

