### PR TITLE
adding ability to parse default bash variables such as ${foo:-bar} 

### DIFF
--- a/config/interpolation.go
+++ b/config/interpolation.go
@@ -15,7 +15,7 @@ func isNum(c uint8) bool {
 }
 
 func validVariableDefault(c uint8, line string, pos int) bool {
-	return c == ':' && line[pos+1] == '-'
+	return (c == ':' && line[pos+1] == '-') || (c == '-')
 }
 
 func validVariableNameChar(c uint8) bool {
@@ -45,6 +45,14 @@ func parseVariable(line string, pos int, mapping func(string) string) (string, i
 func parseDefaultValue(line string, pos int) (string, int, bool) {
 	var buffer bytes.Buffer
 
+	// only skip :, :- and - at the beginning
+	for ; pos < len(line); pos++ {
+		c := line[pos]
+		if c == ':' || c == '-' {
+			continue
+		}
+		break
+	}
 	for ; pos < len(line); pos++ {
 		c := line[pos]
 		if c == '}' {
@@ -76,7 +84,7 @@ func parseVariableWithBraces(line string, pos int, mapping func(string) string) 
 			buffer.WriteByte(c)
 		case validVariableDefault(c, line, pos):
 			defaultValue := ""
-			defaultValue, pos, _ = parseDefaultValue(line, pos+2)
+			defaultValue, pos, _ = parseDefaultValue(line, pos)
 			defaultValues[buffer.String()] = defaultValue
 		default:
 			return "", 0, false

--- a/config/interpolation.go
+++ b/config/interpolation.go
@@ -8,8 +8,14 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+var defaultValues = make(map[string]string)
+
 func isNum(c uint8) bool {
 	return c >= '0' && c <= '9'
+}
+
+func validVariableDefault(c uint8, line string, pos int) bool {
+	return c == ':' && line[pos+1] == '-'
 }
 
 func validVariableNameChar(c uint8) bool {
@@ -36,6 +42,22 @@ func parseVariable(line string, pos int, mapping func(string) string) (string, i
 	return mapping(buffer.String()), pos, true
 }
 
+func parseDefaultValue(line string, pos int) (string, int, bool) {
+	var buffer bytes.Buffer
+
+	for ; pos < len(line); pos++ {
+		c := line[pos]
+		if c == '}' {
+			return buffer.String(), pos - 1, true
+		}
+		err := buffer.WriteByte(c)
+		if err != nil {
+			return "", pos, false
+		}
+	}
+	return "", 0, false
+}
+
 func parseVariableWithBraces(line string, pos int, mapping func(string) string) (string, int, bool) {
 	var buffer bytes.Buffer
 
@@ -49,10 +71,13 @@ func parseVariableWithBraces(line string, pos int, mapping func(string) string) 
 			if bufferString == "" {
 				return "", 0, false
 			}
-
 			return mapping(buffer.String()), pos, true
 		case validVariableNameChar(c):
 			buffer.WriteByte(c)
+		case validVariableDefault(c, line, pos):
+			defaultValue := ""
+			defaultValue, pos, _ = parseDefaultValue(line, pos+2)
+			defaultValues[buffer.String()] = defaultValue
 		default:
 			return "", 0, false
 		}
@@ -143,8 +168,17 @@ func Interpolate(key string, data *interface{}, environmentLookup EnvironmentLoo
 		values := environmentLookup.Lookup(s, nil)
 
 		if len(values) == 0 {
+			if val, ok := defaultValues[s]; ok {
+				return val
+			}
 			logrus.Warnf("The %s variable is not set. Substituting a blank string.", s)
 			return ""
+		}
+
+		if strings.SplitN(values[0], "=", 2)[1] == "" {
+			if val, ok := defaultValues[s]; ok {
+				return val
+			}
 		}
 
 		// Use first result if many are given

--- a/config/interpolation_test.go
+++ b/config/interpolation_test.go
@@ -35,11 +35,14 @@ func TestParseLine(t *testing.T) {
 		"split_VaLue": "WORKED",
 		"9aNumber":    "WORKED",
 		"a9Number":    "WORKED",
+		"defTest":     "WORKED",
 	}
 
 	testInterpolatedLine(t, "WORKED", "$lower", variables)
 	testInterpolatedLine(t, "WORKED", "${MiXeD}", variables)
 	testInterpolatedLine(t, "WORKED", "${split_VaLue}", variables)
+	// make sure variable name is parsed correctly with default value
+	testInterpolatedLine(t, "WORKED", "${defTest:-sometest}", variables)
 	// Starting with a number isn't valid
 	testInterpolatedLine(t, "", "$9aNumber", variables)
 	testInterpolatedLine(t, "WORKED", "$a9Number", variables)
@@ -198,6 +201,43 @@ func TestInterpolate(t *testing.T) {
 			"HOST_PORT":   "=",
 			"LABEL_VALUE": "myvalue==",
 		})
+	// same as above but with default values
+	testInterpolatedConfig(t,
+		`web:
+  # unbracketed name
+  image: busybox
+
+  # array element
+  ports:
+    - "80:8000"
+
+  # dictionary item value
+  labels:
+    mylabel: "myvalue"
+
+  # unset value
+  hostname: "host-"
+
+  # escaped interpolation
+  command: "${ESCAPED}"`,
+
+		`web:
+  # unbracketed name
+  image: ${IMAGE:-busybox}
+
+  # array element
+  ports:
+    - "${HOST_PORT:-80}:8000"
+
+  # dictionary item value
+  labels:
+    mylabel: "${LABEL_VALUE:-myvalue}"
+
+  # unset value
+  hostname: "host-${UNSET_VALUE}"
+
+  # escaped interpolation
+  command: "$${ESCAPED}"`, map[string]string{})
 
 	testInvalidInterpolatedConfig(t,
 		`web:


### PR DESCRIPTION
title is pretty straight forward. This let's you add default values to your docker-compose file.
```
web:
# unbracketed name
image: ${IMAGE:-busybox}
```
parsers to
```
web:
# unbracketed name
image: busybox
```
```
web:
# unbracketed name
image: ${IMAGE-busybox}
```
parsers to
```
web:
# unbracketed name
image: busybox
```