### PR TITLE
Load schemas in init()

### DIFF
--- a/config/schema_helpers.go
+++ b/config/schema_helpers.go
@@ -17,6 +17,16 @@ var (
 	schemaV2                 map[string]interface{}
 )
 
+func init() {
+	if err := setupSchemaLoaders(schemaDataV1, &schemaV1, &schemaLoaderV1, &constraintSchemaLoaderV1); err != nil {
+		panic(err)
+	}
+
+	if err := setupSchemaLoaders(servicesSchemaDataV2, &schemaV2, &schemaLoaderV2, &constraintSchemaLoaderV2); err != nil {
+		panic(err)
+	}
+}
+
 type (
 	environmentFormatChecker struct{}
 	portsFormatChecker       struct{}

--- a/config/validation.go
+++ b/config/validation.go
@@ -157,10 +157,6 @@ func invalidTypeMessage(service, key string, err gojsonschema.ResultError) strin
 }
 
 func validate(serviceMap RawServiceMap) error {
-	if err := setupSchemaLoaders(schemaDataV1, &schemaV1, &schemaLoaderV1, &constraintSchemaLoaderV1); err != nil {
-		return err
-	}
-
 	serviceMap = convertServiceMapKeysToStrings(serviceMap)
 
 	dataLoader := gojsonschema.NewGoLoader(serviceMap)
@@ -174,10 +170,6 @@ func validate(serviceMap RawServiceMap) error {
 }
 
 func validateV2(serviceMap RawServiceMap) error {
-	if err := setupSchemaLoaders(servicesSchemaDataV2, &schemaV2, &schemaLoaderV2, &constraintSchemaLoaderV2); err != nil {
-		return err
-	}
-
 	serviceMap = convertServiceMapKeysToStrings(serviceMap)
 
 	dataLoader := gojsonschema.NewGoLoader(serviceMap)
@@ -250,10 +242,6 @@ func generateErrorMessages(serviceMap RawServiceMap, schema map[string]interface
 }
 
 func validateServiceConstraints(service RawService, serviceName string) error {
-	if err := setupSchemaLoaders(schemaDataV1, &schemaV1, &schemaLoaderV1, &constraintSchemaLoaderV1); err != nil {
-		return err
-	}
-
 	service = convertServiceKeysToStrings(service)
 
 	var validationErrors []string
@@ -289,10 +277,6 @@ func validateServiceConstraints(service RawService, serviceName string) error {
 }
 
 func validateServiceConstraintsv2(service RawService, serviceName string) error {
-	if err := setupSchemaLoaders(servicesSchemaDataV2, &schemaV2, &schemaLoaderV2, &constraintSchemaLoaderV2); err != nil {
-		return err
-	}
-
 	service = convertServiceKeysToStrings(service)
 
 	var validationErrors []string


### PR DESCRIPTION
Issue Observed
----------------

When multiple goroutines use different `Project` instances concurrently,
Go's race detector complains data races.

Issue Detail
------------

`schema_helpers.go` have some global variables and they are initialized
by `setupSchemaLoaders()` when `validate()` and other schema functions
are called for the first time.
However, `setupSchemaLoaders()` does not have mutex, so some times
multiple gorutines proceed into this function, then a race happens.

Suggested Resolution
----------------------

We can add a mutex to `setupSchemaLoader()` to avoid the race condition.
However, the function is supposed to cache results and called not so
many times. Therefore, in this patch, we simply initialize schemas in
`init()`.

(using global variables might be not a good idea. We might want to have some singleton-ish factory or something instead)

Appendix
----------

Stack Trace by the race detector:

```
WARNING: DATA RACE
Write at 0x00c4201a9740 by goroutine 22:
  runtime.mapassign()
      /home/yudai/.gvm/gos/go1.8/src/runtime/hashmap.go:485 +0x0
  github.com/private/repo/vendor/github.com/docker/libcompose/config.setupSchemaLoaders()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/schema_helpers.go:50 +0x227
  github.com/private/repo/vendor/github.com/docker/libcompose/config.validateV2()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/validation.go:177 +0x8f
  github.com/private/repo/vendor/github.com/docker/libcompose/config.MergeServicesV2()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/merge_v2.go:15 +0xa8d
  github.com/private/repo/vendor/github.com/docker/libcompose/config.Merge()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/merge.go:94 +0x7ff
  github.com/private/repo/vendor/github.com/docker/libcompose/project.(*Project).load()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/project/project.go:222 +0x17c
  github.com/private/repo/vendor/github.com/docker/libcompose/project.(*Project).Parse()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/project/project.go:130 +0x338
  github.com/private/repo/vendor/github.com/docker/libcompose/docker.NewProject()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/docker/project.go:58 +0x1e5
  ...snip...

Previous write at 0x00c4201a9740 by goroutine 23:
  runtime.mapassign()
      /home/yudai/.gvm/gos/go1.8/src/runtime/hashmap.go:485 +0x0
  github.com/private/repo/vendor/github.com/docker/libcompose/config.setupSchemaLoaders()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/schema_helpers.go:50 +0x227
  github.com/private/repo/vendor/github.com/docker/libcompose/config.validateV2()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/validation.go:177 +0x8f
  github.com/private/repo/vendor/github.com/docker/libcompose/config.MergeServicesV2()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/merge_v2.go:15 +0xa8d
  github.com/private/repo/vendor/github.com/docker/libcompose/config.Merge()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/config/merge.go:94 +0x7ff
  github.com/private/repo/vendor/github.com/docker/libcompose/project.(*Project).load()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/project/project.go:222 +0x17c
  github.com/private/repo/vendor/github.com/docker/libcompose/project.(*Project).Parse()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/project/project.go:130 +0x338
  github.com/private/repo/vendor/github.com/docker/libcompose/docker.NewProject()
      /home/yudai/repos/private/src/github.com/private/repo/vendor/github.com/docker/libcompose/docker/project.go:58 +0x1e5
  ...snip...
```