### PR TITLE
fix faltal error when using 'group_add' key

### DIFF
--- a/config/schema.go
+++ b/config/schema.go
@@ -281,6 +281,7 @@ var servicesSchemaDataV2 = `{
 
         "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+        "group_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "hostname": {"type": "string"},
         "image": {"type": "string"},
         "ipc": {"type": "string"},


### PR DESCRIPTION
fix #446
Implementation is done by Josh actually. The error is caused by missing key in schema.
The key 'group_add' lives in compose-file version 2 only.