### PR TITLE
Fix GetServiceHash failed due to false hashing

### DIFF
--- a/config/hash.go
+++ b/config/hash.go
@@ -86,8 +86,12 @@ func GetServiceHash(name string, config *ServiceConfig) string {
 			for _, sliceKey := range sliceKeys {
 				io.WriteString(hash, fmt.Sprintf("%s, ", sliceKey))
 			}
+		case *yaml.Networks:
+			io.WriteString(hash, fmt.Sprintf("%s, ", s.HashString()))
+		case *yaml.Volumes:
+			io.WriteString(hash, fmt.Sprintf("%s, ", s.HashString()))
 		default:
-			io.WriteString(hash, fmt.Sprintf("%v", serviceValue))
+			io.WriteString(hash, fmt.Sprintf("%v, ", serviceValue))
 		}
 	}
 

--- a/yaml/network.go
+++ b/yaml/network.go
@@ -3,6 +3,8 @@ package yaml
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 )
 
 // Networks represents a list of service networks in compose file.
@@ -18,6 +20,35 @@ type Network struct {
 	Aliases     []string `yaml:"aliases,omitempty"`
 	IPv4Address string   `yaml:"ipv4_address,omitempty"`
 	IPv6Address string   `yaml:"ipv6_address,omitempty"`
+}
+
+// Generate a hash string to detect service network config changes
+func (n *Networks) HashString() string {
+	if n == nil {
+		return ""
+	}
+	result := []string{}
+	for _, net := range n.Networks {
+		result = append(result, net.HashString())
+	}
+	sort.Strings(result)
+	return strings.Join(result, ",")
+}
+
+// Generate a hash string to detect service network config changes
+func (n *Network) HashString() string {
+	if n == nil {
+		return ""
+	}
+	result := []string{}
+	result = append(result, n.Name)
+	result = append(result, n.RealName)
+	sort.Strings(n.Aliases)
+	result = append(result, strings.Join(n.Aliases, ","))
+	result = append(result, n.IPv4Address)
+	result = append(result, n.IPv6Address)
+	sort.Strings(result)
+	return strings.Join(result, ",")
 }
 
 // MarshalYAML implements the Marshaller interface.

--- a/yaml/volume.go
+++ b/yaml/volume.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -17,6 +18,19 @@ type Volume struct {
 	Source      string `yaml:"-"`
 	Destination string `yaml:"-"`
 	AccessMode  string `yaml:"-"`
+}
+
+// Generate a hash string to detect service volume config changes
+func (v *Volumes) HashString() string {
+	if v == nil {
+		return ""
+	}
+	result := []string{}
+	for _, vol := range v.Volumes {
+		result = append(result, vol.String())
+	}
+	sort.Strings(result)
+	return strings.Join(result, ",")
 }
 
 // String implements the Stringer interface.


### PR DESCRIPTION
Hashing *yaml.Networks and *yaml.Volumes in previous code was processed wrong. Sprintf an array of pointers by %v in default will get a string of mem addresses, which could be changing every time libcompose project up the same compose file. Therefore OutOfSync was always triggered if service had a network config.