### PR TITLE
Use Network.RealName instead of Network.Name during network check

### DIFF
--- a/docker/service/service.go
+++ b/docker/service/service.go
@@ -357,7 +357,7 @@ func (s *Service) connectContainerToNetworks(ctx context.Context, c *container.C
 	}
 	if s.serviceConfig.Networks != nil {
 		for _, network := range s.serviceConfig.Networks.Networks {
-			existingNetwork, ok := connectedNetworks[network.Name]
+			existingNetwork, ok := connectedNetworks[network.RealName]
 			if ok {
 				// FIXME(vdemeester) implement alias checking (to not disconnect/reconnect for nothing)
 				aliasPresent := false


### PR DESCRIPTION
This PR changes how the check to determine if a container is already connected to a network is done. It uses `Network.RealName` instead of `Network.Name`.

A network defined inside `ServiceConfig.Networks` usually have the following properties:

* RealName: `projectname_networkname`
* Name: `networkname`

The network map returned by `Container.Networks()` use the first form (`projectname_networkname`) as keys.

Fix #480 

Signed-off-by: Anthony Lapenna <lapenna.anthony@gmail.com>