### PR TITLE
Fixes issue #454 Environment.ToMap() doesn't support variables with equals signs

### DIFF
--- a/yaml/types_yaml.go
+++ b/yaml/types_yaml.go
@@ -249,8 +249,9 @@ func toStrings(s []interface{}) ([]string, error) {
 func toMap(s []string, sep string) map[string]string {
 	m := map[string]string{}
 	for _, v := range s {
+		// Return everything past first sep
 		values := strings.Split(v, sep)
-		m[values[0]] = values[1]
+		m[values[0]] = strings.SplitN(v, sep, 2)[1]
 	}
 	return m
 }

--- a/yaml/types_yaml_test.go
+++ b/yaml/types_yaml_test.go
@@ -202,3 +202,13 @@ func TestSliceWithEmptyValue(t *testing.T) {
 	assert.True(t, contains(s2.Foo, "empty="))
 	assert.True(t, contains(s2.Foo, "lookup"))
 }
+
+func TestEqualSliceToMapEqualSign(t *testing.T) {
+	slice := MaporEqualSlice{"foo=bar=baz"}
+	result := slice.ToMap()
+	assert.Equal(t, "bar=baz", result["foo"])
+
+	slice = MaporEqualSlice{"foo=bar=baz=buz"}
+	result = slice.ToMap()
+	assert.Equal(t, "bar=baz=buz", result["foo"])
+}


### PR DESCRIPTION
Fixes [this](https://github.com/docker/libcompose/issues/454) issue.