### PR TITLE
Add support for both image and build in v2 files

### DIFF
--- a/config/merge.go
+++ b/config/merge.go
@@ -236,12 +236,6 @@ func readEnvFile(resourceLookup ResourceLookup, inFile string, serviceData RawSe
 
 func mergeConfig(baseService, serviceData RawService) RawService {
 	for k, v := range serviceData {
-		// Image and build are mutually exclusive in merge
-		if k == "image" {
-			delete(baseService, "build")
-		} else if k == "build" {
-			delete(baseService, "image")
-		}
 		existing, ok := baseService[k]
 		if ok {
 			baseService[k] = merge(existing, v)

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -116,8 +116,8 @@ services:
 	}
 }
 
-func TestExtendBuildOverImage(t *testing.T) {
-	_, configV1, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
+func TestExtendBuildOverImageV1(t *testing.T) {
+	_, config, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
 parent:
   image: foo
 child:
@@ -129,41 +129,56 @@ child:
 		t.Fatal(err)
 	}
 
-	_, configV2, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
-version: '2'
-services:
-  parent:
-    image: foo
-  child:
-    build:
-      context: .
-    extends:
-      service: parent
-`), nil)
-	if err != nil {
-		t.Fatal(err)
+	parent := config["parent"]
+	child := config["child"]
+
+	if parent.Image != "foo" {
+		t.Fatal("Invalid image", parent.Image)
 	}
 
-	for _, config := range []map[string]*ServiceConfig{configV1, configV2} {
-		parent := config["parent"]
-		child := config["child"]
+	if child.Build.Context != "." {
+		t.Fatal("Invalid build", child.Build)
+	}
 
-		if parent.Image != "foo" {
-			t.Fatal("Invalid image", parent.Image)
-		}
-
-		if child.Build.Context != "." {
-			t.Fatal("Invalid build", child.Build)
-		}
-
-		if child.Image != "" {
-			t.Fatal("Invalid image", child.Image)
-		}
+	if child.Image != "" {
+		t.Fatal("Invalid image", child.Image)
 	}
 }
 
-func TestExtendImageOverBuild(t *testing.T) {
-	_, configV1, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
+func TestExtendBuildOverImageV2(t *testing.T) {
+	_, config, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
+version: '2'
+services:
+  parent:
+    image: foo
+  child:
+    build:
+      context: .
+    extends:
+      service: parent
+`), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parent := config["parent"]
+	child := config["child"]
+
+	if parent.Image != "foo" {
+		t.Fatal("Invalid image", parent.Image)
+	}
+
+	if child.Build.Context != "." {
+		t.Fatal("Invalid build", child.Build)
+	}
+
+	if child.Image != "foo" {
+		t.Fatal("Invalid image", child.Image)
+	}
+}
+
+func TestExtendImageOverBuildV1(t *testing.T) {
+	_, config, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
 parent:
   build: .
 child:
@@ -175,7 +190,29 @@ child:
 		t.Fatal(err)
 	}
 
-	_, configV2, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
+	parent := config["parent"]
+	child := config["child"]
+
+	if parent.Image != "" {
+		t.Fatal("Invalid image", parent.Image)
+	}
+
+	if parent.Build.Context != "." {
+		t.Fatal("Invalid build", parent.Build)
+	}
+
+	if child.Build.Context != "" {
+		t.Fatal("Invalid build", child.Build)
+	}
+
+	if child.Image != "foo" {
+		t.Fatal("Invalid image", child.Image)
+	}
+
+}
+
+func TestExtendImageOverBuildV2(t *testing.T) {
+	_, config, _, _, err := Merge(NewServiceConfigs(), nil, &NullLookup{}, "", []byte(`
 version: '2'
 services:
   parent:
@@ -190,25 +227,23 @@ services:
 		t.Fatal(err)
 	}
 
-	for _, config := range []map[string]*ServiceConfig{configV1, configV2} {
-		parent := config["parent"]
-		child := config["child"]
+	parent := config["parent"]
+	child := config["child"]
 
-		if parent.Image != "" {
-			t.Fatal("Invalid image", parent.Image)
-		}
+	if parent.Image != "" {
+		t.Fatal("Invalid image", parent.Image)
+	}
 
-		if parent.Build.Context != "." {
-			t.Fatal("Invalid build", parent.Build)
-		}
+	if parent.Build.Context != "." {
+		t.Fatal("Invalid build", parent.Build)
+	}
 
-		if child.Build.Context != "" {
-			t.Fatal("Invalid build", child.Build)
-		}
+	if child.Build.Context != "." {
+		t.Fatal("Invalid build", child.Build)
+	}
 
-		if child.Image != "foo" {
-			t.Fatal("Invalid image", child.Image)
-		}
+	if child.Image != "foo" {
+		t.Fatal("Invalid image", child.Image)
 	}
 }
 

--- a/config/merge_v1.go
+++ b/config/merge_v1.go
@@ -29,7 +29,7 @@ func MergeServicesV1(existingServices *ServiceConfigs, environmentLookup Environ
 				return nil, err
 			}
 
-			data = mergeConfig(rawExistingService, data)
+			data = mergeConfigV1(rawExistingService, data)
 		}
 
 		datas[name] = data
@@ -148,7 +148,7 @@ func parseV1(resourceLookup ResourceLookup, environmentLookup EnvironmentLookup,
 		}
 	}
 
-	baseService = mergeConfig(baseService, serviceData)
+	baseService = mergeConfigV1(baseService, serviceData)
 
 	logrus.Debugf("Merged result %#v", baseService)
 
@@ -176,4 +176,23 @@ func resolveContextV1(inFile string, serviceData RawService) RawService {
 	serviceData["build"] = current
 
 	return serviceData
+}
+
+func mergeConfigV1(baseService, serviceData RawService) RawService {
+	for k, v := range serviceData {
+		// Image and build are mutually exclusive in merge
+		if k == "image" {
+			delete(baseService, "build")
+		} else if k == "build" {
+			delete(baseService, "image")
+		}
+		existing, ok := baseService[k]
+		if ok {
+			baseService[k] = merge(existing, v)
+		} else {
+			baseService[k] = v
+		}
+	}
+
+	return baseService
 }


### PR DESCRIPTION
Previously one was getting removed due to the v1 logic getting applied.
Resolves #471

I broke apart the test cases into separate functions per version since the expected behavior is now different. Let me know if you want this organized differently.