### PR TITLE
Add ServiceNames() to APIProject

### DIFF
--- a/project/interface.go
+++ b/project/interface.go
@@ -41,6 +41,7 @@ type APIProject interface {
 	Containers(ctx context.Context, filter Filter, services ...string) ([]string, error)
 
 	GetServiceConfig(service string) (*config.ServiceConfig, bool)
+	GetServiceNames() []string
 }
 
 // Filter holds filter element to filter containers

--- a/project/project.go
+++ b/project/project.go
@@ -546,6 +546,11 @@ func (p *Project) GetServiceConfig(name string) (*config.ServiceConfig, bool) {
 	return p.ServiceConfigs.Get(name)
 }
 
+// GetServiceNames returnes all service names in the project.
+func (p *Project) GetServiceNames() []string {
+	return p.ServiceConfigs.Keys()
+}
+
 // IsNamedVolume returns whether the specified volume (string) is a named volume or not.
 func IsNamedVolume(volume string) bool {
 	return !strings.HasPrefix(volume, ".") && !strings.HasPrefix(volume, "/") && !strings.HasPrefix(volume, "~")


### PR DESCRIPTION
Issue Observed
--------------

project.APIProject doesn't provide a method to get the service names
define in a project.

You cannot get service names when you use GetSreviceConfig() and other
methods of the interface.

Proposed Resolution
-------------------

We could add a method GetServiceConfigs() which returns the
*ServiceConfigs owned by the concrete struct (project.Project).
However, since the strcut already has ServiceConfigs property, we cannot add a new method with the same name.

In this commit, we add a new method just returns the list of service
names instead of returning the *ServiceConfigs itself.

Signed-off-by: Iwasaki Yudai <yudai@arielworks.com>