### PR TITLE
Extra options for "build" sections in YAML

### DIFF
--- a/config/schema.go
+++ b/config/schema.go
@@ -223,7 +223,7 @@ var servicesSchemaDataV2 = `{
                 "cache_from": {"$ref": "#/definitions/list_of_strings"},
                 "labels": {"$ref": "#/definitions/list_or_dict"},
                 "network": {"type": "string"},
-                "target": {"type": "string"},
+                "target": {"type": "string"}
               },
               "additionalProperties": false
             }

--- a/config/schema.go
+++ b/config/schema.go
@@ -219,7 +219,11 @@ var servicesSchemaDataV2 = `{
               "properties": {
                 "context": {"type": "string"},
                 "dockerfile": {"type": "string"},
-                "args": {"$ref": "#/definitions/list_or_dict"}
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "cache_from": {"$ref": "#/definitions/list_of_strings"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "network": {"type": "string"},
+                "target": {"type": "string"},
               },
               "additionalProperties": false
             }

--- a/docker/builder/builder.go
+++ b/docker/builder/builder.go
@@ -91,6 +91,12 @@ func (d *DaemonBuilder) Build(ctx context.Context, imageName string) error {
 		outFd, isTerminalOut = term.GetFdInfo(w)
 	}
 
+	// Convert map[string]*string to map[string]string
+	labels := make(map[string]string)
+	for lk, lv := range d.Labels {
+		labels[lk] = *lv
+	}
+
 	response, err := d.Client.ImageBuild(ctx, body, types.ImageBuildOptions{
 		Tags:        []string{imageName},
 		NoCache:     d.NoCache,
@@ -101,7 +107,7 @@ func (d *DaemonBuilder) Build(ctx context.Context, imageName string) error {
 		AuthConfigs: d.AuthConfigs,
 		BuildArgs:   d.BuildArgs,
 		CacheFrom:   d.CacheFrom,
-		Labels:      d.Labels,
+		Labels:      labels,
 		NetworkMode: d.Network,
 		Target:      d.Target,
 	})

--- a/docker/builder/builder.go
+++ b/docker/builder/builder.go
@@ -43,6 +43,9 @@ type DaemonBuilder struct {
 	Pull             bool
 	BuildArgs        map[string]*string
 	CacheFrom        []string
+	Labels           map[string]*string
+	Network          string
+	Target           string
 	LoggerFactory    logger.Factory
 }
 
@@ -98,6 +101,9 @@ func (d *DaemonBuilder) Build(ctx context.Context, imageName string) error {
 		AuthConfigs: d.AuthConfigs,
 		BuildArgs:   d.BuildArgs,
 		CacheFrom:   d.CacheFrom,
+		Labels:      d.Labels,
+		NetworkMode: d.Network,
+		Target:      d.Target,
 	})
 	if err != nil {
 		return err

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -8,9 +8,12 @@ import (
 )
 
 var (
-	buildno = "1"
-	user    = "vincent"
-	empty   = "\x00"
+	buildno       = "1"
+	user          = "vincent"
+	empty         = "\x00"
+	testCacheFrom = "someotherimage:latest"
+	target        = "intermediateimage"
+	network       = "buildnetwork"
 )
 
 func TestMarshalBuild(t *testing.T) {
@@ -46,12 +49,28 @@ dockerfile: alternate
 					"buildno": &buildno,
 					"user":    &user,
 				},
+				CacheFrom: []*string{
+					&testCacheFrom,
+				},
+				Labels: map[string]*string{
+					"buildno": &buildno,
+					"user":    &user,
+				},
+				Target:  target,
+				Network: network,
 			},
 			expected: `args:
   buildno: "1"
   user: vincent
+cache_from:
+- someotherimage:latest
 context: .
 dockerfile: alternate
+labels:
+  buildno: "1"
+  user: vincent
+network: buildnetwork
+target: intermediateimage
 `,
 		},
 	}
@@ -92,7 +111,15 @@ dockerfile: alternate`,
 dockerfile: alternate
 args:
   buildno: 1
-  user: vincent`,
+  user: vincent
+cache_from:
+  - someotherimage:latest
+labels:
+  buildno: "1"
+  user: vincent
+target: intermediateimage
+network: buildnetwork
+`,
 			expected: &Build{
 				Context:    ".",
 				Dockerfile: "alternate",
@@ -100,6 +127,15 @@ args:
 					"buildno": &buildno,
 					"user":    &user,
 				},
+				CacheFrom: []*string{
+					&testCacheFrom,
+				},
+				Labels: map[string]*string{
+					"buildno": &buildno,
+					"user":    &user,
+				},
+				Target:  target,
+				Network: network,
 			},
 		},
 		{


### PR DESCRIPTION
Adds support under the `build` heading for:

- `cache_from`
- `labels`
- `network`
- `target`

Note: `network` is undocumented in the [docker-compose.yml reference](https://docs.docker.com/compose/compose-file/) but is supported and works (as of config version 3.4).

@vdemeester do we also need these in [docker/service/service.go](https://github.com/docker/libcompose/blob/master/docker/service/service.go#L176-L186)?