### PR TITLE
Add run option DisableTty

### DIFF
--- a/docker/container/container.go
+++ b/docker/container/container.go
@@ -180,6 +180,7 @@ func (c *Container) Run(ctx context.Context, configOverride *config.ServiceConfi
 		errCh       chan error
 		out, stderr io.Writer
 		in          io.ReadCloser
+		inFd        uintptr
 	)
 
 	if configOverride.StdinOpen {
@@ -202,14 +203,17 @@ func (c *Container) Run(ctx context.Context, configOverride *config.ServiceConfi
 		return -1, err
 	}
 
-	// set raw terminal
-	inFd, _ := term.GetFdInfo(in)
-	state, err := term.SetRawTerminal(inFd)
-	if err != nil {
-		return -1, err
+	if configOverride.StdinOpen {
+		// set raw terminal
+		inFd, _ = term.GetFdInfo(in)
+		state, err := term.SetRawTerminal(inFd)
+		if err != nil {
+			return -1, err
+		}
+		// restore raw terminal
+		defer term.RestoreTerminal(inFd, state)
 	}
-	// restore raw terminal
-	defer term.RestoreTerminal(inFd, state)
+
 	// holdHijackedConnection (in goroutine)
 	errCh = promise.Go(func() error {
 		return holdHijackedConnection(configOverride.Tty, in, out, stderr, resp)

--- a/docker/service/service.go
+++ b/docker/service/service.go
@@ -257,7 +257,7 @@ func (s *Service) Run(ctx context.Context, commandParts []string, options option
 		return -1, err
 	}
 
-	configOverride := &config.ServiceConfig{Command: commandParts, Tty: true, StdinOpen: true}
+	configOverride := &config.ServiceConfig{Command: commandParts, Tty: !options.DisableTty, StdinOpen: !options.DisableTty}
 
 	c, err := s.createContainer(ctx, namer, "", configOverride, true)
 	if err != nil {

--- a/project/options/types.go
+++ b/project/options/types.go
@@ -30,7 +30,8 @@ type Create struct {
 
 // Run holds options of compose run.
 type Run struct {
-	Detached bool
+	Detached   bool
+	DisableTty bool
 }
 
 // Up holds options of compose up.


### PR DESCRIPTION
When calling Run method on a project inside a docker container, it fails with "inappropriate ioctl for device".

os.Stdin is not a terminal, so term.SetRawTerminal fails. It also fails later because of configOverride.Tty set to true.

I added DisableTty option in order to maitain backward compatibility, set Tty and StdinOpen from this option in the service.Run method and disabled the use of a terminal in the container.Run method when tty is disabled
