### PR TITLE
Fix: load config before init NewConfigLookup

### DIFF
--- a/docker/project.go
+++ b/docker/project.go
@@ -19,6 +19,11 @@ import (
 
 // NewProject creates a Project with the specified context.
 func NewProject(context *ctx.Context, parseOptions *config.ParseOptions) (project.APIProject, error) {
+
+	if err := context.LookupConfig(); err != nil {
+		logrus.Errorf("Failed to load docker config: %v", err)
+	}
+
 	if context.AuthLookup == nil {
 		context.AuthLookup = auth.NewConfigLookup(context.ConfigFile)
 	}
@@ -57,11 +62,6 @@ func NewProject(context *ctx.Context, parseOptions *config.ParseOptions) (projec
 
 	err := p.Parse()
 	if err != nil {
-		return nil, err
-	}
-
-	if err = context.LookupConfig(); err != nil {
-		logrus.Errorf("Failed to open project %s: %v", p.Name, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
Fix default private registry login is not working due to false order of context.LookupConfig(). Basically user would like to define context.ConfigDir rather than define context.ConfigFile directly, and context.ConfigFile is parsed by context.LookupConfig(). In the previous code context.ConfigFile is used by context.AuthLookup but loaded after it.

Signed-off-by: Xi <hanx.azure22@gmail.com>