### PR TITLE
Added image cache_from to builder options

### DIFF
--- a/docker/builder/builder.go
+++ b/docker/builder/builder.go
@@ -42,6 +42,7 @@ type DaemonBuilder struct {
 	ForceRemove      bool
 	Pull             bool
 	BuildArgs        map[string]*string
+	CacheFrom        []string
 	LoggerFactory    logger.Factory
 }
 
@@ -96,6 +97,7 @@ func (d *DaemonBuilder) Build(ctx context.Context, imageName string) error {
 		Dockerfile:  d.Dockerfile,
 		AuthConfigs: d.AuthConfigs,
 		BuildArgs:   d.BuildArgs,
+		CacheFrom:   d.CacheFrom,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
This option specifies images that can be considered as cache resources. Since Docker v1.10.0  when pulling from a registry these pulled layers are not allowed in the build cache. See https://github.com/moby/moby/issues/20316 for further explanation.