### PR TITLE
Parse, validate, and load docker-compose v2.1 files

### DIFF
--- a/config/merge.go
+++ b/config/merge.go
@@ -9,6 +9,7 @@ import (
 
 	"reflect"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/urlutil"
 	"github.com/docker/libcompose/utils"
 	composeYaml "github.com/docker/libcompose/yaml"
@@ -110,17 +111,14 @@ func Merge(existingServices *ServiceConfigs, environmentLookup EnvironmentLookup
 		}
 	}
 
+	parts := strings.Split(config.Version, ".")
+	major, _ := strconv.Atoi(parts[0])
 	var serviceConfigs map[string]*ServiceConfig
 
-	switch config.Version {
-	case "2.1":
-		// STUB until we can properly validate and parse minor versions
-		var err error
-		serviceConfigs, err = MergeServicesV2(existingServices, environmentLookup, resourceLookup, file, baseRawServices, options)
-		if err != nil {
-			return "", nil, nil, nil, err
-		}
-	case "2":
+	switch major {
+	case 3:
+		logrus.Fatal("Note: Compose file version 3 is not yet implemented")
+	case 2:
 		var err error
 		serviceConfigs, err = MergeServicesV2(existingServices, environmentLookup, resourceLookup, file, baseRawServices, options)
 		if err != nil {

--- a/config/schema.go
+++ b/config/schema.go
@@ -191,7 +191,7 @@ var schemaDataV1 = `{
 }
 `
 
-var servicesSchemaDataV2 = `{
+var schemaDataV2 = `{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "config_schema_v2.0.json",
   "type": "object",
@@ -484,7 +484,7 @@ var servicesSchemaDataV2 = `{
 }
 `
 
-var servicesSchemaDataV2_1 = `{
+var schemaDataV2_1 = `{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "config_schema_v2.1.json",
   "type": "object",

--- a/config/schema.go
+++ b/config/schema.go
@@ -7,186 +7,186 @@ var schemaDataV1 = `{
   "type": "object",
 
   "patternProperties": {
-    "^[a-zA-Z0-9._-]+$": {
-      "$ref": "#/definitions/service"
-    }
+	"^[a-zA-Z0-9._-]+$": {
+	  "$ref": "#/definitions/service"
+	}
   },
 
   "additionalProperties": false,
 
   "definitions": {
-    "service": {
-      "id": "#/definitions/service",
-      "type": "object",
+	"service": {
+	  "id": "#/definitions/service",
+	  "type": "object",
 
-      "properties": {
-        "build": {"type": "string"},
-        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "cgroup_parent": {"type": "string"},
-        "command": {
-          "oneOf": [
-            {"type": "string"},
-            {"type": "array", "items": {"type": "string"}}
-          ]
-        },
-        "container_name": {"type": "string"},
-        "cpu_shares": {"type": ["number", "string"]},
-        "cpu_quota": {"type": ["number", "string"]},
-        "cpuset": {"type": "string"},
-        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "dns": {"$ref": "#/definitions/string_or_list"},
-        "dns_search": {"$ref": "#/definitions/string_or_list"},
-        "dockerfile": {"type": "string"},
-        "domainname": {"type": "string"},
-        "entrypoint": {
-          "oneOf": [
-            {"type": "string"},
-            {"type": "array", "items": {"type": "string"}}
-          ]
-        },
-        "env_file": {"$ref": "#/definitions/string_or_list"},
-        "environment": {"$ref": "#/definitions/list_or_dict"},
+	  "properties": {
+		"build": {"type": "string"},
+		"cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"cgroup_parent": {"type": "string"},
+		"command": {
+		  "oneOf": [
+			{"type": "string"},
+			{"type": "array", "items": {"type": "string"}}
+		  ]
+		},
+		"container_name": {"type": "string"},
+		"cpu_shares": {"type": ["number", "string"]},
+		"cpu_quota": {"type": ["number", "string"]},
+		"cpuset": {"type": "string"},
+		"devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"dns": {"$ref": "#/definitions/string_or_list"},
+		"dns_search": {"$ref": "#/definitions/string_or_list"},
+		"dockerfile": {"type": "string"},
+		"domainname": {"type": "string"},
+		"entrypoint": {
+		  "oneOf": [
+			{"type": "string"},
+			{"type": "array", "items": {"type": "string"}}
+		  ]
+		},
+		"env_file": {"$ref": "#/definitions/string_or_list"},
+		"environment": {"$ref": "#/definitions/list_or_dict"},
 
-        "expose": {
-          "type": "array",
-          "items": {
-            "type": ["string", "number"],
-            "format": "expose"
-          },
-          "uniqueItems": true
-        },
+		"expose": {
+		  "type": "array",
+		  "items": {
+			"type": ["string", "number"],
+			"format": "expose"
+		  },
+		  "uniqueItems": true
+		},
 
-        "extends": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object",
+		"extends": {
+		  "oneOf": [
+			{
+			  "type": "string"
+			},
+			{
+			  "type": "object",
 
-              "properties": {
-                "service": {"type": "string"},
-                "file": {"type": "string"}
-              },
-              "required": ["service"],
-              "additionalProperties": false
-            }
-          ]
-        },
+			  "properties": {
+				"service": {"type": "string"},
+				"file": {"type": "string"}
+			  },
+			  "required": ["service"],
+			  "additionalProperties": false
+			}
+		  ]
+		},
 
-        "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
-        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "hostname": {"type": "string"},
-        "image": {"type": "string"},
-        "ipc": {"type": "string"},
-        "labels": {"$ref": "#/definitions/list_or_dict"},
-        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "log_driver": {"type": "string"},
-        "log_opt": {"type": "object"},
-        "mac_address": {"type": "string"},
-        "mem_limit": {"type": ["number", "string"]},
-        "mem_reservation": {"type": ["number", "string"]},
-        "memswap_limit": {"type": ["number", "string"]},
-        "mem_swappiness": {"type": "integer"},
-        "net": {"type": "string"},
-        "pid": {"type": ["string", "null"]},
+		"extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+		"external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"hostname": {"type": "string"},
+		"image": {"type": "string"},
+		"ipc": {"type": "string"},
+		"labels": {"$ref": "#/definitions/list_or_dict"},
+		"links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"log_driver": {"type": "string"},
+		"log_opt": {"type": "object"},
+		"mac_address": {"type": "string"},
+		"mem_limit": {"type": ["number", "string"]},
+		"mem_reservation": {"type": ["number", "string"]},
+		"memswap_limit": {"type": ["number", "string"]},
+		"mem_swappiness": {"type": "integer"},
+		"net": {"type": "string"},
+		"pid": {"type": ["string", "null"]},
 
-        "ports": {
-          "type": "array",
-          "items": {
-            "type": ["string", "number"],
-            "format": "ports"
-          },
-          "uniqueItems": true
-        },
+		"ports": {
+		  "type": "array",
+		  "items": {
+			"type": ["string", "number"],
+			"format": "ports"
+		  },
+		  "uniqueItems": true
+		},
 
-        "privileged": {"type": "boolean"},
-        "read_only": {"type": "boolean"},
-        "restart": {"type": "string"},
-        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "shm_size": {"type": ["number", "string"]},
-        "stdin_open": {"type": "boolean"},
-        "stop_signal": {"type": "string"},
-        "tty": {"type": "boolean"},
-        "ulimits": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-z]+$": {
-              "oneOf": [
-                {"type": "integer"},
-                {
-                  "type":"object",
-                  "properties": {
-                    "hard": {"type": "integer"},
-                    "soft": {"type": "integer"}
-                  },
-                  "required": ["soft", "hard"],
-                  "additionalProperties": false
-                }
-              ]
-            }
-          }
-        },
-        "user": {"type": "string"},
-        "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "volume_driver": {"type": "string"},
-        "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
-      },
+		"privileged": {"type": "boolean"},
+		"read_only": {"type": "boolean"},
+		"restart": {"type": "string"},
+		"security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"shm_size": {"type": ["number", "string"]},
+		"stdin_open": {"type": "boolean"},
+		"stop_signal": {"type": "string"},
+		"tty": {"type": "boolean"},
+		"ulimits": {
+		  "type": "object",
+		  "patternProperties": {
+			"^[a-z]+$": {
+			  "oneOf": [
+				{"type": "integer"},
+				{
+				  "type":"object",
+				  "properties": {
+					"hard": {"type": "integer"},
+					"soft": {"type": "integer"}
+				  },
+				  "required": ["soft", "hard"],
+				  "additionalProperties": false
+				}
+			  ]
+			}
+		  }
+		},
+		"user": {"type": "string"},
+		"volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"volume_driver": {"type": "string"},
+		"volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"working_dir": {"type": "string"}
+	  },
 
-      "dependencies": {
-        "memswap_limit": ["mem_limit"]
-      },
-      "additionalProperties": false
-    },
+	  "dependencies": {
+		"memswap_limit": ["mem_limit"]
+	  },
+	  "additionalProperties": false
+	},
 
-    "string_or_list": {
-      "oneOf": [
-        {"type": "string"},
-        {"$ref": "#/definitions/list_of_strings"}
-      ]
-    },
+	"string_or_list": {
+	  "oneOf": [
+		{"type": "string"},
+		{"$ref": "#/definitions/list_of_strings"}
+	  ]
+	},
 
-    "list_of_strings": {
-      "type": "array",
-      "items": {"type": "string"},
-      "uniqueItems": true
-    },
+	"list_of_strings": {
+	  "type": "array",
+	  "items": {"type": "string"},
+	  "uniqueItems": true
+	},
 
-    "list_or_dict": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
+	"list_or_dict": {
+	  "oneOf": [
+		{
+		  "type": "object",
+		  "patternProperties": {
+			".+": {
+			  "type": ["string", "number", "null"]
+			}
+		  },
+		  "additionalProperties": false
+		},
+		{"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+	  ]
+	},
 
-    "constraints": {
-      "service": {
-        "id": "#/definitions/constraints/service",
-        "anyOf": [
-          {
-            "required": ["build"],
-            "not": {"required": ["image"]}
-          },
-          {
-            "required": ["image"],
-            "not": {"anyOf": [
-              {"required": ["build"]},
-              {"required": ["dockerfile"]}
-            ]}
-          }
-        ]
-      }
-    }
+	"constraints": {
+	  "service": {
+		"id": "#/definitions/constraints/service",
+		"anyOf": [
+		  {
+			"required": ["build"],
+			"not": {"required": ["image"]}
+		  },
+		  {
+			"required": ["image"],
+			"not": {"anyOf": [
+			  {"required": ["build"]},
+			  {"required": ["dockerfile"]}
+			]}
+		  }
+		]
+	  }
+	}
   }
 }
 `
@@ -197,289 +197,732 @@ var servicesSchemaDataV2 = `{
   "type": "object",
 
   "patternProperties": {
-    "^[a-zA-Z0-9._-]+$": {
-      "$ref": "#/definitions/service"
-    }
+	"^[a-zA-Z0-9._-]+$": {
+	  "$ref": "#/definitions/service"
+	}
   },
 
   "additionalProperties": false,
 
   "definitions": {
 
-    "service": {
-      "id": "#/definitions/service",
-      "type": "object",
+	"service": {
+	  "id": "#/definitions/service",
+	  "type": "object",
 
-      "properties": {
-        "build": {
-          "oneOf": [
-            {"type": "string"},
-            {
-              "type": "object",
-              "properties": {
-                "context": {"type": "string"},
-                "dockerfile": {"type": "string"},
-                "args": {"$ref": "#/definitions/list_or_dict"}
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
-        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "cgroup_parent": {"type": "string"},
-        "command": {
-          "oneOf": [
-            {"type": "string"},
-            {"type": "array", "items": {"type": "string"}}
-          ]
-        },
-        "container_name": {"type": "string"},
-        "cpu_shares": {"type": ["number", "string"]},
-        "cpu_quota": {"type": ["number", "string"]},
-        "cpuset": {"type": "string"},
-        "depends_on": {"$ref": "#/definitions/list_of_strings"},
-        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "dns": {"$ref": "#/definitions/string_or_list"},
-        "dns_search": {"$ref": "#/definitions/string_or_list"},
-        "domainname": {"type": "string"},
-        "entrypoint": {
-          "oneOf": [
-            {"type": "string"},
-            {"type": "array", "items": {"type": "string"}}
-          ]
-        },
-        "env_file": {"$ref": "#/definitions/string_or_list"},
-        "environment": {"$ref": "#/definitions/list_or_dict"},
+	  "properties": {
+		"build": {
+		  "oneOf": [
+			{"type": "string"},
+			{
+			  "type": "object",
+			  "properties": {
+				"context": {"type": "string"},
+				"dockerfile": {"type": "string"},
+				"args": {"$ref": "#/definitions/list_or_dict"}
+			  },
+			  "additionalProperties": false
+			}
+		  ]
+		},
+		"cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"cgroup_parent": {"type": "string"},
+		"command": {
+		  "oneOf": [
+			{"type": "string"},
+			{"type": "array", "items": {"type": "string"}}
+		  ]
+		},
+		"container_name": {"type": "string"},
+		"cpu_shares": {"type": ["number", "string"]},
+		"cpu_quota": {"type": ["number", "string"]},
+		"cpuset": {"type": "string"},
+		"depends_on": {"$ref": "#/definitions/list_of_strings"},
+		"devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"dns": {"$ref": "#/definitions/string_or_list"},
+		"dns_search": {"$ref": "#/definitions/string_or_list"},
+		"domainname": {"type": "string"},
+		"entrypoint": {
+		  "oneOf": [
+			{"type": "string"},
+			{"type": "array", "items": {"type": "string"}}
+		  ]
+		},
+		"env_file": {"$ref": "#/definitions/string_or_list"},
+		"environment": {"$ref": "#/definitions/list_or_dict"},
 
-        "expose": {
-          "type": "array",
-          "items": {
-            "type": ["string", "number"],
-            "format": "expose"
-          },
-          "uniqueItems": true
-        },
+		"expose": {
+		  "type": "array",
+		  "items": {
+			"type": ["string", "number"],
+			"format": "expose"
+		  },
+		  "uniqueItems": true
+		},
 
-        "extends": {
-          "oneOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "object",
+		"extends": {
+		  "oneOf": [
+			{
+			  "type": "string"
+			},
+			{
+			  "type": "object",
 
-              "properties": {
-                "service": {"type": "string"},
-                "file": {"type": "string"}
-              },
-              "required": ["service"],
-              "additionalProperties": false
-            }
-          ]
-        },
+			  "properties": {
+				"service": {"type": "string"},
+				"file": {"type": "string"}
+			  },
+			  "required": ["service"],
+			  "additionalProperties": false
+			}
+		  ]
+		},
 
-        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
-        "group_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "hostname": {"type": "string"},
-        "image": {"type": "string"},
-        "ipc": {"type": "string"},
-        "labels": {"$ref": "#/definitions/list_or_dict"},
-        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+		"group_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"hostname": {"type": "string"},
+		"image": {"type": "string"},
+		"ipc": {"type": "string"},
+		"labels": {"$ref": "#/definitions/list_or_dict"},
+		"links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
 
-        "logging": {
-            "type": "object",
+		"logging": {
+			"type": "object",
 
-            "properties": {
-                "driver": {"type": "string"},
-                "options": {"type": "object"}
-            },
-            "additionalProperties": false
-        },
+			"properties": {
+				"driver": {"type": "string"},
+				"options": {"type": "object"}
+			},
+			"additionalProperties": false
+		},
 
-        "mac_address": {"type": "string"},
-        "mem_limit": {"type": ["number", "string"]},
-        "mem_reservation": {"type": ["number", "string"]},
-        "memswap_limit": {"type": ["number", "string"]},
-        "mem_swappiness": {"type": "integer"},
-        "network_mode": {"type": "string"},
+		"mac_address": {"type": "string"},
+		"mem_limit": {"type": ["number", "string"]},
+		"mem_reservation": {"type": ["number", "string"]},
+		"memswap_limit": {"type": ["number", "string"]},
+		"mem_swappiness": {"type": "integer"},
+		"network_mode": {"type": "string"},
 
-        "networks": {
-          "oneOf": [
-            {"$ref": "#/definitions/list_of_strings"},
-            {
-              "type": "object",
-              "patternProperties": {
-                "^[a-zA-Z0-9._-]+$": {
-                  "oneOf": [
-                    {
-                      "type": "object",
-                      "properties": {
-                        "aliases": {"$ref": "#/definitions/list_of_strings"},
-                        "ipv4_address": {"type": "string"},
-                        "ipv6_address": {"type": "string"}
-                      },
-                      "additionalProperties": false
-                    },
-                    {"type": "null"}
-                  ]
-                }
-              },
-              "additionalProperties": false
-            }
-          ]
-        },
-        "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
-        "pid": {"type": ["string", "null"]},
+		"networks": {
+		  "oneOf": [
+			{"$ref": "#/definitions/list_of_strings"},
+			{
+			  "type": "object",
+			  "patternProperties": {
+				"^[a-zA-Z0-9._-]+$": {
+				  "oneOf": [
+					{
+					  "type": "object",
+					  "properties": {
+						"aliases": {"$ref": "#/definitions/list_of_strings"},
+						"ipv4_address": {"type": "string"},
+						"ipv6_address": {"type": "string"}
+					  },
+					  "additionalProperties": false
+					},
+					{"type": "null"}
+				  ]
+				}
+			  },
+			  "additionalProperties": false
+			}
+		  ]
+		},
+		"oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
+		"pid": {"type": ["string", "null"]},
 
-        "ports": {
-          "type": "array",
-          "items": {
-            "type": ["string", "number"],
-            "format": "ports"
-          },
-          "uniqueItems": true
-        },
+		"ports": {
+		  "type": "array",
+		  "items": {
+			"type": ["string", "number"],
+			"format": "ports"
+		  },
+		  "uniqueItems": true
+		},
 
-        "privileged": {"type": "boolean"},
-        "read_only": {"type": "boolean"},
-        "restart": {"type": "string"},
-        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "shm_size": {"type": ["number", "string"]},
-        "stdin_open": {"type": "boolean"},
-        "stop_grace_period": {"type": "string"},
-        "stop_signal": {"type": "string"},
-        "tmpfs": {"$ref": "#/definitions/string_or_list"},
-        "tty": {"type": "boolean"},
-        "ulimits": {
-          "type": "object",
-          "patternProperties": {
-            "^[a-z]+$": {
-              "oneOf": [
-                {"type": "integer"},
-                {
-                  "type":"object",
-                  "properties": {
-                    "hard": {"type": "integer"},
-                    "soft": {"type": "integer"}
-                  },
-                  "required": ["soft", "hard"],
-                  "additionalProperties": false
-                }
-              ]
-            }
-          }
-        },
-        "user": {"type": "string"},
-        "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "volume_driver": {"type": "string"},
-        "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
-        "working_dir": {"type": "string"}
-      },
+		"privileged": {"type": "boolean"},
+		"read_only": {"type": "boolean"},
+		"restart": {"type": "string"},
+		"security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"shm_size": {"type": ["number", "string"]},
+		"stdin_open": {"type": "boolean"},
+		"stop_grace_period": {"type": "string"},
+		"stop_signal": {"type": "string"},
+		"tmpfs": {"$ref": "#/definitions/string_or_list"},
+		"tty": {"type": "boolean"},
+		"ulimits": {
+		  "type": "object",
+		  "patternProperties": {
+			"^[a-z]+$": {
+			  "oneOf": [
+				{"type": "integer"},
+				{
+				  "type":"object",
+				  "properties": {
+					"hard": {"type": "integer"},
+					"soft": {"type": "integer"}
+				  },
+				  "required": ["soft", "hard"],
+				  "additionalProperties": false
+				}
+			  ]
+			}
+		  }
+		},
+		"user": {"type": "string"},
+		"volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"volume_driver": {"type": "string"},
+		"volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"working_dir": {"type": "string"}
+	  },
 
-      "dependencies": {
-        "memswap_limit": ["mem_limit"]
-      },
-      "additionalProperties": false
-    },
+	  "dependencies": {
+		"memswap_limit": ["mem_limit"]
+	  },
+	  "additionalProperties": false
+	},
 
-    "network": {
-      "id": "#/definitions/network",
-      "type": "object",
-      "properties": {
-        "driver": {"type": "string"},
-        "driver_opts": {
-          "type": "object",
-          "patternProperties": {
-            "^.+$": {"type": ["string", "number"]}
-          }
-        },
-        "ipam": {
-            "type": "object",
-            "properties": {
-                "driver": {"type": "string"},
-                "config": {
-                    "type": "array"
-                }
-            },
-            "additionalProperties": false
-        },
-        "external": {
-          "type": ["boolean", "object"],
-          "properties": {
-            "name": {"type": "string"}
-          },
-          "additionalProperties": false
-        },
-        "internal": {"type": "boolean"}
-      },
-      "additionalProperties": false
-    },
+	"network": {
+	  "id": "#/definitions/network",
+	  "type": "object",
+	  "properties": {
+		"driver": {"type": "string"},
+		"driver_opts": {
+		  "type": "object",
+		  "patternProperties": {
+			"^.+$": {"type": ["string", "number"]}
+		  }
+		},
+		"ipam": {
+			"type": "object",
+			"properties": {
+				"driver": {"type": "string"},
+				"config": {
+					"type": "array"
+				}
+			},
+			"additionalProperties": false
+		},
+		"external": {
+		  "type": ["boolean", "object"],
+		  "properties": {
+			"name": {"type": "string"}
+		  },
+		  "additionalProperties": false
+		},
+		"internal": {"type": "boolean"}
+	  },
+	  "additionalProperties": false
+	},
 
-    "volume": {
-      "id": "#/definitions/volume",
-      "type": ["object", "null"],
-      "properties": {
-        "driver": {"type": "string"},
-        "driver_opts": {
-          "type": "object",
-          "patternProperties": {
-            "^.+$": {"type": ["string", "number"]}
-          }
-        },
-        "external": {
-          "type": ["boolean", "object"],
-          "properties": {
-            "name": {"type": "string"}
-          }
-        }
-      },
-      "additionalProperties": false
-    },
+	"volume": {
+	  "id": "#/definitions/volume",
+	  "type": ["object", "null"],
+	  "properties": {
+		"driver": {"type": "string"},
+		"driver_opts": {
+		  "type": "object",
+		  "patternProperties": {
+			"^.+$": {"type": ["string", "number"]}
+		  }
+		},
+		"external": {
+		  "type": ["boolean", "object"],
+		  "properties": {
+			"name": {"type": "string"}
+		  }
+		}
+	  },
+	  "additionalProperties": false
+	},
 
-    "string_or_list": {
-      "oneOf": [
-        {"type": "string"},
-        {"$ref": "#/definitions/list_of_strings"}
-      ]
-    },
+	"string_or_list": {
+	  "oneOf": [
+		{"type": "string"},
+		{"$ref": "#/definitions/list_of_strings"}
+	  ]
+	},
 
-    "list_of_strings": {
-      "type": "array",
-      "items": {"type": "string"},
-      "uniqueItems": true
-    },
+	"list_of_strings": {
+	  "type": "array",
+	  "items": {"type": "string"},
+	  "uniqueItems": true
+	},
 
-    "list_or_dict": {
-      "oneOf": [
-        {
-          "type": "object",
-          "patternProperties": {
-            ".+": {
-              "type": ["string", "number", "null"]
-            }
-          },
-          "additionalProperties": false
-        },
-        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
-      ]
-    },
+	"list_or_dict": {
+	  "oneOf": [
+		{
+		  "type": "object",
+		  "patternProperties": {
+			".+": {
+			  "type": ["string", "number", "null"]
+			}
+		  },
+		  "additionalProperties": false
+		},
+		{"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+	  ]
+	},
 
-    "constraints": {
-      "service": {
-        "id": "#/definitions/constraints/service",
-        "anyOf": [
-          {"required": ["build"]},
-          {"required": ["image"]}
-        ],
-        "properties": {
-          "build": {
-            "required": ["context"]
-          }
-        }
-      }
-    }
+	"constraints": {
+	  "service": {
+		"id": "#/definitions/constraints/service",
+		"anyOf": [
+		  {"required": ["build"]},
+		  {"required": ["image"]}
+		],
+		"properties": {
+		  "build": {
+			"required": ["context"]
+		  }
+		}
+	  }
+	}
+  }
+}
+`
+
+var servicesSchemaDataV2_1 = `{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "config_schema_v2.1.json",
+  "type": "object",
+
+  "properties": {
+	"version": {
+	  "type": "string"
+	},
+
+	"services": {
+	  "id": "#/properties/services",
+	  "type": "object",
+	  "patternProperties": {
+		"^[a-zA-Z0-9._-]+$": {
+		  "$ref": "#/definitions/service"
+		}
+	  },
+	  "additionalProperties": false
+	},
+
+	"networks": {
+	  "id": "#/properties/networks",
+	  "type": "object",
+	  "patternProperties": {
+		"^[a-zA-Z0-9._-]+$": {
+		  "$ref": "#/definitions/network"
+		}
+	  }
+	},
+
+	"volumes": {
+	  "id": "#/properties/volumes",
+	  "type": "object",
+	  "patternProperties": {
+		"^[a-zA-Z0-9._-]+$": {
+		  "$ref": "#/definitions/volume"
+		}
+	  },
+	  "additionalProperties": false
+	}
+  },
+
+  "patternProperties": {"^x-": {}},
+  "additionalProperties": false,
+
+  "definitions": {
+
+	"service": {
+	  "id": "#/definitions/service",
+	  "type": "object",
+
+	  "properties": {
+		"blkio_config": {
+		  "type": "object",
+		  "properties": {
+			"device_read_bps": {
+			  "type": "array",
+			  "items": {"$ref": "#/definitions/blkio_limit"}
+			},
+			"device_read_iops": {
+			  "type": "array",
+			  "items": {"$ref": "#/definitions/blkio_limit"}
+			},
+			"device_write_bps": {
+			  "type": "array",
+			  "items": {"$ref": "#/definitions/blkio_limit"}
+			},
+			"device_write_iops": {
+			  "type": "array",
+			  "items": {"$ref": "#/definitions/blkio_limit"}
+			},
+			"weight": {"type": "integer"},
+			"weight_device": {
+			  "type": "array",
+			  "items": {"$ref": "#/definitions/blkio_weight"}
+			}
+		  },
+		  "additionalProperties": false
+		},
+
+		"build": {
+		  "oneOf": [
+			{"type": "string"},
+			{
+			  "type": "object",
+			  "properties": {
+				"context": {"type": "string"},
+				"dockerfile": {"type": "string"},
+				"args": {"$ref": "#/definitions/list_or_dict"},
+				"labels": {"$ref": "#/definitions/list_or_dict"}
+			  },
+			  "additionalProperties": false
+			}
+		  ]
+		},
+		"cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"cgroup_parent": {"type": "string"},
+		"command": {
+		  "oneOf": [
+			{"type": "string"},
+			{"type": "array", "items": {"type": "string"}}
+		  ]
+		},
+		"container_name": {"type": "string"},
+		"cpu_shares": {"type": ["number", "string"]},
+		"cpu_quota": {"type": ["number", "string"]},
+		"cpuset": {"type": "string"},
+		"depends_on": {
+		  "oneOf": [
+			{"$ref": "#/definitions/list_of_strings"},
+			{
+			  "type": "object",
+			  "additionalProperties": false,
+			  "patternProperties": {
+				"^[a-zA-Z0-9._-]+$": {
+				  "type": "object",
+				  "additionalProperties": false,
+				  "properties": {
+					"condition": {
+					  "type": "string",
+					  "enum": ["service_started", "service_healthy"]
+					}
+				  },
+				  "required": ["condition"]
+				}
+			  }
+			}
+		  ]
+		},
+		"devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"dns_opt": {
+		  "type": "array",
+		  "items": {
+			"type": "string"
+		  },
+		  "uniqueItems": true
+		},
+		"dns": {"$ref": "#/definitions/string_or_list"},
+		"dns_search": {"$ref": "#/definitions/string_or_list"},
+		"domainname": {"type": "string"},
+		"entrypoint": {
+		  "oneOf": [
+			{"type": "string"},
+			{"type": "array", "items": {"type": "string"}}
+		  ]
+		},
+		"env_file": {"$ref": "#/definitions/string_or_list"},
+		"environment": {"$ref": "#/definitions/list_or_dict"},
+
+		"expose": {
+		  "type": "array",
+		  "items": {
+			"type": ["string", "number"],
+			"format": "expose"
+		  },
+		  "uniqueItems": true
+		},
+
+		"extends": {
+		  "oneOf": [
+			{
+			  "type": "string"
+			},
+			{
+			  "type": "object",
+
+			  "properties": {
+				"service": {"type": "string"},
+				"file": {"type": "string"}
+			  },
+			  "required": ["service"],
+			  "additionalProperties": false
+			}
+		  ]
+		},
+
+		"external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+		"healthcheck": {"$ref": "#/definitions/healthcheck"},
+		"hostname": {"type": "string"},
+		"image": {"type": "string"},
+		"ipc": {"type": "string"},
+		"isolation": {"type": "string"},
+		"labels": {"$ref": "#/definitions/list_or_dict"},
+		"links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+
+		"logging": {
+			"type": "object",
+
+			"properties": {
+				"driver": {"type": "string"},
+				"options": {"type": "object"}
+			},
+			"additionalProperties": false
+		},
+
+		"mac_address": {"type": "string"},
+		"mem_limit": {"type": ["number", "string"]},
+		"mem_reservation": {"type": ["string", "integer"]},
+		"mem_swappiness": {"type": "integer"},
+		"memswap_limit": {"type": ["number", "string"]},
+		"network_mode": {"type": "string"},
+
+		"networks": {
+		  "oneOf": [
+			{"$ref": "#/definitions/list_of_strings"},
+			{
+			  "type": "object",
+			  "patternProperties": {
+				"^[a-zA-Z0-9._-]+$": {
+				  "oneOf": [
+					{
+					  "type": "object",
+					  "properties": {
+						"aliases": {"$ref": "#/definitions/list_of_strings"},
+						"ipv4_address": {"type": "string"},
+						"ipv6_address": {"type": "string"},
+						"link_local_ips": {"$ref": "#/definitions/list_of_strings"}
+					  },
+					  "additionalProperties": false
+					},
+					{"type": "null"}
+				  ]
+				}
+			  },
+			  "additionalProperties": false
+			}
+		  ]
+		},
+		"oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
+		"group_add": {
+			"type": "array",
+			"items": {
+				"type": ["string", "number"]
+			},
+			"uniqueItems": true
+		},
+		"pid": {"type": ["string", "null"]},
+
+		"ports": {
+		  "type": "array",
+		  "items": {
+			"type": ["string", "number"],
+			"format": "ports"
+		  },
+		  "uniqueItems": true
+		},
+
+		"privileged": {"type": "boolean"},
+		"read_only": {"type": "boolean"},
+		"restart": {"type": "string"},
+		"security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"shm_size": {"type": ["number", "string"]},
+		"sysctls": {"$ref": "#/definitions/list_or_dict"},
+		"pids_limit": {"type": ["number", "string"]},
+		"stdin_open": {"type": "boolean"},
+		"stop_grace_period": {"type": "string", "format": "duration"},
+		"stop_signal": {"type": "string"},
+		"storage_opt": {"type": "object"},
+		"tmpfs": {"$ref": "#/definitions/string_or_list"},
+		"tty": {"type": "boolean"},
+		"ulimits": {
+		  "type": "object",
+		  "patternProperties": {
+			"^[a-z]+$": {
+			  "oneOf": [
+				{"type": "integer"},
+				{
+				  "type":"object",
+				  "properties": {
+					"hard": {"type": "integer"},
+					"soft": {"type": "integer"}
+				  },
+				  "required": ["soft", "hard"],
+				  "additionalProperties": false
+				}
+			  ]
+			}
+		  }
+		},
+		"user": {"type": "string"},
+		"userns_mode": {"type": "string"},
+		"volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"volume_driver": {"type": "string"},
+		"volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+		"working_dir": {"type": "string"}
+	  },
+
+	  "dependencies": {
+		"memswap_limit": ["mem_limit"]
+	  },
+	  "additionalProperties": false
+	},
+
+	"healthcheck": {
+	  "id": "#/definitions/healthcheck",
+	  "type": "object",
+	  "additionalProperties": false,
+	  "properties": {
+		"disable": {"type": "boolean"},
+		"interval": {"type": "string"},
+		"retries": {"type": "number"},
+		"test": {
+		  "oneOf": [
+			{"type": "string"},
+			{"type": "array", "items": {"type": "string"}}
+		  ]
+		},
+		"timeout": {"type": "string"}
+	  }
+	},
+
+	"network": {
+	  "id": "#/definitions/network",
+	  "type": "object",
+	  "properties": {
+		"driver": {"type": "string"},
+		"driver_opts": {
+		  "type": "object",
+		  "patternProperties": {
+			"^.+$": {"type": ["string", "number"]}
+		  }
+		},
+		"ipam": {
+			"type": "object",
+			"properties": {
+				"driver": {"type": "string"},
+				"config": {
+					"type": "array"
+				},
+				"options": {
+				  "type": "object",
+				  "patternProperties": {
+					"^.+$": {"type": "string"}
+				  },
+				  "additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"external": {
+		  "type": ["boolean", "object"],
+		  "properties": {
+			"name": {"type": "string"}
+		  },
+		  "additionalProperties": false
+		},
+		"internal": {"type": "boolean"},
+		"enable_ipv6": {"type": "boolean"},
+		"labels": {"$ref": "#/definitions/list_or_dict"}
+	  },
+	  "additionalProperties": false
+	},
+
+	"volume": {
+	  "id": "#/definitions/volume",
+	  "type": ["object", "null"],
+	  "properties": {
+		"driver": {"type": "string"},
+		"driver_opts": {
+		  "type": "object",
+		  "patternProperties": {
+			"^.+$": {"type": ["string", "number"]}
+		  }
+		},
+		"external": {
+		  "type": ["boolean", "object"],
+		  "properties": {
+			"name": {"type": "string"}
+		  },
+		  "additionalProperties": false
+		},
+		"labels": {"$ref": "#/definitions/list_or_dict"},
+		"name": {"type": "string"}
+	  },
+	  "additionalProperties": false
+	},
+
+	"string_or_list": {
+	  "oneOf": [
+		{"type": "string"},
+		{"$ref": "#/definitions/list_of_strings"}
+	  ]
+	},
+
+	"list_of_strings": {
+	  "type": "array",
+	  "items": {"type": "string"},
+	  "uniqueItems": true
+	},
+
+	"list_or_dict": {
+	  "oneOf": [
+		{
+		  "type": "object",
+		  "patternProperties": {
+			".+": {
+			  "type": ["string", "number", "null"]
+			}
+		  },
+		  "additionalProperties": false
+		},
+		{"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+	  ]
+	},
+
+	"blkio_limit": {
+	  "type": "object",
+	  "properties": {
+		"path": {"type": "string"},
+		"rate": {"type": ["integer", "string"]}
+	  },
+	  "additionalProperties": false
+	},
+	"blkio_weight": {
+	  "type": "object",
+	  "properties": {
+		"path": {"type": "string"},
+		"weight": {"type": "integer"}
+	  },
+	  "additionalProperties": false
+	},
+
+	"constraints": {
+	  "service": {
+		"id": "#/definitions/constraints/service",
+		"anyOf": [
+		  {"required": ["build"]},
+		  {"required": ["image"]}
+		],
+		"properties": {
+		  "build": {
+			"required": ["context"]
+		  }
+		}
+	  }
+	}
   }
 }
 `

--- a/config/schema_helpers.go
+++ b/config/schema_helpers.go
@@ -2,39 +2,62 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/docker/go-connections/nat"
 	"github.com/xeipuuv/gojsonschema"
 )
 
-var (
-	schemaLoaderV1           gojsonschema.JSONLoader
-	constraintSchemaLoaderV1 gojsonschema.JSONLoader
+// Schema represents the various gojsonschema utilites we'll use with our parsed
+// JSON schema data.
+type Schema struct {
+	Loader            gojsonschema.JSONLoader
+	ConstraintsLoader gojsonschema.JSONLoader
+	Data              map[string]interface{}
+}
 
-	schemaLoaderV2           gojsonschema.JSONLoader
-	constraintSchemaLoaderV2 gojsonschema.JSONLoader
+// SchemaRegistry represents our map of Compose versions to Schema objects.
+type SchemaRegistry map[string]*Schema
 
-	schemaLoaderV2_1           gojsonschema.JSONLoader
-	constraintSchemaLoaderV2_1 gojsonschema.JSONLoader
+// GetVersion
+func (reg SchemaRegistry) GetVersion(version string) (*Schema, error) {
+	if schema, ok := reg[version]; ok {
+		return schema, nil
+	}
+	return nil, fmt.Errorf("couldn't load JSON schema '%s'")
+}
 
-	schemaV1   map[string]interface{}
-	schemaV2   map[string]interface{}
-	schemaV2_1 map[string]interface{}
-)
+var schemaRegistry SchemaRegistry
 
+// Initialize our app's schemaRegistry which maps Compose version numbers to
+// various JSON schemas.
 func init() {
-	if err := setupSchemaLoaders(schemaDataV1, &schemaV1, &schemaLoaderV1, &constraintSchemaLoaderV1); err != nil {
-		panic(err)
+	var err error
+	schemaRegistry, err = NewSchemaRegistry(map[string]string{
+		"":    schemaDataV1,
+		"2":   schemaDataV2,
+		"2.0": schemaDataV2,
+		"2.1": schemaDataV2_1,
+	})
+	if err != nil {
+		logrus.Fatalf("can't init JSON schema registry:", err)
 	}
+}
 
-	if err := setupSchemaLoaders(servicesSchemaDataV2, &schemaV2, &schemaLoaderV2, &constraintSchemaLoaderV2); err != nil {
-		panic(err)
+// NewSchemaRegistry creates a new SchemaRegistry which converts a map of
+// versions to JSON schemas into versions and proper Schema objects.
+func NewSchemaRegistry(schemaData map[string]string) (map[string]*Schema, error) {
+	schemaRegistry := make(map[string]*Schema)
+	for version, data := range schemaData {
+		schema, err := NewSchema(data)
+		if err != nil {
+			return nil, fmt.Errorf("can't load JSON schema:", err)
+		}
+		schemaRegistry[version] = schema
 	}
-
-	if err := setupSchemaLoaders(servicesSchemaDataV2_1, &schemaV2_1, &schemaLoaderV2_1, &constraintSchemaLoaderV2_1); err != nil {
-		panic(err)
-	}
+	return schemaRegistry, nil
 }
 
 type (
@@ -44,8 +67,12 @@ type (
 
 func (checker environmentFormatChecker) IsFormat(input string) bool {
 	// If the value is a boolean, a warning should be given
-	// However, we can't determine type since gojsonschema converts the value to a string
-	// Adding a function with an interface{} parameter to gojsonschema is probably the best way to handle this
+	//
+	// However, we can't determine type since gojsonschema converts the value to
+	// a string
+	//
+	// Adding a function with an interface{} parameter to gojsonschema is
+	// probably the best way to handle this
 	return true
 }
 
@@ -54,30 +81,32 @@ func (checker portsFormatChecker) IsFormat(input string) bool {
 	return err == nil
 }
 
-func setupSchemaLoaders(schemaData string, schema *map[string]interface{}, schemaLoader, constraintSchemaLoader *gojsonschema.JSONLoader) error {
-	if *schema != nil {
-		return nil
-	}
-
-	var schemaRaw interface{}
-	err := json.Unmarshal([]byte(schemaData), &schemaRaw)
+// NewSchema constructs a new Schema including parsing and initializing JSON
+// schema loaders used to validate sections of a Compose file.
+func NewSchema(schemaJSON string) (*Schema, error) {
+	var schemaParsed interface{}
+	err := json.Unmarshal([]byte(schemaJSON), &schemaParsed)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	*schema = schemaRaw.(map[string]interface{})
+	data := schemaParsed.(map[string]interface{})
 
 	gojsonschema.FormatCheckers.Add("environment", environmentFormatChecker{})
 	gojsonschema.FormatCheckers.Add("ports", portsFormatChecker{})
 	gojsonschema.FormatCheckers.Add("expose", portsFormatChecker{})
-	*schemaLoader = gojsonschema.NewGoLoader(schemaRaw)
+	loader := gojsonschema.NewGoLoader(schemaParsed)
 
-	definitions := (*schema)["definitions"].(map[string]interface{})
+	definitions := data["definitions"].(map[string]interface{})
 	constraints := definitions["constraints"].(map[string]interface{})
 	service := constraints["service"].(map[string]interface{})
-	*constraintSchemaLoader = gojsonschema.NewGoLoader(service)
+	constraintsLoader := gojsonschema.NewGoLoader(service)
 
-	return nil
+	return &Schema{
+		Loader:            loader,
+		ConstraintsLoader: constraintsLoader,
+		Data:              data,
+	}, nil
 }
 
 // gojsonschema doesn't provide a list of valid types for a property

--- a/config/schema_helpers.go
+++ b/config/schema_helpers.go
@@ -11,10 +11,16 @@ import (
 var (
 	schemaLoaderV1           gojsonschema.JSONLoader
 	constraintSchemaLoaderV1 gojsonschema.JSONLoader
+
 	schemaLoaderV2           gojsonschema.JSONLoader
 	constraintSchemaLoaderV2 gojsonschema.JSONLoader
-	schemaV1                 map[string]interface{}
-	schemaV2                 map[string]interface{}
+
+	schemaLoaderV2_1           gojsonschema.JSONLoader
+	constraintSchemaLoaderV2_1 gojsonschema.JSONLoader
+
+	schemaV1   map[string]interface{}
+	schemaV2   map[string]interface{}
+	schemaV2_1 map[string]interface{}
 )
 
 func init() {
@@ -23,6 +29,10 @@ func init() {
 	}
 
 	if err := setupSchemaLoaders(servicesSchemaDataV2, &schemaV2, &schemaLoaderV2, &constraintSchemaLoaderV2); err != nil {
+		panic(err)
+	}
+
+	if err := setupSchemaLoaders(servicesSchemaDataV2_1, &schemaV2_1, &schemaLoaderV2_1, &constraintSchemaLoaderV2_1); err != nil {
 		panic(err)
 	}
 }

--- a/config/schema_test.go
+++ b/config/schema_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSchemaRegistry(t *testing.T) {
+	schemaData := map[string]string{
+		"":    schemaDataV1,
+		"2":   schemaDataV2,
+		"2.0": schemaDataV2,
+		"2.1": schemaDataV2_1,
+	}
+
+	schemaRegistry, err := NewSchemaRegistry(schemaData)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for _, schema := range schemaRegistry {
+		assert.NotNil(t, schema.Data)
+		assert.NotNil(t, schema.Loader)
+		assert.NotNil(t, schema.ConstraintsLoader)
+	}
+}

--- a/config/validation.go
+++ b/config/validation.go
@@ -161,11 +161,18 @@ func validate(serviceMap RawServiceMap) error {
 
 	dataLoader := gojsonschema.NewGoLoader(serviceMap)
 
+	schema, err := schemaRegistry.GetVersion("")
+	if err != nil {
+		return err
+	}
+	schemaLoaderV1 := schema.Loader
+
 	result, err := gojsonschema.Validate(schemaLoaderV1, dataLoader)
 	if err != nil {
 		return err
 	}
 
+	schemaV1 := schema.Data
 	return generateErrorMessages(serviceMap, schemaV1, result)
 }
 
@@ -174,11 +181,18 @@ func validateV2(serviceMap RawServiceMap) error {
 
 	dataLoader := gojsonschema.NewGoLoader(serviceMap)
 
+	schema, err := schemaRegistry.GetVersion("2")
+	if err != nil {
+		return err
+	}
+	schemaLoaderV2 := schema.Loader
+
 	result, err := gojsonschema.Validate(schemaLoaderV2, dataLoader)
 	if err != nil {
 		return err
 	}
 
+	schemaV2 := schema.Data
 	return generateErrorMessages(serviceMap, schemaV2, result)
 }
 
@@ -248,6 +262,12 @@ func validateServiceConstraints(service RawService, serviceName string) error {
 
 	dataLoader := gojsonschema.NewGoLoader(service)
 
+	schema, err := schemaRegistry.GetVersion("")
+	if err != nil {
+		return err
+	}
+	constraintSchemaLoaderV1 := schema.ConstraintsLoader
+
 	result, err := gojsonschema.Validate(constraintSchemaLoaderV1, dataLoader)
 	if err != nil {
 		return err
@@ -282,6 +302,12 @@ func validateServiceConstraintsv2(service RawService, serviceName string) error 
 	var validationErrors []string
 
 	dataLoader := gojsonschema.NewGoLoader(service)
+
+	schema, err := schemaRegistry.GetVersion("2")
+	if err != nil {
+		return err
+	}
+	constraintSchemaLoaderV2 := schema.ConstraintsLoader
 
 	result, err := gojsonschema.Validate(constraintSchemaLoaderV2, dataLoader)
 	if err != nil {

--- a/hack/binary
+++ b/hack/binary
@@ -6,7 +6,8 @@ rm -f libcompose-cli
 
 go generate
 
-BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/') &> /dev/null
+# NOTE: explicit `strftime(3)` so we support non-GNU `date(1)` on macOS
+BUILDTIME=$(date +"%Y-%m-%d %H:%M:%S.%N%:z" | sed -e 's/ /T/') &> /dev/null
 GITCOMMIT=$(git rev-parse --short HEAD)
 
 # Build binaries

--- a/hack/config_schema_v2.1.json
+++ b/hack/config_schema_v2.1.json
@@ -1,0 +1,441 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "config_schema_v2.1.json",
+  "type": "object",
+
+  "properties": {
+    "version": {
+      "type": "string"
+    },
+
+    "services": {
+      "id": "#/properties/services",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/service"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "networks": {
+      "id": "#/properties/networks",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/network"
+        }
+      }
+    },
+
+    "volumes": {
+      "id": "#/properties/volumes",
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/volume"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
+  "patternProperties": {"^x-": {}},
+  "additionalProperties": false,
+
+  "definitions": {
+
+    "service": {
+      "id": "#/definitions/service",
+      "type": "object",
+
+      "properties": {
+        "blkio_config": {
+          "type": "object",
+          "properties": {
+            "device_read_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_read_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "weight": {"type": "integer"},
+            "weight_device": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_weight"}
+            }
+          },
+          "additionalProperties": false
+        },
+
+        "build": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+              "properties": {
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"}
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup_parent": {"type": "string"},
+        "command": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "container_name": {"type": "string"},
+        "cpu_shares": {"type": ["number", "string"]},
+        "cpu_quota": {"type": ["number", "string"]},
+        "cpuset": {"type": "string"},
+        "depends_on": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "condition": {
+                      "type": "string",
+                      "enum": ["service_started", "service_healthy"]
+                    }
+                  },
+                  "required": ["condition"]
+                }
+              }
+            }
+          ]
+        },
+        "devices": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "dns_opt": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "uniqueItems": true
+        },
+        "dns": {"$ref": "#/definitions/string_or_list"},
+        "dns_search": {"$ref": "#/definitions/string_or_list"},
+        "domainname": {"type": "string"},
+        "entrypoint": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "env_file": {"$ref": "#/definitions/string_or_list"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
+        "expose": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"],
+            "format": "expose"
+          },
+          "uniqueItems": true
+        },
+
+        "extends": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object",
+
+              "properties": {
+                "service": {"type": "string"},
+                "file": {"type": "string"}
+              },
+              "required": ["service"],
+              "additionalProperties": false
+            }
+          ]
+        },
+
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "extra_hosts": {"$ref": "#/definitions/list_or_dict"},
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "hostname": {"type": "string"},
+        "image": {"type": "string"},
+        "ipc": {"type": "string"},
+        "isolation": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+
+        "logging": {
+            "type": "object",
+
+            "properties": {
+                "driver": {"type": "string"},
+                "options": {"type": "object"}
+            },
+            "additionalProperties": false
+        },
+
+        "mac_address": {"type": "string"},
+        "mem_limit": {"type": ["number", "string"]},
+        "mem_reservation": {"type": ["string", "integer"]},
+        "mem_swappiness": {"type": "integer"},
+        "memswap_limit": {"type": ["number", "string"]},
+        "network_mode": {"type": "string"},
+
+        "networks": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "aliases": {"$ref": "#/definitions/list_of_strings"},
+                        "ipv4_address": {"type": "string"},
+                        "ipv6_address": {"type": "string"},
+                        "link_local_ips": {"$ref": "#/definitions/list_of_strings"}
+                      },
+                      "additionalProperties": false
+                    },
+                    {"type": "null"}
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "oom_score_adj": {"type": "integer", "minimum": -1000, "maximum": 1000},
+        "group_add": {
+            "type": "array",
+            "items": {
+                "type": ["string", "number"]
+            },
+            "uniqueItems": true
+        },
+        "pid": {"type": ["string", "null"]},
+
+        "ports": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"],
+            "format": "ports"
+          },
+          "uniqueItems": true
+        },
+
+        "privileged": {"type": "boolean"},
+        "read_only": {"type": "boolean"},
+        "restart": {"type": "string"},
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "pids_limit": {"type": ["number", "string"]},
+        "stdin_open": {"type": "boolean"},
+        "stop_grace_period": {"type": "string", "format": "duration"},
+        "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
+        "tmpfs": {"$ref": "#/definitions/string_or_list"},
+        "tty": {"type": "boolean"},
+        "ulimits": {
+          "type": "object",
+          "patternProperties": {
+            "^[a-z]+$": {
+              "oneOf": [
+                {"type": "integer"},
+                {
+                  "type":"object",
+                  "properties": {
+                    "hard": {"type": "integer"},
+                    "soft": {"type": "integer"}
+                  },
+                  "required": ["soft", "hard"],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          }
+        },
+        "user": {"type": "string"},
+        "userns_mode": {"type": "string"},
+        "volumes": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "volume_driver": {"type": "string"},
+        "volumes_from": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "working_dir": {"type": "string"}
+      },
+
+      "dependencies": {
+        "memswap_limit": ["mem_limit"]
+      },
+      "additionalProperties": false
+    },
+
+    "healthcheck": {
+      "id": "#/definitions/healthcheck",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "disable": {"type": "boolean"},
+        "interval": {"type": "string"},
+        "retries": {"type": "number"},
+        "test": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "timeout": {"type": "string"}
+      }
+    },
+
+    "network": {
+      "id": "#/definitions/network",
+      "type": "object",
+      "properties": {
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "ipam": {
+            "type": "object",
+            "properties": {
+                "driver": {"type": "string"},
+                "config": {
+                    "type": "array"
+                },
+                "options": {
+                  "type": "object",
+                  "patternProperties": {
+                    "^.+$": {"type": "string"}
+                  },
+                  "additionalProperties": false
+                }
+            },
+            "additionalProperties": false
+        },
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "internal": {"type": "boolean"},
+        "enable_ipv6": {"type": "boolean"},
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false
+    },
+
+    "volume": {
+      "id": "#/definitions/volume",
+      "type": ["object", "null"],
+      "properties": {
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "external": {
+          "type": ["boolean", "object"],
+          "properties": {
+            "name": {"type": "string"}
+          },
+          "additionalProperties": false
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "name": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+
+    "string_or_list": {
+      "oneOf": [
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
+      ]
+    },
+
+    "list_of_strings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+
+    "list_or_dict": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": ["string", "number", "null"]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "blkio_limit": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "rate": {"type": ["integer", "string"]}
+      },
+      "additionalProperties": false
+    },
+    "blkio_weight": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "weight": {"type": "integer"}
+      },
+      "additionalProperties": false
+    },
+
+    "constraints": {
+      "service": {
+        "id": "#/definitions/constraints/service",
+        "anyOf": [
+          {"required": ["build"]},
+          {"required": ["image"]}
+        ],
+        "properties": {
+          "build": {
+            "required": ["context"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/hack/cross-binary
+++ b/hack/cross-binary
@@ -18,7 +18,8 @@ fi
 # Get rid of existing binaries
 rm -f bundles/libcompose-cli*
 
-BUILDTIME=$(date --rfc-3339 ns | sed -e 's/ /T/') &> /dev/null
+# NOTE: explicit `strftime(3)` so we support non-GNU `date(1)` on macOS
+BUILDTIME=$(date +"%Y-%m-%d %H:%M:%S.%N%:z" | sed -e 's/ /T/') &> /dev/null
 GITCOMMIT=$(git rev-parse --short HEAD)
 
 # Build binaries

--- a/hack/inline_schema.go
+++ b/hack/inline_schema.go
@@ -20,6 +20,10 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	schemaV2_1, err := ioutil.ReadFile("./hack/config_schema_v2.1.json")
+	if err != nil {
+		panic(err)
+	}
 
 	inlinedFile, err := os.Create("config/schema.go")
 	if err != nil {
@@ -27,8 +31,9 @@ func main() {
 	}
 
 	err = t.Execute(inlinedFile, map[string]string{
-		"schemaV1": string(schemaV1),
-		"schemaV2": string(schemaV2),
+		"schemaV1":   string(schemaV1),
+		"schemaV2":   string(schemaV2),
+		"schemaV2_1": string(schemaV2_1),
 	})
 
 	if err != nil {

--- a/hack/schema_template.go
+++ b/hack/schema_template.go
@@ -3,3 +3,5 @@ package config
 var schemaDataV1 = `{{.schemaV1}}`
 
 var servicesSchemaDataV2 = `{{.schemaV2}}`
+
+var servicesSchemaDataV2_1 = `{{.schemaV2_1}}`


### PR DESCRIPTION
Ref: #441 

The goal of this PR is to hopefully introduce v2.1 formatted compose files so I can use `libcompose` for various stuff I'm working on around Joyent's Elastic Docker Host (Triton).

I've started by refactoring how compose files are loaded and validated by their version numbers. This solves the immediate issue of #441 by cleaning up how the version is referenced when parsing compose YAML. At the moment, I've left off cleaning up how JSON schema files are loaded and passed into `config/validation.go`. This is working well so I'll start utilizing this for loading v2.1 specifically.

I'm working on this in my spare time ATM (which isn't much) so bare with me. Also, I'm opening this up to get any early feedback. I do realize I need tests for some stuff. 😄 